### PR TITLE
chore(swfw): Add cert expire banner to Orchestration Hub

### DIFF
--- a/src/components/CertExpireBanner/index.js
+++ b/src/components/CertExpireBanner/index.js
@@ -1,0 +1,31 @@
+import React from "react";
+import Link from "@docusaurus/Link";
+import "./styles.scss";
+
+export default function CertExpireBanner() {
+  return (
+    <div className="banner-cert-expire">
+      <h4>
+        <div className="banner-cert-expire__line1">
+          Emergency Update Required
+        </div>
+        <div className="banner-cert-expire__line2">
+          PAN-OS Root Certificate Expiration
+        </div>
+      </h4>
+      <div className="view-advisory-link">
+        <Link
+          to="https://live.paloaltonetworks.com/t5/customer-advisories/emergency-update-required-pan-os-root-and-default-certificate/ta-p/564672"
+          className="tab-item__link"
+        >
+          <span>View Advisory</span>
+          <img
+            src="/img/icons/arrow-forward.svg"
+            alt="Forward arrow icon"
+            height="15"
+          />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CertExpireBanner/styles.scss
+++ b/src/components/CertExpireBanner/styles.scss
@@ -1,0 +1,47 @@
+html[data-theme="dark"] {
+  .banner-cert-expire {
+    color: black;
+  }
+}
+
+.banner-cert-expire {
+  background-color: #ffffff;
+  padding: 13px;
+  width: 100%;
+  max-width: 30em;
+  position: relative;
+  top: 10px;
+  margin-left: auto;
+  margin-right: auto;
+  border-radius: 4px;
+  box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.16);
+  z-index: 100;
+
+  h4 {
+    margin-bottom: 0.4em;
+    font-family: "Montserrat", sans-serif;
+  }
+
+  &__line2 {
+    font-weight: 500;
+  }
+
+  // .view-advisory-link {
+  // margin: 0.5em 0;
+  // }
+
+  .tab-item__link {
+    display: flex;
+    align-items: center;
+    color: var(--ifm-color-main);
+
+    img {
+      max-width: 25px;
+      margin-left: 0.25em;
+    }
+
+    :hover {
+      color: var(--ifm-color-main);
+    }
+  }
+}

--- a/src/pages/swfw.js
+++ b/src/pages/swfw.js
@@ -14,6 +14,7 @@ import {
 import "./swfw.scss";
 import CloudCard from "../components/CloudCard";
 import LinkList from "../components/LinkList";
+import CertExpireBanner from "../components/CertExpireBanner";
 
 export default function SWFWLandingPage() {
   return (
@@ -22,6 +23,7 @@ export default function SWFWLandingPage() {
       title={SWFW_METADATA.title}
       wrapperClassName="swfw-landing-page"
     >
+      <CertExpireBanner />
       <div className="swfw-landing-page__container">
         <section className={`product-hero-container swfw swfw-hero-container`}>
           <div className={`product-hero__inner-content swfw`}>

--- a/src/pages/swfw.scss
+++ b/src/pages/swfw.scss
@@ -61,6 +61,12 @@ html[data-theme="dark"] {
     max-width: 1200px;
     align-self: center;
     overflow: visible;
+
+    // to accomodate the cert expiration banner
+    @media (min-width: 1068px) {
+      position: relative;
+      top: -40px;
+    }
   }
 
   html[data-theme="dark"] {


### PR DESCRIPTION
## Description

Adds a banner to the Orchestration Hub landing page with notification of the PAN-OS Root Cert Expiration advisory

## How Has This Been Tested?

Tested locally

## Screenshots (if appropriate)

![Google Chrome - 2023-11-17 11 22 13](https://github.com/PaloAltoNetworks/pan.dev/assets/4164289/3e05c6b7-436a-4b30-935f-05e9d1da114f)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
