### PR TITLE
[Bug] Resolve local console errors caused by React Slick Carousel

### DIFF
--- a/src/components/Medium/index.js
+++ b/src/components/Medium/index.js
@@ -1,9 +1,7 @@
 import Link from "@docusaurus/Link";
 import clsx from "clsx";
 import React from "react";
-import Slider from "react-slick";
-import "slick-carousel/slick/slick-theme.css";
-import "slick-carousel/slick/slick.css";
+import Slider from "../Slider/Slider";
 import "./Slider.scss";
 import styles from "./styles.module.css";
 
@@ -12,15 +10,8 @@ const blogs = blog_json.items.slice(0, 9);
 
 function Medium() {
   const sliderSettings = {
-    autoplay: true,
-    autoplaySpeed: 7500,
-    dots: true,
-    infinite: true,
-    speed: 850,
     slidesToShow: 3,
     slidesToScroll: 3,
-    nextArrow: <img src="/icons/slider-arrow-forward.svg" />,
-    prevArrow: <img src="/icons/slider-arrow-back.svg" />,
     responsive: [
       {
         breakpoint: 1024,

--- a/src/components/ProductLandingPage/Hero/Hero.js
+++ b/src/components/ProductLandingPage/Hero/Hero.js
@@ -1,10 +1,10 @@
-import React from 'react'
+import React from "react";
 // components
-import Link from '@docusaurus/Link'
-import Slider from '../Slider/Slider'
-import Card from '../Cards/Card'
+import Link from "@docusaurus/Link";
+import Slider from "../../Slider/Slider";
+import Card from "../Cards/Card";
 // styles
-import './Hero.scss'
+import "./Hero.scss";
 
 function ProductHero({ anchorLink, product, header, subheader, sliderCards }) {
   return (
@@ -16,28 +16,28 @@ function ProductHero({ anchorLink, product, header, subheader, sliderCards }) {
             {subheader}
           </header>
           <Link to={anchorLink}>
-            <button className="button button--primary">
-              Learn More
-            </button>
+            <button className="button button--primary">Learn More</button>
           </Link>
         </div>
-        {sliderCards.length && <div className="product-hero__inner-right">
-          <Slider className="product-hero__slider-container">
-            {sliderCards.map((card, i) =>
-              <Card
-                key={i}
-                cta={card.cta}
-                description={card.description}
-                image={card.image}
-                title={card.title}
-                type="imageCard"
-              />
-            )}
-          </Slider>
-        </div>}
+        {sliderCards.length && (
+          <div className="product-hero__inner-right">
+            <Slider className="product-hero__slider-container">
+              {sliderCards.map((card, i) => (
+                <Card
+                  key={i}
+                  cta={card.cta}
+                  description={card.description}
+                  image={card.image}
+                  title={card.title}
+                  type="imageCard"
+                />
+              ))}
+            </Slider>
+          </div>
+        )}
       </div>
     </section>
-  )
+  );
 }
 
-export default ProductHero
+export default ProductHero;

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -4,6 +4,35 @@ import "slick-carousel/slick/slick-theme.css";
 import "slick-carousel/slick/slick.css";
 
 function SliderComponent(props) {
+  const SlickArrowLeft = ({ currentSlide, slideCount, ...props }) => (
+    <button
+      {...props}
+      className={
+        "slick-prev slick-arrow" + (currentSlide === 0 ? " slick-disabled" : "")
+      }
+      aria-hidden="true"
+      aria-disabled={currentSlide === 0 ? true : false}
+      type="button"
+    >
+      <img src="/icons/slider-arrow-back.svg" />
+    </button>
+  );
+
+  const SlickArrowRight = ({ currentSlide, slideCount, ...props }) => (
+    <button
+      {...props}
+      className={
+        "slick-next slick-arrow" +
+        (currentSlide === slideCount - 1 ? " slick-disabled" : "")
+      }
+      aria-hidden="true"
+      aria-disabled={currentSlide === slideCount - 1 ? true : false}
+      type="button"
+    >
+      <img src="/icons/slider-arrow-forward.svg" />
+    </button>
+  );
+
   const defaultSettings = {
     autoplay: true,
     autoplaySpeed: 7500,
@@ -12,8 +41,8 @@ function SliderComponent(props) {
     speed: 850,
     slidesToShow: 2,
     slidesToScroll: 2,
-    nextArrow: <img src="/icons/slider-arrow-forward.svg" />,
-    prevArrow: <img src="/icons/slider-arrow-back.svg" />,
+    nextArrow: <SlickArrowRight />,
+    prevArrow: <SlickArrowLeft />,
     responsive: [
       {
         breakpoint: 996,

--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -1,5 +1,7 @@
 import React from "react";
 import Slider from "react-slick";
+import "slick-carousel/slick/slick-theme.css";
+import "slick-carousel/slick/slick.css";
 
 function SliderComponent(props) {
   const defaultSettings = {
@@ -36,8 +38,8 @@ function SliderComponent(props) {
   return (
     <Slider {...defaultSettings} {...props}>
       {props.children}
-    </Slider >
-  )
+    </Slider>
+  );
 }
 
-export default SliderComponent
+export default SliderComponent;


### PR DESCRIPTION
## Description
**Environment:** Dev 
**Device:** Mac | Chrome 

This PR introduces a fix for local console errors caused by React Slick Carousel. The console error was caused by a known issue when using custom arrows, more info can be found [here](https://github.com/akiran/react-slick/issues/623#issuecomment-629764816). In addition, the `Slider` component is now a single component that can be used across the app and can receive [custom props](https://react-slick.neostack.com/docs/api/) for customizability.

_**Note: While working on this issue, another [console error](https://stackoverflow.com/questions/54181734/chrome-extension-message-passing-unchecked-runtime-lasterror-could-not-establi/54686484#54686484) (unrelated to Slick Carousel) came to my attention which will be addressed in a later PR.**_

## Motivation and Context

There should be no console errors in the browser.

## How Has This Been Tested?

Navigated to the pages that contained the `Slider` component and ensured the error was no longer in the console and that carousel functionality was intact. 

## Screenshots (if appropriate)

### Before
**Homepage**
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/48506502/213588751-a0957bfc-a10f-468a-b2f2-43b5fb0f518b.png">

**Terraform Landing Page** 
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/48506502/213588917-32d2bcf4-f218-462a-b190-d313a09e7c6d.png">

### After 
**Homepage**
<img width="1785" alt="image" src="https://user-images.githubusercontent.com/48506502/213589215-973bdc63-5eaa-41c4-937e-6a6c73f2b76c.png">

**Terraform Landing Page** 
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/48506502/213589254-85488639-01b5-4669-b39b-3fb0471376ee.png">

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
