### PR TITLE
add prisma redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -4,5 +4,6 @@
 /strata https://strata.pan.dev
 /xsoar https://xsoar.pan.dev
 /demisto https://xsoar.pan.dev
+/prisma https://prisma.pan.dev
 # Redirect domain aliases to primary domain
 https://developers.paloaltonetworks.com/* https://pan.dev/:splat 301!


### PR DESCRIPTION
## Description

Adding redirect for prisma.pan.dev

## Motivation and Context

Allows for reaching prisma.pan.dev by navigating to either `pan.dev/prisma` or `developers.paloaltonetworks.com/prisma`

## How Has This Been Tested?

n/a

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
