### PR TITLE
Move to custom blog parser/converter

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "",
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "yarn gen-all && docusaurus start",
+    "start": "yarn getAllFeeds && yarn gen-all && docusaurus start",
     "build": "run-script-os",
     "build:windows": "set NODE_OPTIONS=--max_old_space_size=8192 && yarn gen-all && yarn docusaurus build",
     "build:default": "export NODE_OPTIONS=--max_old_space_size=8192 && yarn gen-all && yarn docusaurus build",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "",
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "yarn getAllFeeds && yarn gen-all && docusaurus start",
+    "start": "yarn gen-all && docusaurus start",
     "build": "run-script-os",
     "build:windows": "set NODE_OPTIONS=--max_old_space_size=8192 && yarn gen-all && yarn docusaurus build",
     "build:default": "export NODE_OPTIONS=--max_old_space_size=8192 && yarn gen-all && yarn docusaurus build",
@@ -21,8 +21,8 @@
     "gen-all": "docusaurus gen-api-docs all --all-versions",
     "clean-all": "docusaurus clean-api-docs all --all-versions",
     "re-gen": "yarn clean-all && yarn gen-all",
-    "getBlogs": "curl -f -s -H \"Accept: application/json\" \"https://www.toptal.com/developers/feed2json/convert?url=https%3A%2F%2Fmedium.com%2Ffeed%2Fpalo-alto-networks-developer-blog\" -o src/components/Medium/blogs.json || (echo \"[]\" > src/components/Medium/blogs.json)",
-    "getHashicorpBlogs": "curl -f -s -H \"Accept: application/json\" \"https://www.toptal.com/developers/feed2json/convert?url=https%3A%2F%2Fwww.hashicorp.com%2Fblog%2Fproducts%2Fterraform%2Ffeed.xml\" -o src/components/ProductLandingPage/Feeds/feeds.json || (echo \"[]\" > src/components/ProductLandingPage/Feeds/feeds.json)",
+    "getBlogs": "node scripts/feed2json.js https://medium.com/feed/palo-alto-networks-developer-blog > src/components/Medium/blogs.json",
+    "getHashicorpBlogs": "node scripts/feed2json.js https://www.hashicorp.com/blog/products/terraform/feed.xml > src/components/ProductLandingPage/Feeds/feeds.json",
     "getAllFeeds": "yarn --silent getBlogs && yarn --silent getHashicorpBlogs",
     "start:netsec": "cross-env PRODUCTS_INCLUDE=cdss,threat-vault,dns-security,iot,expedition,cloudngfw,cdl,panos,terraform,ansible,splunk,aiops-ngfw-bpa,email-dlp,dlp,ai-runtime-security yarn start",
     "start:splunk": "cross-env PRODUCTS_INCLUDE=panos,terraform,ansible,splunk yarn start",
@@ -92,6 +92,7 @@
     "lint-staged": "^13.0.3",
     "prettier": "2.7.1",
     "rimraf": "^3.0.2",
-    "run-script-os": "^1.1.6"
+    "run-script-os": "^1.1.6",
+    "xml2js": "^0.6.2"
   }
 }

--- a/scripts/feed2json.js
+++ b/scripts/feed2json.js
@@ -1,0 +1,122 @@
+// rssParser.js
+const fs = require("fs");
+const https = require("https");
+const http = require("http");
+const { URL } = require("url");
+const xml2js = require("xml2js");
+
+// Helper to fetch XML from URL
+function fetchXmlFromUrl(feedUrl) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(feedUrl);
+    const client = url.protocol === "https:" ? https : http;
+
+    client
+      .get(feedUrl, (res) => {
+        if (res.statusCode !== 200) {
+          return reject(
+            new Error(`Request failed with status ${res.statusCode}`)
+          );
+        }
+
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => resolve(data));
+      })
+      .on("error", reject);
+  });
+}
+
+// Function to convert XML feed (RSS 2.0 or Atom) to JSON Feed format
+async function parseRSS(source) {
+  try {
+    let xml;
+    if (source.startsWith("http://") || source.startsWith("https://")) {
+      xml = await fetchXmlFromUrl(source);
+    } else {
+      xml = fs.readFileSync(source, "utf-8");
+    }
+
+    const parser = new xml2js.Parser({
+      explicitArray: false,
+      mergeAttrs: true,
+      preserveChildrenOrder: true,
+      charsAsChildren: false,
+      xmlns: false,
+      explicitRoot: true,
+    });
+
+    const result = await parser.parseStringPromise(xml);
+
+    if (result.rss?.channel) {
+      // RSS 2.0 Format
+      const channel = result.rss.channel;
+      const items = Array.isArray(channel.item) ? channel.item : [channel.item];
+
+      return {
+        version: "https://jsonfeed.org/version/1",
+        title: channel.title,
+        home_page_url: channel.link,
+        description: channel.description,
+        author: { name: channel.webMaster },
+        items: items.filter(Boolean).map((item) => ({
+          guid: item.guid,
+          url: item.link,
+          title: item.title,
+          content_html: item["content:encoded"] || item.description || "",
+          date_published: item.pubDate
+            ? new Date(item.pubDate).toISOString()
+            : undefined,
+          author: item["dc:creator"] ? { name: item["dc:creator"] } : undefined,
+        })),
+      };
+    } else if (result.feed) {
+      // Atom Format
+      const feed = result.feed;
+      const entries = Array.isArray(feed.entry) ? feed.entry : [feed.entry];
+
+      return {
+        version: "https://jsonfeed.org/version/1",
+        title: feed.title,
+        home_page_url: Array.isArray(feed.link)
+          ? feed.link.find((l) => l.rel === "alternate")?.href ||
+            feed.link[0]?.href ||
+            feed.link[0]
+          : feed.link?.href || feed.link,
+        description: feed.subtitle,
+        favicon: feed.icon,
+        author: feed.author?.name ? { name: feed.author.name } : undefined,
+        items: entries.filter(Boolean).map((entry) => ({
+          guid: entry.id,
+          url: entry.link?.href || entry.link,
+          title: entry.title?._ || entry.title,
+          content_html: entry.content?._ || entry.content || "",
+          summary: entry.summary?._ || entry.summary || "",
+          date_published: entry.updated
+            ? new Date(entry.updated).toISOString()
+            : undefined,
+          author: entry.author?.name ? { name: entry.author.name } : undefined,
+        })),
+      };
+    } else {
+      console.error(
+        "Unexpected XML structure:",
+        JSON.stringify(result, null, 2)
+      );
+      throw new Error("Unrecognized feed format. Expected RSS or Atom.");
+    }
+  } catch (error) {
+    console.error("Error parsing feed:", error);
+    throw error;
+  }
+}
+
+// Example usage:
+(async () => {
+  const source = process.argv[2] || "example.xml"; // File path or URL passed via CLI
+  const jsonOutput = await parseRSS(source);
+  console.log(JSON.stringify(jsonOutput, null, 2));
+})();
+
+// Export function if needed for external usage
+module.exports = { parseRSS };

