### PR TITLE
More details for Status Page APIs

### DIFF
--- a/products/cross-platform/docs/service-status-api.mdx
+++ b/products/cross-platform/docs/service-status-api.mdx
@@ -8,52 +8,51 @@ keywords:
   - crossplatform
 ---
 
-There is a Palo Alto Networks cross-platform Service Status page hosted at https://status.paloaltonetworks.com. There is documentation for the companion API for this Service Status, hosted at https://status.paloaltonetworks.com/api, which includes a Javascript wrapper and example code for consuming the API.
+There is a Palo Alto Networks cross-platform Status Page hosted at https://status.paloaltonetworks.com. There is documentation for the companion API for this Status Page, hosted at https://status.paloaltonetworks.com/api, which includes a Javascript wrapper.
 
 The API itself is delivered via Atlassian's StatusPage offering. This API provides a collections of endpoints which all return JSON formatted payloads. The API does not provide any built-in filtering; any filtering or parsing of responses should be done client-side, with the suggestion to use a JSON parsing library within the programming language of choice.
 
+The endpoints available are described below.
 
-The following endpoints are available:
-
-Summary:
+### Summary
 https://status.paloaltonetworks.com/api/v2/summary.json
 - Despite being called a summary, this provides details from the entire status page, including an overall status indicator for the entire portfolio, statuses of individual components, unresolved incidents, and any upcoming or in-progress scheduled maintenances.
 
-Portfolio Status:
+### Portfolio Status
 https://status.paloaltonetworks.com/api/v2/status.json
 - Provides just an overall status for the entire portfolio of products and services listed on the status page.
 - Status indicator potential values: none, minor, major, critical
 
-Product/Service (Component) Statuses:
+### Product/Service (Component) Statuses
 https://status.paloaltonetworks.com/api/v2/components.json
 - Lists each product or service (component) from the status page with a status for each.
 - Component status potential values: operational, degraded_performance, partial_outage, major_outage
 
-Unresolved Incidents:
+### Unresolved Incidents
 https://status.paloaltonetworks.com/api/v2/incidents/unresolved.json
 - Lists all incidents which are unresolved, with their impact and status.
 - Incident impact potential values: none, minor, major, critical
 - Incident status potential values: investigating, identified, monitoring
 
-Recent Incidents:
+### Recent Incidents
 https://status.paloaltonetworks.com/api/v2/incidents.json
 - Lists the most recent 50 incidents, whether they are resolved or unresolved, with their impact and status.
 - Incident impact potential values: none, minor, major, critical
 - Incident status potential values: investigating, identified, monitoring, resolved, postmortem
 
-Upcoming Maintenance Events:
+### Upcoming Maintenance Events
 https://status.paloaltonetworks.com/api/v2/scheduled-maintenances/upcoming.json
 - Lists upcoming events such as planned outages, upgrades, or general notices of work on products and services which may cause disruptions.
 - Maintenance event status potential values: scheduled
 - Maintenance event impact potential values: none, maintenance, minor, major, critical
 
-Active Maintenance Events:
+### Active Maintenance Events
 https://status.paloaltonetworks.com/api/v2/scheduled-maintenances/active.json
 - Lists upcoming events such as planned outages, upgrades, or general notices of work on products and services which may cause disruptions.
 - Maintenance event status potential values: in progress, verifying
 - Maintenance event impact potential values: none, maintenance, minor, major, critical
 
-All Maintenance Events:
+### All Maintenance Events
 https://status.paloaltonetworks.com/api/v2/scheduled-maintenances.json
 - Lists the most recent 50 maintenance events such as planned outages, upgrades, or general notices of work on products and services which may cause disruptions.
 - Maintenance event status potential values: scheduled, in progress, verifying, completed

