### PR TITLE
[Bug] DropdownNavbarItemMobile: Cannot read properties of undefined (reading 'map')

### DIFF
--- a/src/theme/NavbarItem/DropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DropdownNavbarItem.js
@@ -314,6 +314,7 @@ function DropdownNavbarItemMobile({
             >
               {products.map((product, j) => (
                 <li
+                  key={j}
                   className={clsx("menu__list-item", {
                     "menu__list-item--collapsed": j !== productIdx,
                   })}
@@ -339,30 +340,40 @@ function DropdownNavbarItemMobile({
                     className="menu__list"
                     collapsed={j !== productIdx}
                   >
-                    <NavbarNavLink
-                      className={clsx("menu__link section__title")}
-                      label={"Docs"}
-                      onClick={(e) => e.preventDefault()}
-                    />
-                    {product.docs.map((productDoc) => (
-                      <NavbarNavLink
-                        className={clsx("menu__link menu__link--sublist")}
-                        label={productDoc.label}
-                        to={productDoc.to}
-                      />
-                    ))}
-                    <NavbarNavLink
-                      className={clsx("menu__link section__title")}
-                      label={"API Reference"}
-                      onClick={(e) => e.preventDefault()}
-                    />
-                    {product.apiDocs.map((apiDoc) => (
-                      <NavbarNavLink
-                        className={clsx("menu__link menu__link--sublist")}
-                        label={apiDoc.label}
-                        to={apiDoc.to}
-                      />
-                    ))}
+                    {product.docs && (
+                      <>
+                        <NavbarNavLink
+                          className={clsx("menu__link section__title")}
+                          label={"Docs"}
+                          onClick={(e) => e.preventDefault()}
+                        />
+                        {product.docs.map((productDoc, i) => (
+                          <NavbarNavLink
+                            key={i}
+                            className={clsx("menu__link menu__link--sublist")}
+                            label={productDoc.label}
+                            to={productDoc.to}
+                          />
+                        ))}
+                      </>
+                    )}
+                    {product.apiDocs && (
+                      <>
+                        <NavbarNavLink
+                          className={clsx("menu__link section__title")}
+                          label={"API Reference"}
+                          onClick={(e) => e.preventDefault()}
+                        />
+                        {product.apiDocs.map((apiDoc, i) => (
+                          <NavbarNavLink
+                            key={i}
+                            className={clsx("menu__link menu__link--sublist")}
+                            label={apiDoc.label}
+                            to={apiDoc.to}
+                          />
+                        ))}
+                      </>
+                    )}
                   </Collapsible>
                 </li>
               ))}


### PR DESCRIPTION
## Description

Currently, the `<DropdownNavbarItemMobile />` component does not properly handle conditional rendering of `product.docs` and `product.apiDocs`. Products that did not contain an `apiDocs` or `docs` property within `docusaurus.config.js` caused the site to crash when resizing the browser to mobile viewports.

## Motivation and Context

This PR introduces the fix to the bug described above by conditionally mapping and rendering `product.apiDocs` and `product.docs` to prevent the site from crashing when viewing in mobile.

## How Has This Been Tested?

Tested locally with https://github.com/PaloAltoNetworks/pan.dev/pull/213

## Steps to reproduce:
1. Navigate to https://pan-dev-f1b58--pr213-6jmh959f.web.app/
2. Decrease browser size to mobile
3. Observe page crash and error message `Cannot read properties of undefined (reading 'map')`

## Screenshots (if appropriate)

### Before

https://user-images.githubusercontent.com/48506502/211913216-514e90e4-a9bf-4557-ab50-9982b201990e.mov

### After 

https://user-images.githubusercontent.com/48506502/211913321-0456379e-cf96-4533-88cc-b16124697047.mov

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
