### PR TITLE
Reorganize API docs to improve breadcrumb experience

### DIFF
--- a/cloudngfw/sidebar.js
+++ b/cloudngfw/sidebar.js
@@ -1,33 +1,40 @@
 module.exports = {
   cloudngfw_docs: [
     {
-        type: "doc",
-        id: "docs/home"
+      type: "doc",
+      id: "docs/home"
     },
     {
-        label: "Get Started",
-        type: "category",
-        collapsed: false,
-        items: [
-            {
-                type: "doc",
-                id: "docs/getstarted_aws"
-            },
-        ]
+      label: "Get Started",
+      type: "category",
+      collapsed: false,
+      items: [
+        {
+          type: "doc",
+          id: "docs/getstarted_aws"
+        }
+      ]
     },
     {
-        label: "Other Documentation",
-        type: "category",
-        collapsed: true,
-        items: [
-				{
-                        type: "link",
-                        label: "Cloud NGFW for AWS",
-                        href: 'https://docs.paloaltonetworks.com/cloud-ngfw/aws/cloud-ngfw-on-aws'
-                    },
-            
-                ]
-    },
+      label: "Other Documentation",
+      type: "category",
+      collapsed: true,
+      items: [
+        {
+          type: "link",
+          label: "Cloud NGFW for AWS",
+          href: "https://docs.paloaltonetworks.com/cloud-ngfw/aws/cloud-ngfw-on-aws"
+        }
+      ]
+    }
   ],
-   cloudngfwforaws_api: require("../static/cloudngfw/aws/spec/sidebar_builder").sidebar,
+  cloudngfwforaws_api: [
+    {
+      label: "Cloud NGFW for AWS API",
+      type: "category",
+      collapsed: false,
+      link: { type: "doc", id: "api/aws/awsapi" },
+      items: require("../static/cloudngfw/aws/spec/sidebar_builder").sidebar
+    }
+  ]
 };

--- a/sase/sidebar.js
+++ b/sase/sidebar.js
@@ -2,94 +2,149 @@ module.exports = {
   sase_docs: [
     {
       type: "doc",
-      id: "docs/home",
+      id: "docs/home"
     },
     {
-        type: "category",
-        label: "Get Started",
-        collapsed: true,
-        items: [
+      type: "category",
+      label: "Get Started",
+      collapsed: true,
+      items: [
+        {
+          type: "doc",
+          id: "docs/getstarted"
+        },
+        {
+          type: "doc",
+          id: "docs/tenant-service-groups"
+        },
+        {
+          type: "doc",
+          id: "docs/service-accounts"
+        },
+        {
+          type: "category",
+          label: "Roles",
+          collapsed: true,
+          items: [
             {
               type: "doc",
-              id: "docs/getstarted",
+              id: "docs/roles-overview"
             },
             {
               type: "doc",
-              id: "docs/tenant-service-groups",
+              id: "docs/roles-assign"
             },
             {
               type: "doc",
-              id: "docs/service-accounts",
-            },
-              {
-                  type: "category",
-                  label: "Roles",
-                  collapsed: true,
-                  items: [
-                        {
-                          type: "doc",
-                          id: "docs/roles-overview",
-                        },
-                        {
-                          type: "doc",
-                          id: "docs/roles-assign",
-                        },
-                        {
-                          type: "doc",
-                          id: "docs/all-roles",
-                        },
-                  ]
-              },
-            {
-                  type: "category",
-                  label: "Access Tokens",
-                  collapsed: true,
-                  items: [
-                        {
-                          type: "doc",
-                          id: "docs/access-tokens",
-                        },
-                        {
-                          type: "doc",
-                          id: "docs/scope",
-                        },
-                  ]
-              },
+              id: "docs/all-roles"
+            }
+          ]
+        },
+        {
+          type: "category",
+          label: "Access Tokens",
+          collapsed: true,
+          items: [
             {
               type: "doc",
-              id: "docs/api-call",
+              id: "docs/access-tokens"
             },
-        ]
+            {
+              type: "doc",
+              id: "docs/scope"
+            }
+          ]
+        },
+        {
+          type: "doc",
+          id: "docs/api-call"
+        }
+      ]
     },
     {
       type: "category",
       label: "Prisma Access Configuration",
       collapsed: true,
-      items: ["docs/prisma-access-config/prisma-access-config",
-      ],
+      items: ["docs/prisma-access-config/prisma-access-config"]
     },
     {
       type: "category",
       label: "Aggregate Monitoring",
       collapsed: true,
-      items: ["docs/mt-monitor/mt-monitor",
-              "docs/mt-monitor/parameters",      
-              "docs/mt-monitor/filters"
-      ],
+      items: [
+        "docs/mt-monitor/mt-monitor",
+        "docs/mt-monitor/parameters",
+        "docs/mt-monitor/filters"
+      ]
     },
     {
       type: "category",
       label: "Prisma SASE API Release Notes",
       collapsed: true,
-      items: ["docs/release-notes/release-notes",
-              "docs/release-notes/changelog"
-      ],
-    },
+      items: [
+        "docs/release-notes/release-notes",
+        "docs/release-notes/changelog"
+      ]
+    }
   ],
