### PR TITLE
Add custom sidebar menu component

### DIFF
--- a/src/components/SidebarMenu/index.js
+++ b/src/components/SidebarMenu/index.js
@@ -1,0 +1,26 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+function sidebarMenu(label, items) {
+  const template = `
+<div class="dropdown">
+  <button class="button button--block button--sm button--secondary">${label}</button>
+  <ul class="dropdown__menu">
+    ${items
+      .map(
+        (item) => `
+      <li><a class="dropdown__link" href="${item.baseUrl}">${item.label}</a></li>
+    `
+      )
+      .join("")}
+  </ul>
+</div>
+  `;
+  return template;
+}
+
+module.exports = sidebarMenu;

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -781,3 +781,7 @@ code {
 .openapi-explorer__form-item {
   font-size: 0.9rem !important;
 }
+
+.sidebar__menu-button {
+  display: grid !important;
+}


### PR DESCRIPTION
## Description

Adds a custom sidebar menu component to allow contributors to implement a dropdown menu at any position in a sidebar.

Example: 

https://github.com/user-attachments/assets/42884ee1-41f7-4e3e-b300-57fd73421dc3

Example sidebars.js (note that the first argument/parameter is the dropdown label and the second is the array of menu items):

```
const sidebarMenu = require("../../src/components/SidebarMenu");

module.exports = {
  expedition: [
    {
      type: "html",
      defaultStyle: true,
      value: sidebarMenu("Select Config Type", [
        { label: "This is an even longer test", baseUrl: "/" },
        { label: "This is a test", baseUrl: "/" },
        { label: "This is a medium length test", baseUrl: "/" },
      ]),
      className: "sidebar__menu-button dropdown--hoverable dropdown--left", // see https://infima.dev/docs/components/dropdown for additional usage/classes examples
    },
    "expedition/docs/home",
    "expedition/docs/expedition_qs",
    "expedition/docs/expedition_export",
    ...
```



