### PR TITLE
Adds more control over breadcrumbs

### DIFF
--- a/crumbs.json
+++ b/crumbs.json
@@ -347,6 +347,7 @@
   },
   "terraform-panos": {
     "href": "/terraform",
+    "make_link": true,
     "label": "Terraform",
     "sitemap_feature": ["Automation"],
     "children": [


### PR DESCRIPTION
## Description

Provides more control over breadcrumb links and generation while preserving existing functionality. All pages should act the same unless specifically changed in the crumbs.json file.

* Product breadcrumbs can now link to a product landing page by adding the key `make_link: true` to the crumbs.json

* Non-product breadcrumbs (eg. top level pages) that sometimes don't show up in the breadcrumbs can optionally show up now with `add_crumb: true` in the crumbs.json

## Motivation and Context

Breadcrumbs that can link to a page don't currently. And breadcrumbs for top level pages that are not in the category are not in the breadcrumbs currently.

## How Has This Been Tested?

Tested locally

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes if appropriate.
- [] All new and existing tests passed.