-  iam_api: require("../static/sase/spec/iam/sidebar_builder").sidebar,
-  tenancy_api: require("../static/sase/spec/tenancy/sidebar_builder").sidebar,
-  auth_api: require("../static/sase/spec/auth/sidebar_builder").sidebar,
-  pa_config_api: require("../static/sase/spec/prisma-access-config/sidebar_builder").sidebar,
-  msp_api: require("../static/sase/spec/mt-monitor/sidebar_builder").sidebar,
-  subscription_api: require("../static/sase/spec/subscription/sidebar_builder").sidebar,
+  sase_api: [
+    {
+      label: "SASE API",
+      type: "category",
+      collapsed: false,
+      link: {
+        type: "generated-index",
+        title: "SASE API",
+        slug: "/category/sase-api-docs"
+      },
+      items: [
+        {
+          label: "Tenancy Service",
+          type: "category",
+          collapsed: true,
+          link: { type: "doc", id: "api/tenancy/tenancy-api" },
+          items: require("../static/sase/spec/tenancy/sidebar_builder").sidebar
+        },
+        {
+          label: "Identity and Access Management",
+          type: "category",
+          collapsed: true,
+          link: { type: "doc", id: "api/iam/iam-api" },
+          items: require("../static/sase/spec/iam/sidebar_builder").sidebar
+        },
+        {
+          label: "Authentication Service",
+          type: "category",
+          collapsed: true,
+          link: { type: "doc", id: "api/auth/auth-api" },
+          items: require("../static/sase/spec/auth/sidebar_builder").sidebar
+        },
+        {
+          label: "Subscription Service",
+          type: "category",
+          collapsed: true,
+          link: { type: "doc", id: "api/subscription/subscription-api" },
+          items: require("../static/sase/spec/subscription/sidebar_builder")
+            .sidebar
+        },
+        {
+          label: "Prisma Access Configuration",
+          type: "category",
+          collapsed: true,
+          link: { type: "doc", id: "api/prisma-access-config/config-api" },
+          items:
+            require("../static/sase/spec/prisma-access-config/sidebar_builder")
+              .sidebar
+        },
+        {
+          label: "Aggregate Monitoring",
+          type: "category",
+          collapsed: true,
+          link: { type: "doc", id: "api/mt-monitor/msp-api" },
+          items: require("../static/sase/spec/mt-monitor/sidebar_builder")
+            .sidebar
+        }
+      ]
+    }
+  ]
 };

--- a/static/cloudngfw/aws/spec/sidebar_builder.js
+++ b/static/cloudngfw/aws/spec/sidebar_builder.js
@@ -2,9 +2,10 @@ const globby = require("globby");
 const yaml = require("js-yaml");
 const fs = require("fs");
 // Use the following to frontload docs