--- a/src/components/Medium/index.js
+++ b/src/components/Medium/index.js
@@ -3,7 +3,14 @@ import Slider from "../Slider/Slider";
 import BlogCard from "./BlogCard.js";
 import "./Slider.scss";
 
-const blog_json = require("./blogs.json");
+let blog_json;
+
+try {
+  blog_json = require("./blogs.json");
+} catch (error) {
+  blog_json = null;
+}
+
 const blogs = blog_json?.items?.slice(0, 9);
 
 function Medium() {

--- a/src/components/ProductLandingPage/Feeds/Feeds.js
+++ b/src/components/ProductLandingPage/Feeds/Feeds.js
@@ -2,9 +2,22 @@ import React from "react";
 import Link from "@docusaurus/Link";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import feedsJson from "./feeds.json";
-import mediumFeedsJson from "../../Medium/blogs.json";
 import "./Feeds.scss";
+
+let mediumFeedsJson;
+let feedsJson;
+
+try {
+  mediumFeedsJson = require("../../Medium/blogs.json");
+} catch (error) {
+  mediumFeedsJson = null;
+}
+
+try {
+  feedsJson = require("./feeds.json");
+} catch (error) {
+  feedsJson = null;
+}
 
 function Feeds() {
   const hashicorpImageFeeds = feedsJson.items.slice(0, 2);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8577,11 +8577,6 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lucide-react@^0.487.0:
-  version "0.487.0"
-  resolved "https://registry.npmjs.org/lucide-react/-/lucide-react-0.487.0.tgz#c18a463404e8ef106d46a7c9cceddf9fc8b9ff6b"
-  integrity sha512-aKqhOQ+YmFnwq8dWgGjOuLc8V1R9/c/yOd+zDY4+ohsR2Jo05lSGc3WsstYPIzcTpeosN7LoCkLReUUITvaIvw==
-
 markdown-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz#34bebc83e9938cae16e0e017e4a9814a8330d3c4"
@@ -12032,7 +12027,7 @@ sass@^1.77.8, sass@^1.80.4:
   optionalDependencies:
     "@parcel/watcher" "^2.4.1"
 
-sax@^1.2.4:
+sax@>=0.6.0, sax@^1.2.4:
   version "1.4.1"
   resolved "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
   integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
@@ -13590,6 +13585,19 @@ xml-parser-xo@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-3.2.0.tgz#c633ab55cf1976d6b03ab4a6a85045093ac32b73"
   integrity sha512-8LRU6cq+d7mVsoDaMhnkkt3CTtAs4153p49fRo+HIB3I1FD1o5CeXRjRH29sQevIfVJIcPjKSsPU/+Ujhq09Rg==
+
+xml2js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
+  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
## Description

Ditches https://www.toptal.com/developers/feed2json/ for a custom node script that handles reading, parsing and converting Medium and Terraform RSS/XML feeds to JSON format.  

With this new approach, the feeds will be fetched using the `feed2json.js` script. The script will output JSON with empty items if a self-signed certificate error is encountered during the fetch.

> Note: I also wrapped the JSON imports in try/catch as an additional fall back

## Motivation and Context

Over-reliance on services like toptal has caused issues in the past due to service outage, caching, etc.

## How Has This Been Tested?

Tested in local dev - see deploy preview to verify it works in prod.

- [x] Verify empty items JSON feed when self-signed cert encountered
- [x] Verify no console warnings/errors appear 
- [x] Verify Medium and Terraform feed components render in DEV/PROD (when successfully fetched)
