### PR TITLE
Update Cortex docs link in mega-nav and landing page

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -174,17 +174,10 @@ const config = {
                   label: "Cortex",
                   to: "#",
                   logoClass: "cortex",
-                  apiDocs: [
-                    {
-                      label: "Expander API",
-                      to: "https://cortex.pan.dev/api/expander/annotations-api",
-                      icon: "api-doc",
-                    },
-                  ],
                   docs: [
                     {
-                      label: "Xpanse Python SDK",
-                      to: "https://cortex-xpanse-python-sdk.readthedocs.io/en/latest/",
+                      label: "Cortex Developer Docs",
+                      to: "https://docs-cortex.paloaltonetworks.com/",
                       icon: "doc",
                     },
                   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -12511,11 +12511,6 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@^2.6.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-  
-tty-browserify@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
-  integrity sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==
 
 turndown@^7.2.0:
   version "7.2.0"


### PR DESCRIPTION
## Description

Updates links in nav/landing page to point to Cortex developer docs site (previously cortex.pan.dev).