### PR TITLE
DNS Security API fixes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -650,7 +650,7 @@ const config = {
             specPath: "openapi-specs/dns-security/dns-security.yaml",
             outputDir: "products/dns-security/api",
             proxy: "https://cors.pan.dev",
-            sidebarOptions: { groupPathsBy: "tag", categoryLinkSource: "info" },
+            sidebarOptions: { groupPathsBy: "tag" },
           },
           cdl: {
             specPath: "openapi-specs/cdl/logforwarding",

--- a/openapi-specs/dns-security/dns-security.yaml
+++ b/openapi-specs/dns-security/dns-security.yaml
@@ -464,7 +464,7 @@ paths:
       - X-DNS-API-APIKEY: []
       summary: Request Domain Category Change.
       tags:
-      - DNS Security
+      - DNS Security API
 
 
 
@@ -558,7 +558,7 @@ paths:
       - X-DNS-API-APIKEY: []
       summary: Request Domain Information.
       tags:
-      - DNS Security
+      - DNS Security API
 produces:
 - application/json
 schemes:


### PR DESCRIPTION
## Description

Addresses an incompatible OpenAPI plugin setting and a mismatch between operation tags and global tags.

## Motivation and Context

Upcoming version of plugin will generate `info` doc which could lead to sidebar issues if the operation and global tags are not synched. Since `dns-security.yaml` is a single spec, `categoryLinkSource: "info"` is unnecessary. Instead, we can just render the "Introduction" doc.

## How Has This Been Tested?

See deploy preview.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)