### PR TITLE
Disable pointer events for copy icons

### DIFF
--- a/src/components/CopyButton/index.js
+++ b/src/components/CopyButton/index.js
@@ -95,7 +95,7 @@ function CopyButton({ isVisible }) {
     >
       <button
         onClick={handleCopyMarkdown}
-        className={`copy-markdown-btn ${copied ? "copied" : ""}`}
+        className={`copy-markdown-btn${copied ? " copied" : ""}`}
         type="button"
       >
         <span className="icon-container">

--- a/src/components/CopyButton/styles.css
+++ b/src/components/CopyButton/styles.css
@@ -36,6 +36,7 @@ html[data-theme="dark"] .sparkles {
   display: inline-block;
   width: 16px;
   height: 16px;
+  pointer-events: none;
 }
 
 .copy-markdown-btn i {


### PR DESCRIPTION
## Description

Disables pointer events for icon container to ensure click class is `copy-markdown-btn`. 