-var docs = [
-    "api/aws/awsapi"
-];
+// var docs = [
+//     "api/aws/awsapi"
+// ];
+var docs = [];
 
 // Change these variables to match your doc path
 const relativePath = "api/aws";
@@ -16,7 +17,7 @@ function genEndpoints() {
     absolute: false,
     objectMode: true,
     deep: 1,
-    onlyDirectories: false,
+    onlyDirectories: false
   });
   specs.map((spec) => {
     const specContents = fs.readFileSync(spec.path, "utf8");
@@ -34,8 +35,8 @@ function genEndpoints() {
       collapsed: true,
       link: {
         type: "doc",
-        id: linkId,
-      },
+        id: linkId
+      }
     };
     var items = [];
     for ([path, methods] of Object.entries(paths)) {
@@ -47,8 +48,8 @@ function genEndpoints() {
           label: linkLabel,
           href: `${absolutePath}/${docId}#operation/${operationId}`,
           customProps: {
-            method: method,
-          },
+            method: method
+          }
         };
         items.push(item);
       }
@@ -61,5 +62,5 @@ function genEndpoints() {
 const endpoints = genEndpoints();
 const sidebar = docs.concat(endpoints);
 module.exports = {
-  sidebar: sidebar,
+  sidebar: sidebar
 };

--- a/static/sase/spec/auth/sidebar_builder.js
+++ b/static/sase/spec/auth/sidebar_builder.js
@@ -2,9 +2,10 @@ const globby = require("globby");
 const yaml = require("js-yaml");
 const fs = require("fs");
 // Use the following to frontload docs
-var docs = [
-    "api/auth/auth-api",
-];
+// var docs = [
+//     "api/auth/auth-api",
+// ];
+var docs = [];
 
 // Change these variables to match your doc path
 const relativePath = "api/auth";
@@ -16,7 +17,7 @@ function genEndpoints() {
     absolute: false,
     objectMode: true,
     deep: 1,
-    onlyDirectories: false,
+    onlyDirectories: false
   });
   specs.map((spec) => {
     const specContents = fs.readFileSync(spec.path, "utf8");
@@ -34,8 +35,8 @@ function genEndpoints() {
       collapsed: true,
       link: {
         type: "doc",
-        id: linkId,
-      },
+        id: linkId
+      }
     };
     var items = [];
     for ([path, methods] of Object.entries(paths)) {
@@ -47,8 +48,8 @@ function genEndpoints() {
           label: linkLabel,
           href: `${absolutePath}/${docId}#operation/${operationId}`,
           customProps: {
-            method: method,
-          },
+            method: method
+          }
         };
         items.push(item);
       }
@@ -61,5 +62,5 @@ function genEndpoints() {
 const endpoints = genEndpoints();
 const sidebar = docs.concat(endpoints);
 module.exports = {
-  sidebar: sidebar,
+  sidebar: sidebar
 };

--- a/static/sase/spec/iam/sidebar_builder.js
+++ b/static/sase/spec/iam/sidebar_builder.js
@@ -2,9 +2,10 @@ const globby = require("globby");
 const yaml = require("js-yaml");
 const fs = require("fs");
 // Use the following to frontload docs
-var docs = [
-    "api/iam/iam-api",
-];
+// var docs = [
+//     "api/iam/iam-api",
+// ];
+var docs = [];
 
 // Change these variables to match your doc path
 const relativePath = "api/iam";
@@ -16,7 +17,7 @@ function genEndpoints() {
     absolute: false,
     objectMode: true,
     deep: 1,
-    onlyDirectories: false,
+    onlyDirectories: false
   });
   specs.map((spec) => {
     const specContents = fs.readFileSync(spec.path, "utf8");
@@ -34,8 +35,8 @@ function genEndpoints() {
       collapsed: true,
       link: {
         type: "doc",
-        id: linkId,
-      },
+        id: linkId
+      }
     };
     var items = [];
     for ([path, methods] of Object.entries(paths)) {
@@ -47,8 +48,8 @@ function genEndpoints() {
           label: linkLabel,
           href: `${absolutePath}/${docId}#operation/${operationId}`,
           customProps: {
-            method: method,
-          },
+            method: method
+          }
         };
         items.push(item);
       }
