### PR TITLE
Add codeowners and contributing guide for SWFW content

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,3 +13,7 @@ products/terraform/* @PaloAltoNetworks/design-hive
 products/ansible/* @PaloAltoNetworks/design-hive
 products/panos/* @PaloAltoNetworks/design-hive
 products/splunk/* @PaloAltoNetworks/design-hive
+
+# SWFW "Orchestration Hub"
+products/terraform/docs/swfw/* @PaloAltoNetworks/pso_prisma_maintainers
+products/terraform/sidebars.js @PaloAltoNetworks/pso_prisma_maintainers

--- a/products/contributing/advanced/auto-generated-docs.md
+++ b/products/contributing/advanced/auto-generated-docs.md
@@ -1,0 +1,21 @@
+---
+id: auto-generated-docs
+title: Automatically Generated Pages
+sidebar_label: Auto-generated Pages
+description: Describing that some pages are automatically generated.
+---
+
+## Automatically Generated Pages
+
+Some content in pan.dev is generated elsewhere, not in the pan.dev repository directly. This is important to know, because any changes made directly to the files located in the pan.dev repository for this content could be overwritten and lost. Instances of content generated elsewhere are listed below with further details of the original content source.
+
+### Software Firewall (SWFW) Terraform Documentation
+
+The pages linked from the [Orchestration Hub](https://pan.dev/swfw) which describe References Architectures, Examples and Modules for Terraform are automatically copied from their source repository, using a sync system. These pages are viewable on pan.dev at `https://pan.dev/terraform/docs/swfw/{{cloud-id}}}}/vmseries/{{type}}/`, where `cloud-id` is currently `aws`, `azure` or `gcp`, and `type` is currently `reference-architectures`, `examples` or `modules`.
+
+Changes required to these pages should be made in the source repositories. These are currently:
+- AWS: https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules
+- Azure: https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules
+- GCP: https://github.com/PaloAltoNetworks/terraform-google-vmseries-modules
+
+Any changes made to the README.md files in the `examples` or `modules` directories of the repositories above will be copied to the pan.dev repository in a cloud-specific PR and branch, when a release is performed in the source repository. The changes can then be reviewed and merged using the usual process for pan.dev content.


### PR DESCRIPTION
## Description
Adds codeowners and contributing guide for SWFW content linked from the [Orchestration Hub](https://pan.dev/swfw)

## Motivation and Context
To conclude the build of the content system for SWFW content. The content sync system has been tested successfully and will used for future updates to the SWFW content for Terraform. This requires that the relevant team has permission to review PRs for their docs which are copied into pan.dev. Also a contributing guide has been added to make future contributors aware that they should not attempt to modify the relevant content directly in the pan.dev repo.

## How Has This Been Tested?
Test locally with yarn

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.