### PR TITLE
Add pages and menu items for service status APIs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -537,6 +537,18 @@ const config = {
                     },
                   ],
                 },
+                {
+                  label: "Prisma SASE Service Status",
+                  to: "#",
+                  logoClass: "prisma",
+                  docs: [
+                    {
+                      label: "Prisma SASE Service Status API",
+                      to: "sase/saseservicestatusapi",
+                      icon: "doc",
+                    },
+                  ],
+                },
               ],
             },
             {
@@ -573,6 +585,26 @@ const config = {
                     {
                       label: "Splunk App/Add-on",
                       to: "splunk/docs",
+                      icon: "doc",
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              label: "Cross-Platform",
+              to: "#",
+              colorclass: "cross-platform",
+              description:
+                "Learn about opportunities across Palo Alto Networks platforms.",
+              products: [
+                {
+                  label: "Service Status",
+                  to: "#",
+                  docs: [
+                    {
+                      label: "Service Status API",
+                      to: "cross-platform/servicestatusapi",
                       icon: "doc",
                     },
                   ],

--- a/products/cross-platform/service-status-api.mdx
+++ b/products/cross-platform/service-status-api.mdx
@@ -1,0 +1,11 @@
+---
+id: servicestatusapi
+title: Cross-Platform Service Status API
+description: Cross-Platform Service Status API
+hide_title: false
+hide_table_of_contents: false
+keywords:
+  - crossplatform
+---
+
+There is a Palo Alto Networks cross-platform Service Status page hosted at https://status.paloaltonetworks.com. The documentation for the companion API for this Service Status is hosted at https://status.paloaltonetworks.com/api which includes a Javascript wrapper and example code for consuming the API.

--- a/products/sase/docs/service-status-api.mdx
+++ b/products/sase/docs/service-status-api.mdx
@@ -1,0 +1,11 @@
+---
+id: saseservicestatusapi
+title: Prisma SASE Service Status API
+description: Prisma SASE Service Status API
+hide_title: false
+hide_table_of_contents: false
+keywords:
+  - sase
+---
+
+There is a Palo Alto Networks cross-platform Service Status page hosted at https://sase.status.paloaltonetworks.com. The documentation for the companion API for this Service Status is hosted at https://sase.status.paloaltonetworks.com/api which includes a Javascript wrapper and example code for consuming the API.


### PR DESCRIPTION
## Description

Add pages and menu items for two service status APIs hosted by Palo Alto Networks

## Motivation and Context

There is currently no listing of these APIs in pan.dev. This is the minimum we should have. A future target would be to host the documentation for these APIs directly on pan.dev

## How Has This Been Tested?
Locally

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.