@@ -61,5 +62,5 @@ function genEndpoints() {
 const endpoints = genEndpoints();
 const sidebar = docs.concat(endpoints);
 module.exports = {
-  sidebar: sidebar,
+  sidebar: sidebar
 };

--- a/static/sase/spec/mt-monitor/sidebar_builder.js
+++ b/static/sase/spec/mt-monitor/sidebar_builder.js
@@ -2,9 +2,10 @@ const globby = require("globby");
 const yaml = require("js-yaml");
 const fs = require("fs");
 // Use the following to frontload docs
-var docs = [
-    "api/mt-monitor/msp-api",
-];
+// var docs = [
+//     "api/mt-monitor/msp-api",
+// ];
+var docs = [];
 
 // Change these variables to match your doc path
 const relativePath = "api/mt-monitor";
@@ -16,7 +17,7 @@ function genEndpoints() {
     absolute: false,
     objectMode: true,
     deep: 1,
-    onlyDirectories: false,
+    onlyDirectories: false
   });
   specs.map((spec) => {
     const specContents = fs.readFileSync(spec.path, "utf8");
@@ -34,8 +35,8 @@ function genEndpoints() {
       collapsed: true,
       link: {
         type: "doc",
-        id: linkId,
-      },
+        id: linkId
+      }
     };
     var items = [];
     for ([path, methods] of Object.entries(paths)) {
@@ -47,8 +48,8 @@ function genEndpoints() {
           label: linkLabel,
           href: `${absolutePath}/${docId}#operation/${operationId}`,
           customProps: {
-            method: method,
-          },
+            method: method
+          }
         };
         items.push(item);
       }
