### PR TITLE
RLP-139832 Rate Limits Documentation Update 

### DIFF
--- a/products/prisma-cloud/api/cspm/ratelimits.md
+++ b/products/prisma-cloud/api/cspm/ratelimits.md
@@ -4,4 +4,12 @@ title: Rate Limits
 sidebar_label: Rate Limits
 ---
 
-Prisma Cloud uses API throttling to protect the performance and availability of its services. Generally, if request submissions exceed an API rate limit, you will receive an HTTP 429 response code. The description for each API request includes any rate limits for that request.
+Prisma Cloud uses API throttling to protect the performance and availability of its services. Requests exceeding these limits will result in an  `HTTP 429 - Too Many Requests` response.
+
+Rate limiting varies depending on the specific API endpoint you are using. If an endpoint has rate limits, they will be documented in that endpoint's description.
+
+Rate limits are expressed using two values: `Rate Limit` and `Burst Rate`
+
+- **Rate Limit**: Number of individual requests per second allowed by the endpoint.
+- **Burst Rate**: Maximum number of concurrent requests allowed in one second.
+


### PR DESCRIPTION
## Description
> [RLP-139832](https://redlock.atlassian.net/browse/RLP-139832)

Update Rate Limiting documentation page following the [API rate limit look ahead notice](https://docs.prismacloud.io/en/enterprise-edition/rn/look-ahead-planned-updates-prisma-cloud/look-ahead-secure-the-infrastructure#api-rate-limits). 

- Additional updates may follow in upcoming releases as limits are officially introduced

![image](https://github.com/PaloAltoNetworks/pan.dev/assets/3386501/536762fb-3811-409a-9113-7116b5ac77f5)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
