### PR TITLE
[WebUI] Update deprecated @import with @use for tailwindcss

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -11,8 +11,8 @@
  */
 /* You can override the default Infima variables here. */
 
+@use "tailwindcss";
 @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
-@import "tailwindcss";
 
 @font-face {
   font-family: "Inter";


### PR DESCRIPTION
## Description

This PR addresses the following warning by replacing the use of `@import` (currently deprecated) with `@use` for importing tailwind styles.

```
[WARNING] {"message":"  ⚠ ModuleWarning: Deprecation Warning on line 14, column 8 of file:///Users/blinda/Desktop/projects/pan.dev/src/css/custom.scss:14:8:\n  │ Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.\n  │ \n  │ More info and automated migrator: https://sass-lang.com/d/import\n  │ \n  │ 14 | @import \"tailwindcss\";\n  │ \n  │ \n  │ src/css/custom.scss 15:9  root stylesheet\n  │  (from: /Users/blinda/Desktop/projects/pan.dev/node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[10].oneOf[1].use[3])\n","moduleIdentifier":"/Users/blinda/Desktop/projects/pan.dev/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[10].oneOf[1].use[1]!/Users/blinda/Desktop/projects/pan.dev/node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[10].oneOf[1].use[2]!/Users/blinda/Desktop/projects/pan.dev/node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[10].oneOf[1].use[3]!/Users/blinda/Desktop/projects/pan.dev/src/css/custom.scss","moduleName":""}
```

## Motivation and Context

Build processes should be free of errors/warnings

## How Has This Been Tested?

Tested locally and ensured warning above is no longer present.

## Screenshots (if appropriate)

<img width="801" alt="image" src="https://github.com/user-attachments/assets/aa6d1481-bb46-4e9e-a1cb-270025252239" />


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
