### PR TITLE
Add adobe analytics tag to scripts config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -724,6 +724,12 @@ const config = {
       rel: "stylesheet",
     },
   ],
+  scripts: [
+    {
+      src: "https://assets.adobedtm.com/9273d4aedcd2/b9b0ac3add2f/launch-a24de682dd3b.min.js",
+      async: true,
+    },
+  ],
   onDuplicateRoutes: "warn",
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",


### PR DESCRIPTION
## Description

Previously, the Adobe Analytics tag was injected via Google Tag Manager. This change moves it directly to `docusaurus.config.js` under the `scripts` section.

## Motivation and Context

GTM no longer appears to support injecting custom HTML/JS. Testing to see if this could be a viable alternative.
