### PR TITLE
[Enhancement] Sanitize Medium blog content to only show first paragraph

### DIFF
--- a/src/components/Medium/index.js
+++ b/src/components/Medium/index.js
@@ -43,6 +43,23 @@ function Medium() {
   };
 
   const BlogCard = ({ blog }) => {
+    const getFirstParagraph = (blogContent) => {
+      let firstParagraph = null;
+      let div = document.createElement("div");
+      div.innerHTML = blogContent;
+      let elements = div.childNodes;
+
+      // Find the first paragraph element in the blog content
+      for (let i = 0; i < elements.length; i++) {
+        if (elements[i].nodeName === "P") {
+          firstParagraph = elements[i].innerText;
+          break;
+        }
+      }
+
+      return firstParagraph;
+    };
+
     return (
       <div className={clsx("card", styles.showcaseBlog)}>
         <div className="card__image">
@@ -62,7 +79,7 @@ function Medium() {
           <br />
           <div className="avatar__intro margin-left--none">
             <div className={styles.content}>
-              <div dangerouslySetInnerHTML={{ __html: blog.content }} />
+              <p>{getFirstParagraph(blog.content)}</p>
             </div>
           </div>
         </div>

--- a/src/components/Medium/index.js
+++ b/src/components/Medium/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 import Link from "@docusaurus/Link";
 import Slider from "../Slider/Slider";
 import clsx from "clsx";
@@ -79,7 +80,9 @@ function Medium() {
           <br />
           <div className="avatar__intro margin-left--none">
             <div className={styles.content}>
-              <p>{getFirstParagraph(blog.content)}</p>
+              <BrowserOnly>
+                {() => <p>{getFirstParagraph(blog.content)}</p>}
+              </BrowserOnly>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description

This PR introduces content sanitization for our Medium Blog Cards. Currently, there are unseen elements being rendered onto the DOM. Since the Blog Cards only show a preview of the blog content, it may be unnecessary to inject the html of the entire blog. The approach taken is to only render up to the first paragraph of each blog content and omitting all the other proceeding elements.

## How Has This Been Tested?

Inspected DOM for each blog card content to ensure there weren't any unseen elements being injected.

## Screenshots (if appropriate)

### Before 
![Screenshot 2023-02-03 at 3 34 00 PM](https://user-images.githubusercontent.com/48506502/216730501-98db9e8c-34bf-43a6-af4e-d68f66ee3a30.png)

### After 
![Screenshot 2023-02-03 at 3 27 52 PM](https://user-images.githubusercontent.com/48506502/216730545-cfc42de9-5dc1-4d95-96cc-ebb6e86ed54d.png)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
