### PR TITLE
[Dependencies] Add resolutions for @apidevtools/json-schema-ref-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
     "prettier": "2.7.1",
     "rimraf": "^3.0.2",
     "run-script-os": "^1.1.6"
+  },
+  "resolutions": {
+    "@apidevtools/json-schema-ref-parser": "9.0.9"
   }
 }


### PR DESCRIPTION
## Description

A breaking change was introduced to `json-schema-ref-parser` that requires that we pin/resolve to an earlier version. See the following for background: https://github.com/APIDevTools/json-schema-ref-parser/issues/298

## Motivation and Context

The breaking change causes builds to fail internally.

## How Has This Been Tested?

Tested internally.