### PR TITLE
Enable processing md files as commonmark

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,6 +28,7 @@ const config = {
   favicon: "img/PANW_Parent_Glyph_Red.svg",
   organizationName: "PaloAltoNetworks",
   projectName: "pan.dev",
+  markdown: { format: "detect" },
   themeConfig: {
     prism: {
       additionalLanguages: ["csharp", "php", "hcl"],


### PR DESCRIPTION
## Description

Docusaurus option that allows docs with `.md` extension to be processed using `commonmark`, as opposed to MDX. 

## Motivation and Context

Currently, upgrading to Docusaurus v3 is blocked by MDX parsing/syntax errors that exist in `.md` files, including `{`, `<<<`, indented code blocks and other cases. The hope is that this change will address the majority or all of the MDX parsing issues encountered when testing upgrading to v3. 

See #667 for more background.

## How Has This Been Tested?

Will test using the deploy preview