### PR TITLE
Use .yarnrc to change default registry url

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+registry "https://registry.npmjs.org/"

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,1 @@
-registry "https://registry.npmjs.org/"
+registry "https://registry.npmjs.org"


### PR DESCRIPTION
## Description

The default yarn registry (https://registry.yarnpkg.com) has a TLS setup that is incompatible with SSL decryption. The following StackOverflow page suggests that the yarn registry is simply a proxy for https://registry.npmjs.org.

Source: https://stackoverflow.com/questions/58071109/difference-between-yarn-registry-and-npm-registry

This change uses `.yarnrc` to change the default registry URL to https://registry.npmjs.org to help avoid SSL decryption issues.

## Motivation and Context

Improve DX for pan.dev contributors who work behind an SSL decryption proxy.

## How Has This Been Tested?

Output of `yarn config list` after updating `.yarnrc`:

```
yarn config v1.22.19
info yarn config
{
  'version-tag-prefix': 'v',
  'version-git-tag': true,
  'version-commit-hooks': true,
  'version-git-sign': false,
  'version-git-message': 'v%s',
  'init-version': '1.0.0',
  'init-license': 'MIT',
  'save-prefix': '^',
  'bin-links': true,
  'ignore-scripts': false,
  'ignore-optional': false,
  registry: 'https://registry.npmjs.org/',
  'strict-ssl': false,
  'user-agent': 'yarn/1.22.19 npm/? node/v18.13.0 darwin arm64',
  lastUpdateCheck: 1674488750961
}
```