### PR TITLE
Remove content security policy

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -15,15 +15,6 @@
             "value": "no-cache"
           }
         ]
-      },
-      {
-        "source": "**/*",
-        "headers": [
-          {
-            "key": "Content-Security-Policy",
-            "value": "default-src 'self'; script-src 'report-sample' 'self' 'unsafe-eval' 'sha256-iIf+c/EMxKD/FXoUDy0YsZ3mE+JhzPsmR+aVbrjkdwM=' 'sha256-mC5lwOEBZZZXJoN3sDvzxnxAdNIEKujq9NSXgmhc4HM=' 'sha256-eHA/c1eEwnVIP0JdQf5OoHlH0twlYKVdCPpF0Uxun4U=' 'sha256-HEXSlCvj5t1knUX5S9reED7mj347MrX5NNWmhVKV3AY=' 'sha256-LJv39KYSfXELQ23XLwGsxKqh55fWlLAveXNhE4GJztE=' 'sha256-zkIfJey2QJSMWsoE/xLvQ6GebR1o8N9s0f9cjTQ7mS0=' 'sha256-IfbgmjMKKAFfhR1EW5CeLOLA6QyZyVAEeldA3Hbac90=' 'sha256-iIf+c/EMxKD/FXoUDy0YsZ3mE+JhzPsmR+aVbrjkdwM=' https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com https://*.googletagmanager.com https://www.google.com/recaptcha/enterprise.js https://www.gstatic.com https://tagmanager.google.com https://static.hotjar.com https://script.hotjar.com https://*.demdex.net https://cm.everesttech.net https://assets.adobedtm.com; style-src 'report-sample' 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com pan.dev https://tagmanager.google.com https://fonts.googleapis.com; object-src 'none'; base-uri 'self'; font-src 'self' data: https://fonts.gstatic.com https://use.fontawesome.com; img-src 'self' data: https://cdn-images-1.medium.com https://medium.com https://www.datocms-assets.com https://www.google-analytics.com https://pan.dev https://raw.githubusercontent.com https://googletagmanager.com https://*.google-analytics.com https://*.googletagmanager.com https://avatars.githubusercontent.com https://github.com https://cdn.twistlock.com https://*.demdex.net https://cm.everesttech.net https://assets.adobedtm.com https://*.2o7.net https://ssl.gstatic.com https://www.gstatic.com; worker-src 'none'; connect-src https://*.demdex.net https://cm.everesttech.net https://assets.adobedtm.com https://stats.g.doubleclick.net https://www.google-analytics.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.paloaltonetworks.com https://cors.pan.dev https://*.algolia.net https://*.googleapis.com https://analytics.google.com https://*.hotjar.com wss://ws.hotjar.com https://*.hotjar.io https://panwprod.*.net https://pan.dev; frame-src 'self' https://www.google.com https://*.demdex.net https://td.doubleclick.net;"
-          }
-        ]
       }
     ],
     "public": "build",


### PR DESCRIPTION
## Description

Removes CSP configuration from firebase config

## Motivation and Context

Over time, our CSP has become increasingly difficult to manage, especially given inline scripts and changing sources/origins.

## How Has This Been Tested?

This has not been tested. The expectation is that removing the policy directives will disable it altogether.