### PR TITLE
Limit smooth scrolling to homepage

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -28,7 +28,8 @@
   src: url("/fonts/Metropolis-SemiBold.ttf") format("truetype");
 }
 
-html {
+/* Apply smooth scrolling only to homepage */
+html:has(body):has(div):has(div):has(.homepage) {
   scroll-behavior: smooth;
 }
 


### PR DESCRIPTION
## Description

This change leverages a nested `has()` selector to limit smooth scrolling to home page.

## Motivation and Context

When navigating from one page to another, users may experience a momentary delay as the browser scrolls from the current position to the top of the page:

https://user-images.githubusercontent.com/9343811/213208175-199cb159-75cd-4647-9e71-f96cf3ce590c.mov

After change:

https://user-images.githubusercontent.com/9343811/213208769-a06818fd-3867-47a1-a993-b9e71d021042.mov

> Notice smooth scrolling is preserved for home page

## How Has This Been Tested?

Local dev server - see deploy preview for live demo