### PR TITLE
Remove applause button from doc footer and floating island

### DIFF
--- a/src/components/FloatingIsland/index.js
+++ b/src/components/FloatingIsland/index.js
@@ -41,12 +41,9 @@ function FloatingIsland() {
     ? isInViewport(containerRef)
     : true;
 
-  const canDisplayAllButtons = !!(editUrl && !hide_applause && !hide_issue);
-  const canDisplayTwoButtons = !!(
-    (editUrl && !hide_applause) ||
-    (editUrl && !hide_issue) ||
-    (!hide_applause && !hide_issue)
-  );
+  const canDisplayAllButtons = editUrl && !hide_issue;
+  const canDisplayTwoButtons = editUrl && !hide_issue;
+  console.log(canDisplayAllButtons, canDisplayTwoButtons);
 
   return (
     <div ref={containerRef}>
@@ -61,10 +58,6 @@ function FloatingIsland() {
             : undefined
         }
       >
-        {!isVisible && !hide_applause && <ApplauseButton />}
-        {!isVisible &&
-          !hide_applause &&
-          (canDisplayAllButtons || canDisplayTwoButtons) && <Divider />}
         {!isVisible && editUrl && <EditThisPageButton />}
         {!isVisible &&
           editUrl &&

--- a/src/components/FloatingIsland/styles.css
+++ b/src/components/FloatingIsland/styles.css
@@ -1,6 +1,6 @@
 .floating-island-container {
   height: 40px;
-  width: 200px;
+  width: 150px;
   align-items: center;
   display: flex;
   border-radius: 20px;

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -9,7 +9,6 @@ import TagsListInline, {
 
 import styles from "./styles.module.css";
 import FloatingIsland from "../../../components/FloatingIsland";
-import ApplauseButton from "../../../components/Applause";
 import { ReportAnIssue } from "../../../components/Issue";
 
 function TagsRow(props: TagsListInlineProps) {
@@ -49,7 +48,6 @@ function EditMetaRow({
       <hr></hr>
       <div className={clsx(ThemeClassNames.docs.docFooterEditMetaRow, "row")}>
         <div className={clsx("col", styles.docFooterEditMetaRowItem)}>
-          {!hide_applause && <ApplauseButton />}
         </div>
         <div className={styles.docFooterEditMetaRowItemRight}>
           {editUrl && <EditThisPage editUrl={editUrl} />}


### PR DESCRIPTION
## Description

Removes applause button

## Motivation and Context

Retiring feature due to low adoption/value

## How Has This Been Tested?

see deploy preview