### PR TITLE
Override details markers to match Docusaurus caret

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -687,3 +687,24 @@ a {
   }
 }
 /* END EDIT THIS PAGE */
+
+/* START DETAILS MARKERS */
+.theme-api-markdown > div:first-child summary::before {
+  content: "";
+  background: var(--ifm-menu-link-sublist-icon) 50% / 1.2rem 1.2rem;
+  filter: var(--ifm-menu-link-sublist-icon-filter);
+  height: 0.75rem;
+  transform: rotate(90deg) !important;
+  width: 0.75rem;
+  transition: transform var(--ifm-transition-fast) linear !important;
+  border: none !important;
+  transform-origin: unset !important;
+}
+
+.theme-api-markdown
+  > div:first-child
+  details[data-collapsed="false"]
+  > summary::before {
+  transform: rotate(180deg) !important;
+}
+/* END DETAILS MARKERS */

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -691,7 +691,8 @@ a {
 /* START DETAILS MARKERS */
 .theme-api-markdown > div:first-child summary::before {
   content: "";
-  background: var(--ifm-menu-link-sublist-icon) 50% / 1.2rem 1.2rem;
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>')
+    50% / 1.2rem 1.2rem;
   filter: var(--ifm-menu-link-sublist-icon-filter);
   height: 0.75rem;
   transform: rotate(90deg) !important;


### PR DESCRIPTION
## Description

Overrides details markers so that they better match the built-in caret markers used by Docusaurus.

## Motivation and Context

Adds more consistent styling to details markers which is hopefully less distracting and a better UI/UX.

## How Has This Been Tested?

See deploy preview

## Screenshots (if appropriate)

Before:

<img width="731" alt="Screenshot 2023-03-01 at 8 02 43 AM" src="https://user-images.githubusercontent.com/9343811/222146817-3f7dbf05-0b18-4863-8cef-a129d5aa1e5b.png">

After:

<img width="802" alt="Screenshot 2023-03-01 at 8 01 58 AM" src="https://user-images.githubusercontent.com/9343811/222146660-9e71aaef-115d-4592-bc68-1aac1e9aaa9f.png">

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)