### PR TITLE
[Experimental]: Documentation Testing with Playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "sos": "yarn clean && yarn install",
     "format": "prettier --write .",
     "format:diff": "prettier --list-different .",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test:ui": "playwright test --ui",
+    "test": "playwright test"
   },
   "husky": {
     "hooks": {
@@ -87,6 +89,8 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "@types/node": "^22.15.21",
     "cross-env": "^7.0.3",
     "husky": "^8.0.2",
     "lint-staged": "^13.0.3",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,51 @@
+// @ts-check
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+export default defineConfig({
+  testDir: "./tests",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: "http://localhost:3000",
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: "npm run start",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000, // Increased timeout for Docusaurus startup
+  },
+});

--- a/scripts/collect-mdx-paths.js
+++ b/scripts/collect-mdx-paths.js
@@ -1,0 +1,107 @@
+const fs = require("fs");
+const path = require("path");
+const glob = require("glob");
+
+/**
+ * Collects all MDX files from the products directory, organized by product
+ * @returns {Object} Object with product directories as keys and arrays of MDX file paths as values
+ */
+function collectAllMdxFiles() {
+  const productsDir = path.join(__dirname, "../products");
+  const testsDir = path.join(__dirname, "../tests");
+
+  // Check if products directory exists
+  if (!fs.existsSync(productsDir)) {
+    console.error("Products directory not found:", productsDir);
+    return {};
+  }
+
+  // Ensure tests directory exists
+  if (!fs.existsSync(testsDir)) {
+    fs.mkdirSync(testsDir, { recursive: true });
+  }
+
+  // Create a subdirectory for product-specific test files
+  const productTestsDir = path.join(testsDir, "products");
+  if (!fs.existsSync(productTestsDir)) {
+    fs.mkdirSync(productTestsDir, { recursive: true });
+  }
+
+  // Find all MDX files in the products directory (with relative paths)
+  const mdxFiles = glob.sync("**/*.mdx", {
+    cwd: productsDir,
+  });
+
+  // Filter out files with .info or .tag in their filenames
+  const filteredFiles = mdxFiles.filter((file) => {
+    const filename = path.basename(file);
+    return !filename.includes(".info") && !filename.includes(".tag");
+  });
+
+  // Group files by product directory (first-level directory)
+  const productMap = {};
+
+  filteredFiles.forEach((file) => {
+    // Get the file's directory path and filename
+    const dirPath = path.dirname(file);
+    const filename = path.basename(file);
+
+    // Extract the product directory (first segment of the path)
+    const productDir = dirPath.split(path.sep)[0] || "root";
+
+    // Extract the part of the filename before the first dot
+    const cleanFilename = filename.split(".")[0];
+
+    // Combine directory path with clean filename
+    let formattedPath = path.join(dirPath, cleanFilename);
+
+    // Add leading slash to make it a proper URL path
+    formattedPath = "/" + formattedPath;
+
+    // Initialize the product array if it doesn't exist
+    if (!productMap[productDir]) {
+      productMap[productDir] = [];
+    }
+
+    // Add the formatted path to the product's array
+    productMap[productDir].push(formattedPath);
+  });
+
+  // Count total files across all products
+  const totalFiles = Object.values(productMap).reduce(
+    (sum, files) => sum + files.length,
+    0
+  );
+
+  // Write the main results file
+  const mainOutputPath = path.join(testsDir, "all-mdx-files.json");
+  fs.writeFileSync(mainOutputPath, JSON.stringify(productMap, null, 2));
+
+  // Write individual product files
+  Object.entries(productMap).forEach(([product, paths]) => {
+    const productOutputPath = path.join(
+      productTestsDir,
+      `${product}-mdx-files.json`
+    );
+    fs.writeFileSync(productOutputPath, JSON.stringify(paths, null, 2));
+  });
+
+  console.log(
+    `Found ${totalFiles} MDX files across ${
+      Object.keys(productMap).length
+    } product directories`
+  );
+  console.log(`Main results written to: ${mainOutputPath}`);
+  console.log(`Individual product files written to: ${productTestsDir}`);
+
+  return productMap;
+}
+
+// Execute if run directly
+if (require.main === module) {
+  collectAllMdxFiles();
+} else {
+  module.exports = {
+    collectAllMdxFiles,
+  };
+}

--- a/src/components/Medium/index.js
+++ b/src/components/Medium/index.js
@@ -48,7 +48,7 @@ function Medium() {
   };
 
   return (
-    <div className="container">
+    <div className="medium-container container">
       <div className="slider-container container">
         {blogs?.length && (
           <Slider {...sliderSettings}>

--- a/tests/api-docs.spec.js
+++ b/tests/api-docs.spec.js
@@ -1,0 +1,98 @@
+// @ts-nocheck
+import { test, expect } from "@playwright/test";
+import fs from "fs";
+import path from "path";
+import glob from "glob";
+
+// Get all product test files
+const productFiles = glob.sync("products/*-mdx-files.json", {
+  cwd: path.join(__dirname),
+});
+
+// Fallback to using the combined file if no individual product files are found
+const allProductsMap = fs.existsSync(path.join(__dirname, "all-mdx-files.json"))
+  ? JSON.parse(
+      fs.readFileSync(path.join(__dirname, "all-mdx-files.json"), "utf8")
+    )
+  : {};
+
+test.describe("Generated API Documentation", () => {
+  // Test each product category
+  for (const productFile of productFiles) {
+    const productName = path.basename(productFile, "-mdx-files.json");
+
+    test.describe(`${productName} API Documentation`, () => {
+      // Load the product-specific paths
+      const productPaths = JSON.parse(
+        fs.readFileSync(path.join(__dirname, productFile), "utf8")
+      );
+
+      // Take a sample of paths to test (adjust the sample size as needed)
+      const sampleSize = 5;
+      const pathsToTest =
+        productPaths.length <= sampleSize
+          ? productPaths
+          : productPaths.slice(0, sampleSize);
+
+      for (const apiPath of pathsToTest) {
+        test(`${productName}: API docs at ${apiPath} load correctly`, async ({
+          page,
+        }) => {
+          await page.goto(apiPath);
+
+          // Expect page to load without error (no 404)
+          await expect(page).not.toHaveTitle(/Not Found/);
+
+          // Check for common elements that should appear in API docs
+          const mainContent = page.locator("main");
+          await expect(mainContent).toBeVisible();
+
+          // Check if API content is rendered (may not be present on all pages)
+          const apiContent = page.locator(".openapi-left-panel__container");
+          if ((await apiContent.count()) > 0) {
+            await expect(apiContent).toBeVisible();
+          }
+        });
+      }
+
+      // Test specific API features if applicable for this product
+      test(`${productName}: API request execution UI is present`, async ({
+        page,
+      }) => {
+        // Choose the first path for this product
+        const testPath = productPaths[0];
+        await page.goto(testPath);
+
+        // Check for request execution UI elements
+        const requestBlocks = page.locator(".openapi-right-panel__container");
+        if ((await requestBlocks.count()) > 0) {
+          await expect(requestBlocks).toBeVisible();
+        }
+      });
+    });
+  }
+
+  // Fallback to test using the combined product map if no individual files found
+  if (productFiles.length === 0 && Object.keys(allProductsMap).length > 0) {
+    test.describe("API Documentation (using combined map)", () => {
+      for (const [productName, paths] of Object.entries(allProductsMap)) {
+        test(`${productName}: Sample API docs load correctly`, async ({
+          page,
+        }) => {
+          // Test just the first path for each product
+          if (paths.length > 0) {
+            const testPath = paths[0];
+            await page.goto(testPath);
+
+            // Expect page to load without error (no 404)
+            await expect(page).not.toHaveTitle(/Not Found/);
+
+            // Check for common elements that should appear in API docs
+            const mainContent = page.locator("main");
+            await expect(mainContent).toBeVisible();
+          }
+        });
+      }
+    });
+  }
+});

--- a/tests/homepage.spec.js
+++ b/tests/homepage.spec.js
@@ -1,0 +1,147 @@
+// @ts-nocheck
+import { test, expect } from "@playwright/test";
+
+test.describe("Homepage", () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the homepage before each test
+    await page.goto("/");
+  });
+
+  test("has the correct page title", async ({ page }) => {
+    await expect(page).toHaveTitle(/Develop with Palo Alto Networks/);
+  });
+
+  test("has correct meta description", async ({ page }) => {
+    const description = await page.getAttribute(
+      'meta[name="description"]',
+      "content"
+    );
+    expect(description).toContain(
+      "The hub for Palo Alto Networks developer documentation"
+    );
+  });
+
+  test("hero section is visible and contains key elements", async ({
+    page,
+  }) => {
+    // Test hero section is present
+    const heroSection = page.locator(".homepage-main > div").first();
+    await expect(heroSection).toBeVisible();
+
+    // Verify main headline exists (actual text would depend on your HeroSectionOne implementation)
+    const headline = heroSection.locator(".flipwords-container");
+    await expect(headline).toBeVisible();
+  });
+
+  test("tabs component is visible on desktop view", async ({ page }) => {
+    // Test tabs component is visible on desktop
+    // Note: Your code shows this is hidden on mobile with "hidden md:block"
+    const tabsComponent = page.locator(".container.hidden.md\\:block");
+
+    // Get viewport size
+    const viewportSize = page.viewportSize();
+
+    if (viewportSize && viewportSize.width >= 768) {
+      // md breakpoint is typically 768px
+      await expect(tabsComponent).toBeVisible();
+    } else {
+      await expect(tabsComponent).not.toBeVisible();
+    }
+  });
+
+  test("developer docs section is present with correct title", async ({
+    page,
+  }) => {
+    const devDocsSection = page.locator("#developer-docs-section");
+    await expect(devDocsSection).toBeVisible();
+
+    const sectionTitle = devDocsSection.locator("#developer-docs-header");
+
+    console.log(sectionTitle);
+    await expect(sectionTitle).toContainText(
+      "Developer Docs and API References"
+    );
+  });
+
+  test("partner tools section is present with correct title", async ({
+    page,
+  }) => {
+    const partnerToolsTitle = page.getByText("Explore our Partner Tools");
+    await expect(partnerToolsTitle).toBeVisible();
+
+    // Check if the PartnerTools component is rendering
+    const partnerToolsSection = page.locator(".container").filter({
+      has: page.getByText("Explore our Partner Tools"),
+    });
+    await expect(partnerToolsSection).toBeVisible();
+  });
+
+  test("blog section is present with correct title", async ({ page }) => {
+    const blogSectionTitle = page.getByText("Read our latest Developer Blogs");
+    await expect(blogSectionTitle).toBeVisible();
+
+    // Check if Medium component is rendering blog posts
+    const mediumSection = page.locator("section").filter({
+      has: page.getByText("Read our latest Developer Blogs"),
+    });
+
+    // Verify there are blog posts visible
+    const blogPosts = mediumSection.locator(".medium-container");
+    await expect(blogPosts).toBeVisible();
+  });
+
+  test("navigation elements are functional", async ({ page }) => {
+    // Test navbar
+    const navbar = page.locator("nav.navbar");
+    await expect(navbar).toBeVisible();
+
+    // Test logo
+    const logo = navbar.locator(".navbar__logo");
+    await expect(logo).toBeVisible();
+
+    // Test search button
+    const searchButton = page.locator(".DocSearch-Button");
+    await expect(searchButton).toBeVisible();
+
+    // Test search button click opens search dialog
+    await searchButton.click();
+    const searchModal = page.locator(".DocSearch-Modal");
+    await expect(searchModal).toBeVisible();
+
+    // Close the search modal
+    await page.keyboard.press("Escape");
+  });
+
+  test("responsive design - mobile view", async ({ page }) => {
+    // Set viewport to mobile size
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    // Tabs should be hidden on mobile
+    const tabsComponent = page.locator(".container.hidden.md\\:block");
+    await expect(tabsComponent).not.toBeVisible();
+
+    // Check if mobile menu toggle is present
+    const menuToggle = page.locator(".navbar__toggle");
+    await expect(menuToggle).toBeVisible();
+
+    // Test mobile menu functionality
+    await menuToggle.click();
+    const mobileMenu = page.locator(".navbar-sidebar");
+    await expect(mobileMenu).toBeVisible();
+  });
+
+  test("footer is present with copyright information", async ({ page }) => {
+    const footer = page.locator("footer");
+    await expect(footer).toBeVisible();
+
+    // Check for copyright text
+    const copyright = footer.getByText(/Copyright © \d{4} Palo Alto Networks/);
+    await expect(copyright).toBeVisible();
+
+    // Check for footer logo
+    const footerLogo = footer.locator(
+      'img[alt="Palo Alto Networks for developers"]'
+    );
+    await expect(footerLogo).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Description

This PR introduces a comprehensive testing framework with Playwright for our API documentation, allowing us to automatically verify that all API documentation pages load correctly across our product ecosystem.

## Motivation and Context

- Early Detection: Catch broken API documentation before it reaches production
- Complete Coverage: Test across all product categories
- Efficient Testing: Sample-based approach keeps test runs manageable
- Clear Reporting: Issues are reported by product category for easier debugging

## How Has This Been Tested?

**Note: Ensure local environment is running prior to the following steps**

### Step 1: Generate MDX Paths

First, run the collection script to scan all MDX files and generate the necessary paths:

`node scripts/collect-mdx-paths.js`

This will:

- Scan the products/ directory for all MDX files
- Create individual product test files in `tests/products/` directory

### Step 2: Run Playwright Tests

Once the test files are generated, run the Playwright tests: 

`yarn playwright test`

or 

`yarn playwright test --ui` (provides an intuitive testing experience)

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/c86a951a-865e-45a8-9256-8fd6ecce8e8b)

### Playwright UI Testing Environment
![Screenshot 2025-05-29 at 4 59 55 PM](https://github.com/user-attachments/assets/b5af4940-605a-48cc-87a2-53fccdcb1205)


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