@@ -61,5 +62,5 @@ function genEndpoints() {
 const endpoints = genEndpoints();
 const sidebar = docs.concat(endpoints);
 module.exports = {
-  sidebar: sidebar,
+  sidebar: sidebar
 };

--- a/static/sase/spec/prisma-access-config/sidebar.js
+++ b/static/sase/spec/prisma-access-config/sidebar.js
@@ -2,7 +2,9 @@ const globby = require("globby");
 const yaml = require("js-yaml");
 const fs = require("fs");
 // Use the following to frontload docs
-var docs = ["sase/config/config-api"];
+// var docs = ["sase/config/config-api"];
+var docs = [];
+
 // Change these variables to match your doc path
 const relativePath = "sase/config";
 const absolutePath = "/api/sase/config";
@@ -15,7 +17,7 @@ function genEndpoints() {
     absolute: false,
     objectMode: true,
     deep: 1,
-    onlyDirectories: false,
+    onlyDirectories: false
   });
   specs.map((spec) => {
     const specContents = fs.readFileSync(spec.path, "utf8");
@@ -29,7 +31,7 @@ function genEndpoints() {
     const paths = data.paths;
     var category = {
       type: "category",
-      label: categoryLabel,
+      label: categoryLabel
     };
     var items = [`${relativePath}/${docId}`];
     for ([path, methods] of Object.entries(paths)) {
@@ -41,8 +43,8 @@ function genEndpoints() {
           label: linkLabel,
           href: `${absolutePath}/${docId}#operation/${operationId}`,
           customProps: {
-            method: method,
-          },
+            method: method
+          }
         };
         items.push(item);
       }
@@ -59,5 +61,5 @@ function genEndpoints() {
 const [endpoints, endEndpoints] = genEndpoints();
 const sidebar = docs.concat(endpoints).concat(endEndpoints);
 module.exports = {
-  sidebar: sidebar,
+  sidebar: sidebar
 };

--- a/static/sase/spec/subscription/sidebar_builder.js
+++ b/static/sase/spec/subscription/sidebar_builder.js
@@ -2,9 +2,10 @@ const globby = require("globby");
 const yaml = require("js-yaml");
 const fs = require("fs");
 // Use the following to frontload docs
-var docs = [
-    "api/subscription/subscription-api",
-];
+// var docs = [
+//     "api/subscription/subscription-api",
+// ];
+var docs = [];
 
 // Change these variables to match your doc path
 const relativePath = "api/subscription";
@@ -16,7 +17,7 @@ function genEndpoints() {
     absolute: false,
     objectMode: true,
     deep: 1,
-    onlyDirectories: false,
+    onlyDirectories: false
   });
   specs.map((spec) => {
     const specContents = fs.readFileSync(spec.path, "utf8");
@@ -34,8 +35,8 @@ function genEndpoints() {
       collapsed: true,
       link: {
         type: "doc",
-        id: linkId,
-      },
+        id: linkId
+      }
     };
     var items = [];
     for ([path, methods] of Object.entries(paths)) {
@@ -47,8 +48,8 @@ function genEndpoints() {
           label: linkLabel,
           href: `${absolutePath}/${docId}#operation/${operationId}`,
           customProps: {
-            method: method,
-          },
+            method: method
+          }
         };
         items.push(item);
       }
@@ -61,5 +62,5 @@ function genEndpoints() {
 const endpoints = genEndpoints();
 const sidebar = docs.concat(endpoints);
 module.exports = {
-  sidebar: sidebar,
+  sidebar: sidebar
 };

--- a/static/sase/spec/tenancy/sidebar_builder.js
+++ b/static/sase/spec/tenancy/sidebar_builder.js
@@ -2,9 +2,10 @@ const globby = require("globby");
 const yaml = require("js-yaml");
 const fs = require("fs");
 // Use the following to frontload docs
-var docs = [
-    "api/tenancy/tenancy-api",
-];
+// var docs = [
+//     "api/tenancy/tenancy-api",
+// ];
+var docs = [];
 
 // Change these variables to match your doc path
 const relativePath = "api/tenancy";
@@ -16,7 +17,7 @@ function genEndpoints() {
     absolute: false,
     objectMode: true,
     deep: 1,
-    onlyDirectories: false,
+    onlyDirectories: false
   });
   specs.map((spec) => {
     const specContents = fs.readFileSync(spec.path, "utf8");
@@ -34,8 +35,8 @@ function genEndpoints() {
       collapsed: true,
       link: {
         type: "doc",
-        id: linkId,
-      },
+        id: linkId
+      }
     };
     var items = [];
     for ([path, methods] of Object.entries(paths)) {
@@ -47,8 +48,8 @@ function genEndpoints() {
           label: linkLabel,
           href: `${absolutePath}/${docId}#operation/${operationId}`,
           customProps: {
-            method: method,
-          },
+            method: method
+          }
         };
         items.push(item);
       }
@@ -61,5 +62,5 @@ function genEndpoints() {
 const endpoints = genEndpoints();
 const sidebar = docs.concat(endpoints);
 module.exports = {
-  sidebar: sidebar,
+  sidebar: sidebar
 };


### PR DESCRIPTION
## Description

This change attempts to improve the overall breadcrumb experience and content organization for API docs. The strategy is to, whenever possible:

* Group API docs under the same sidebar
* Establish "landing pages" for each sidebar item, i.e. category or doc links or `generated-index`
* Use `generated-index` when >1 API/Service exists in sidebar

Please feel free to provide feedback directly to this PR. Thanks!

## Motivation and Context

The existing implementation can lead to a disjointed experience moving from one API doc to another, especially under the same product vertical. This approach seeks to enable a more seamless experience while limiting the degree of segmentation between product API docs.

## How Has This Been Tested?

Tested locally.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
