### PR TITLE
Add rate limit description notice to AuditLogsMicroservice endpoints

### DIFF
--- a/openapi-specs/cspm/AuditLogsMicroService.json
+++ b/openapi-specs/cspm/AuditLogsMicroService.json
@@ -64,7 +64,7 @@
           "Audit Logs"
         ],
         "summary": "Get Audit Logs",
-        "description": "Retrieves paginated audit logs based on the provided filter criteria.",
+        "description": "Retrieves paginated audit logs based on the provided filter criteria.\n\n#### Rate Limits ####\n\nThe following rate limits apply:\n* Request rate limit: 10/sec \n* Burst limit: 10/sec \n",
         "operationId": "getAuditLogs",
         "requestBody": {
           "content": {
@@ -143,7 +143,7 @@
           "Audit Logs"
         ],
         "summary": "Get Filter Suggestions",
-        "description": "Get UI Filter Suggestions for Resource Types and User",
+        "description": "Get UI Filter Suggestions for Resource Types and User\n\n#### Rate Limits ####\n\nThe following rate limits apply:\n* Request rate limit: 10/sec \n* Burst limit: 10/sec \n",
         "operationId": "getResourceTypes",
         "requestBody": {
           "content": {


### PR DESCRIPTION
## Description

**RLP-151119**: Add Rate limit to descriptions on Audit Log Microservice endpoints

![image](https://github.com/user-attachments/assets/0c0d4dea-bc3b-4bdc-8976-03e140a945b8)


## How Has This Been Tested?

- _clean install and build_

- `yarn start:cloud`


## Types of changes

- Documentation
