### PR TITLE
Fix Prisma SD-WAN Legacy nav link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -367,7 +367,7 @@ const config = {
                       icon: "api-doc",
                     },
                     {
-                      to: "sdwan/api/legacy/legacy",
+                      to: "sdwan/api/legacy",
                       label: "Prisma SD-WAN Legacy",
                       icon: "api-doc",
                     },


### PR DESCRIPTION
## Description

Current Prisma SD-WAN Legacy navigation link is outdated and results in a 404 (Page Not Found). Updated Prisma SASE SD-WAN Legacy nav link to `sdwan/api/legacy`.

## How Has This Been Tested?

Tested the following: 
- Navigation Menu: Developer Docs -> Secure Access Service Edge -> Prisma SD-WAN -> Prisma SD-WAN Legacy
- Product Group Card: Secure Access Service Edge -> Prisma SD-WAN -> Prisma SD-WAN Legacy

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
