### PR TITLE
bump Prisma Cloud Compute version to 31.03 from 31.02

### DIFF
--- a/products/compute/api/stable-endpoints.md
+++ b/products/compute/api/stable-endpoints.md
@@ -14,7 +14,7 @@ The deployment scripts and Twistcli that you download from Console, uses the API
 
 All minor or maintainance versions (xx) of 31.xx release have n-2 support for backward compatibility. The documentation for supported releases is available here:
 
-* [Prisma Cloud Compute Edition - 31.02](/compute/api/)
+* [Prisma Cloud Compute Edition - 31.03](/compute/api/)
 * [Prisma Cloud Compute Edition - 30.03](/compute/api/30-03/)
 * [Prisma Cloud Compute Edition - 22.12](/compute/api/22-12/)
 

--- a/products/compute/sidebars.js
+++ b/products/compute/sidebars.js
@@ -15,7 +15,7 @@ module.exports = {
     {
       type: "html",
       defaultStyle: true,
-      value: versionCrumb(`31-02`),
+      value: versionCrumb(`31-03`),
     },
     "compute/api/compute-api-reference-home",
     "compute/api/access-api-self-hosted",


### PR DESCRIPTION
## Description
Updating the Prisma Cloud Compute version to 31.03 from 31.02. No API change. 

## Motivation and Context
Prisma Cloud Compute version 31.03 released

## How Has This Been Tested?
N/A

## Screenshots (if appropriate)
N/A

## Types of changes
N/A

## Checklist
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