--- a/products/cross-platform/docs/service-status-api.mdx
+++ b/products/cross-platform/docs/service-status-api.mdx
@@ -17,43 +17,44 @@ The endpoints available are described below.
 ### Summary
 https://status.paloaltonetworks.com/api/v2/summary.json
 - Despite being called a summary, this provides details from the entire status page, including an overall status indicator for the entire portfolio, statuses of individual components, unresolved incidents, and any upcoming or in-progress scheduled maintenances.
+- Potential values are discussed in the subsequent API endpoints below.
 
 ### Portfolio Status
 https://status.paloaltonetworks.com/api/v2/status.json
-- Provides just an overall status for the entire portfolio of products and services listed on the status page.
-- Status indicator potential values: none, minor, major, critical
+- Provides an overall status for the entire portfolio of products and services listed on the status page.
+- Status indicator potential values: `none`, `minor`, `major`, `critical`
 
 ### Product/Service (Component) Statuses
 https://status.paloaltonetworks.com/api/v2/components.json
 - Lists each product or service (component) from the status page with a status for each.
-- Component status potential values: operational, degraded_performance, partial_outage, major_outage
+- Component status potential values: `operational`, `degraded_performance`, `partial_outage`, `major_outage`
 
 ### Unresolved Incidents
 https://status.paloaltonetworks.com/api/v2/incidents/unresolved.json
 - Lists all incidents which are unresolved, with their impact and status.
-- Incident impact potential values: none, minor, major, critical
-- Incident status potential values: investigating, identified, monitoring
+- Incident impact potential values: `none`, `minor`, `major`, `critical`
+- Incident status potential values: `investigating`, `identified`, `monitoring`
 
 ### Recent Incidents
 https://status.paloaltonetworks.com/api/v2/incidents.json
 - Lists the most recent 50 incidents, whether they are resolved or unresolved, with their impact and status.
-- Incident impact potential values: none, minor, major, critical
-- Incident status potential values: investigating, identified, monitoring, resolved, postmortem
+- Incident impact potential values: `none`, `minor`, `major`, `critical`
+- Incident status potential values: `investigating`, `identified`, `monitoring`, `resolved`, `postmortem`
 
 ### Upcoming Maintenance Events
 https://status.paloaltonetworks.com/api/v2/scheduled-maintenances/upcoming.json
-- Lists upcoming events such as planned outages, upgrades, or general notices of work on products and services which may cause disruptions.
-- Maintenance event status potential values: scheduled
-- Maintenance event impact potential values: none, maintenance, minor, major, critical
+- Lists upcoming events such as planned outages, upgrades, or general notices of work on products and services which may cause disruption.
+- Maintenance event status potential values: `scheduled`
+- Maintenance event impact potential values: `none`, `maintenance`, `minor`, `major`, `critical`
 
 ### Active Maintenance Events
 https://status.paloaltonetworks.com/api/v2/scheduled-maintenances/active.json
-- Lists upcoming events such as planned outages, upgrades, or general notices of work on products and services which may cause disruptions.
-- Maintenance event status potential values: in progress, verifying
-- Maintenance event impact potential values: none, maintenance, minor, major, critical
+- Lists upcoming events such as planned outages, upgrades, or general notices of work on products and services which may cause disruption.
+- Maintenance event status potential values: `in progress`, `verifying`
+- Maintenance event impact potential values: `none`, `maintenance`, `minor`, `major`, `critical`
 
 ### All Maintenance Events
 https://status.paloaltonetworks.com/api/v2/scheduled-maintenances.json
-- Lists the most recent 50 maintenance events such as planned outages, upgrades, or general notices of work on products and services which may cause disruptions.
-- Maintenance event status potential values: scheduled, in progress, verifying, completed
-- Maintenance event impact potential values: none, maintenance, minor, major, critical
+- Lists the most recent 50 maintenance events such as planned outages, upgrades, or general notices of work on products and services which may cause disruption.
+- Maintenance event status potential values: `scheduled`, `in progress`, `verifying`, `completed`
+- Maintenance event impact potential values: `none`, `maintenance`, `minor`, `major`, `critical`

