### PR TITLE
RLP-156282 Fix Crashing CSPM API Pages - add type property to BaseFilterSchema 

### DIFF
--- a/openapi-specs/cspm/Alerts.json
+++ b/openapi-specs/cspm/Alerts.json
@@ -776,6 +776,9 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "type": {
+            "type":"string"
           }
         },
         "type": "object"

--- a/openapi-specs/cspm/AssetExplorer.json
+++ b/openapi-specs/cspm/AssetExplorer.json
@@ -142,6 +142,9 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "type": {
+            "type":"string"
           }
         },
         "type": "object"

--- a/openapi-specs/cspm/AssetInventory.json
+++ b/openapi-specs/cspm/AssetInventory.json
@@ -343,6 +343,9 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "type": {
+            "type":"string"
           }
         },
         "type": "object"

--- a/openapi-specs/cspm/CompliancePosture.json
+++ b/openapi-specs/cspm/CompliancePosture.json
@@ -117,6 +117,9 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "type": {
+            "type":"string"
           }
         },
         "type": "object"


### PR DESCRIPTION
## Fix Crashing CSPM API Pages

> https://jira-dc.paloaltonetworks.com/browse/RLP-156282

## Problem and Fix
![image](https://github.com/user-attachments/assets/a9ff965b-14ff-4d3f-89a1-05a0336858b6)

The Schema `BaseFilterModel` defines a discriminator with a propertyName of `type`.
This "property" is not defined with in the `properties` of the schema. To fix the issue, define the `type` property to the `BaseFilterSchema` as follows:

This is a temporary fix to stop pages from crashing that fail to  define the discriminator.


_Added to Alerts.json, AssetInventory.json, AssetExplorer.json, and CompliancePosture.json spec files within the properties of `BaseFilterSchema` schema object_

```js
          "type": {
            "type":"string"
          }
```

Commit message: "RLP-156282 add type property to BaseFilterSchema to fix crashing pages"

## Impacted Pages

- https://pan.dev/prisma-cloud/api/cspm/dismiss-alerts/
- https://pan.dev/prisma-cloud/api/cspm/reopen-alerts/
- https://pan.dev/prisma-cloud/api/cspm/post-compliance-posture-v-2/
- https://pan.dev/prisma-cloud/api/cspm/post-method-asset-inventory-trend-v-3/
- https://pan.dev/prisma-cloud/api/cspm/post-resource-scan-info-v-2/


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
