### PR TITLE
[Bug] Remove original Slick arrow styling

### DIFF
--- a/src/components/Slider/Slider.js
+++ b/src/components/Slider/Slider.js
@@ -2,6 +2,7 @@ import React from "react";
 import Slider from "react-slick";
 import "slick-carousel/slick/slick-theme.css";
 import "slick-carousel/slick/slick.css";
+import "./Slider.scss";
 
 function SliderComponent(props) {
   const SlickArrowLeft = ({ currentSlide, slideCount, ...props }) => (

--- a/src/components/Slider/Slider.scss
+++ b/src/components/Slider/Slider.scss
@@ -1,3 +1,3 @@
-.slick-arrow:before {
+.slick-arrow::before {
   content: "";
 }

--- a/src/components/Slider/Slider.scss
+++ b/src/components/Slider/Slider.scss
@@ -1,0 +1,3 @@
+.slick-arrow:before {
+  content: "";
+}


### PR DESCRIPTION
## Description

This PR addresses the rendering of original Slick arrows within the carousel. These arrows should not appear, since we are using custom arrows instead.

## How Has This Been Tested?

Tested with both dark/light mode to ensure that the original arrows were not being rendered on top of the custom arrows and arrow functionality remains intact.

## Screenshots (if appropriate)

### Before

**Homepage**
![image](https://user-images.githubusercontent.com/48506502/214658302-d1f6ae40-3698-447e-b37b-a3bfb685b994.png)

**Terraform Landing Page**
![image](https://user-images.githubusercontent.com/48506502/214658973-9a0d62d3-b6fd-4282-a46c-4aab866f0b0e.png)

### After
**Homepage**
![image](https://user-images.githubusercontent.com/48506502/214658398-503c161f-269b-4880-a640-c03688787a93.png)

**Terraform Landing Page**
![image](https://user-images.githubusercontent.com/48506502/214658732-272bc52e-d5f5-44e2-a1f7-ed1d1f0e3691.png)

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
