### PR TITLE
Whitelist create-pr-on-fork-for-pan-dev[bot]

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -16,7 +16,12 @@ jobs:
     steps:
       - name: Check if actor is org member
         id: is-org-member
-        run:  echo "is-org-member-result=$(gh api -X GET orgs/PaloAltoNetworks/memberships/${{ github.actor }} | jq -r .message)" >> "$GITHUB_OUTPUT"
+        run: |
+          if [[ "${{ github.actor }}" == "create-pr-on-fork-for-pan-dev[bot]" ]]; then
+            echo "is-org-member-result=null" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-org-member-result=$(gh api -X GET orgs/PaloAltoNetworks/memberships/${{ github.actor }} | jq -r .message)" >> "$GITHUB_OUTPUT"
+          fi
     env:
       GH_TOKEN: ${{ secrets.PAT }}
 


### PR DESCRIPTION
## Description

Updates the deploy-preview workflow to allow `create-pr-on-fork-for-pan-dev[bot]` to continue without manual approval.