### PR TITLE
Remove code block word wrap CSS override

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -310,7 +310,7 @@ html[data-theme="dark"] {
 }
 /* END MIME TABS */
 
-/* START SCHEMA TABS */ 
+/* START SCHEMA TABS */
 .schemaTabsListContainer_node_modules-docusaurus-theme-openapi-docs-lib-next-theme-SchemaTabs-styles-module {
   li {
     border: 1px solid var(--ifm-color-primary);
@@ -423,13 +423,6 @@ html[data-theme="dark"] {
 
 /* END NAVBAR */
 
-/* START CODE */
-pre {
-  white-space: pre-wrap;
-  word-wrap: break-word;
-}
-/* END CODE */
-
 /* START SIDEBAR */
 
 .theme-doc-sidebar-item-link-level-1 {
@@ -462,7 +455,7 @@ pre {
     .menu__list-item-collapsible + .menu__list {
       padding-left: 1.1rem;
     }
-    
+
     .theme-doc-sidebar-item-link {
       margin-top: 0;
 
@@ -663,7 +656,7 @@ a {
 
 /* START VERSION BADGES */
 .theme-doc-version-badge {
-  margin-bottom: var(--ifm-leading); 
-  color: white; 
+  margin-bottom: var(--ifm-leading);
+  color: white;
 }
 /* END VERSION BADGES */


### PR DESCRIPTION
## Description

Remove CSS style overriding default `CodeBlock` overflow behavior, where users are given the option to toggle line/word wrap if supported by language.

## Motivation and Context

Some code snippets extend beyond visible area which resulted in ugly wrapping.

## How Has This Been Tested?

See deploy preview for full test. Tested locally.

## Screenshots (if appropriate)

https://user-images.githubusercontent.com/9343811/201747286-1f48bbf1-9241-46c4-acd5-49ee507119b1.mov