--- a/products/cross-platform/docs/service-status-api.mdx
+++ b/products/cross-platform/docs/service-status-api.mdx
@@ -8,4 +8,53 @@ keywords:
   - crossplatform
 ---
 
-There is a Palo Alto Networks cross-platform Service Status page hosted at https://status.paloaltonetworks.com. The documentation for the companion API for this Service Status is hosted at https://status.paloaltonetworks.com/api which includes a Javascript wrapper and example code for consuming the API.
+There is a Palo Alto Networks cross-platform Service Status page hosted at https://status.paloaltonetworks.com. There is documentation for the companion API for this Service Status, hosted at https://status.paloaltonetworks.com/api, which includes a Javascript wrapper and example code for consuming the API.
+
+The API itself is delivered via Atlassian's StatusPage offering. This API provides a collections of endpoints which all return JSON formatted payloads. The API does not provide any built-in filtering; any filtering or parsing of responses should be done client-side, with the suggestion to use a JSON parsing library within the programming language of choice.
+
+
+The following endpoints are available:
+
+Summary:
+https://status.paloaltonetworks.com/api/v2/summary.json
+- Despite being called a summary, this provides details from the entire status page, including an overall status indicator for the entire portfolio, statuses of individual components, unresolved incidents, and any upcoming or in-progress scheduled maintenances.
+
+Portfolio Status:
+https://status.paloaltonetworks.com/api/v2/status.json
+- Provides just an overall status for the entire portfolio of products and services listed on the status page.
+- Status indicator potential values: none, minor, major, critical
+
+Product/Service (Component) Statuses:
+https://status.paloaltonetworks.com/api/v2/components.json
+- Lists each product or service (component) from the status page with a status for each.
+- Component status potential values: operational, degraded_performance, partial_outage, major_outage
+
+Unresolved Incidents:
+https://status.paloaltonetworks.com/api/v2/incidents/unresolved.json
+- Lists all incidents which are unresolved, with their impact and status.
+- Incident impact potential values: none, minor, major, critical
+- Incident status potential values: investigating, identified, monitoring
+
+Recent Incidents:
+https://status.paloaltonetworks.com/api/v2/incidents.json
+- Lists the most recent 50 incidents, whether they are resolved or unresolved, with their impact and status.
+- Incident impact potential values: none, minor, major, critical
+- Incident status potential values: investigating, identified, monitoring, resolved, postmortem
+
+Upcoming Maintenance Events:
+https://status.paloaltonetworks.com/api/v2/scheduled-maintenances/upcoming.json
+- Lists upcoming events such as planned outages, upgrades, or general notices of work on products and services which may cause disruptions.
+- Maintenance event status potential values: scheduled
+- Maintenance event impact potential values: none, maintenance, minor, major, critical
+
+Active Maintenance Events:
+https://status.paloaltonetworks.com/api/v2/scheduled-maintenances/active.json
+- Lists upcoming events such as planned outages, upgrades, or general notices of work on products and services which may cause disruptions.
+- Maintenance event status potential values: in progress, verifying
+- Maintenance event impact potential values: none, maintenance, minor, major, critical
+
+All Maintenance Events:
+https://status.paloaltonetworks.com/api/v2/scheduled-maintenances.json
+- Lists the most recent 50 maintenance events such as planned outages, upgrades, or general notices of work on products and services which may cause disruptions.
+- Maintenance event status potential values: scheduled, in progress, verifying, completed
+- Maintenance event impact potential values: none, maintenance, minor, major, critical

--- a/products/sase/docs/service-status-api.mdx
+++ b/products/sase/docs/service-status-api.mdx
@@ -8,4 +8,53 @@ keywords:
   - sase
 ---
 
