### PR TITLE
Add CORS proxy to SASE auth API

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -554,6 +554,7 @@ const config = {
           auth: {
             specPath: "openapi-specs/sase/auth",
             outputDir: "products/sase/api/auth",
+            proxy: "https://cors.pan.dev",
             sidebarOptions: {
               groupPathsBy: "tag",
             },


### PR DESCRIPTION
## Description

The SASE auth create token endpoint requires a CORS anywhere proxy in order to support requests from the browser.

## Motivation and Context

Allow customers/users to generate tokens from the browser.

## How Has This Been Tested?

Tested using my own service account and TSG ID. Will follow up and test other endpoints to see if any more need the proxy.