### PR TITLE
[WebUI] Add missing tab index to Copy for AI button

### DIFF
--- a/src/components/CopyButton/index.js
+++ b/src/components/CopyButton/index.js
@@ -90,6 +90,7 @@ function CopyButton({ isVisible }) {
 
   return (
     <Tooltip
+      tabIndex="0"
       isVisible={isVisible}
       text="Copy contents of documentation as Markdown format for AI usage"
     >

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -1,9 +1,9 @@
 import React from "react";
 import "./styles.css";
 
-const Tooltip = ({ children, text, isVisible }) => {
+const Tooltip = ({ children, text, isVisible, tabIndex }) => {
   return (
-    <div className="tooltip-container">
+    <div className="tooltip-container" tabindex={tabIndex}>
       {children}
       <span
         className={`tooltip-text ${isVisible ? "non-floating-island" : ""}`}


### PR DESCRIPTION
## Description

This PR consists of adding a missing `tabindex` attribute to the Copy for AI button.

## Motivation and Context

Allow users to tab through the Copy for AI button 

## How Has This Been Tested?

Navigating to a docs page and ensuring that the Copy for AI button can be tabbed through.

## Screenshots (if appropriate)

https://github.com/user-attachments/assets/a580d727-df83-4d4d-80d6-cfb6ac57e308

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