-There is a Palo Alto Networks cross-platform Service Status page hosted at https://sase.status.paloaltonetworks.com. The documentation for the companion API for this Service Status is hosted at https://sase.status.paloaltonetworks.com/api which includes a Javascript wrapper and example code for consuming the API.
+There is a Palo Alto Networks SASE Status Page hosted at https://sase.status.paloaltonetworks.com. There is documentation for the companion API for this Status Page, hosted at https://sase.status.paloaltonetworks.com/api which includes a Javascript wrapper.
+
+The API itself is delivered via Atlassian's StatusPage offering. This API provides a collections of endpoints which all return JSON formatted payloads. The API does not provide any built-in filtering; any filtering or parsing of responses should be done client-side, with the suggestion to use a JSON parsing library within the programming language of choice.
+
+The endpoints available are described below.
+
+### Summary
+https://sase.status.paloaltonetworks.com/api/v2/summary.json
+- Despite being called a summary, this provides details from the entire status page, including an overall status indicator for the entire SASE service, statuses of individual SASE service components, unresolved incidents, and any upcoming or in-progress scheduled maintenances.
+- Potential values are discussed in the subsequent API endpoints below.
+
+### Portfolio Status
+https://sase.status.paloaltonetworks.com/api/v2/status.json
+- Provides an overall status for the entire SASE service.
+- Status indicator potential values: `none`, `minor`, `major`, `critical`
+
+### Service Component Statuses
+https://sase.status.paloaltonetworks.com/api/v2/components.json
+- Lists each SASE service component from the status page with a status for each.
+- Component status potential values: `operational`, `degraded_performance`, `partial_outage`, `major_outage`
+
+### Unresolved Incidents
+https://sase.status.paloaltonetworks.com/api/v2/incidents/unresolved.json
+- Lists all incidents which are unresolved, with their impact and status.
+- Incident impact potential values: `none`, `minor`, `major`, `critical`
+- Incident status potential values: `investigating`, `identified`, `monitoring`
+
+### Recent Incidents
+https://sase.status.paloaltonetworks.com/api/v2/incidents.json
+- Lists the most recent 50 incidents, whether they are resolved or unresolved, with their impact and status.
+- Incident impact potential values: `none`, `minor`, `major`, `critical`
+- Incident status potential values: `investigating`, `identified`, `monitoring`, `resolved`, `postmortem`
+
+### Upcoming Maintenance Events
+https://sase.status.paloaltonetworks.com/api/v2/scheduled-maintenances/upcoming.json
+- Lists upcoming events such as planned outages, upgrades, or general notices of work on SASE services which may cause disruption.
+- Maintenance event status potential values: `scheduled`
+- Maintenance event impact potential values: `none`, `maintenance`, `minor`, `major`, `critical`
+
+### Active Maintenance Events
+https://sase.status.paloaltonetworks.com/api/v2/scheduled-maintenances/active.json
+- Lists upcoming events such as planned outages, upgrades, or general notices of work on SASE services which may cause disruption.
+- Maintenance event status potential values: `in progress`, `verifying`
+- Maintenance event impact potential values: `none`, `maintenance`, `minor`, `major`, `critical`
+
+### All Maintenance Events
+https://sase.status.paloaltonetworks.com/api/v2/scheduled-maintenances.json
+- Lists the most recent 50 maintenance events such as planned outages, upgrades, or general notices of work on SASE services which may cause disruption.
+- Maintenance event status potential values: `scheduled`, `in progress`, `verifying`, `completed`
+- Maintenance event impact potential values: `none`, `maintenance`, `minor`, `major`, `critical`


### PR DESCRIPTION
## Description
Adds more details for consuming the Status Page APIs, on top of the original documentation which just pointed to URLs.

## Motivation and Context
The first PR (#746) intentionally just listed the URLs of the APIs. This second part adds narrative on the API endpoints, what they provide, and potential values of key properties in the JSON response payloads.

## How Has This Been Tested?
Locally

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.