### PR TITLE
Convert single quotes to escaped double quotes for Windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gen-all": "docusaurus gen-api-docs all && docusaurus gen-api-docs:version sdwan:all && docusaurus gen-api-docs:version insights:all",
     "clean-all": "docusaurus clean-api-docs all && docusaurus clean-api-docs:version sdwan:all && docusaurus clean-api-docs:version insights:all",
     "re-gen": "yarn clean-all && yarn gen-all",
-    "getBlogs": "curl -H 'Accept: application/json' 'https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fmedium.com%2Ffeed%2Fpalo-alto-networks-developer-blog' -o src/components/Medium/blogs.json",
+    "getBlogs": "curl -H \"Accept: application/json\" \"https://api.rss2json.com/v1/api.json?rss_url=https%3A%2F%2Fmedium.com%2Ffeed%2Fpalo-alto-networks-developer-blog\" -o src/components/Medium/blogs.json",
     "start:netsec": "PRODUCTS_INCLUDE=cdss,threat-vault,dns-security,iot,expedition,cloudngfw,cdl,panos,terraform,ansible yarn start",
     "start:sase": "PRODUCTS_INCLUDE=sase,access,sdwan yarn start"
   },


### PR DESCRIPTION
## Description

Wrapping `curl` command args in single quotes is not supported on Windows which causes the `getBlogs` script to fail. 

## Motivation and Context

This change converts single quotes to escaped double quotes for cross-compatibility between *nix and Windows systems.

## How Has This Been Tested?

Tested with MacOS terminal and Windows 11 cmd.