### PR TITLE
Revert default list-style

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -12,6 +12,15 @@
 /* You can override the default Infima variables here. */
 
 @use "tailwindcss";
+
+// revert default list-style overridden by tailwindcss
+@layer base {
+  ul,
+  ol {
+    list-style: revert;
+  }
+}
+
 @import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro&display=swap");
 
 @font-face {


### PR DESCRIPTION
## Description

The introduction of tailwindcss appears to have polluted `ul` list styles, effectively preventing uniform lists from rendering bullets, numbering, etc. This change attempts to revert to default `list-style` to allow for rendering list markers.

Will need to scrub styles to see what if anything else could be affected.

## Motivation and Context

List markers make it easier to organize and read some content.

## How Has This Been Tested?

Tested locally in dev.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->
Before: 

<img width="668" alt="Screenshot 2025-05-30 at 11 22 44 AM" src="https://github.com/user-attachments/assets/ec5579b8-8d10-45d3-8938-9ac5a373ca9f" />

After:

<img width="940" alt="Screenshot 2025-05-30 at 11 23 36 AM" src="https://github.com/user-attachments/assets/9d2f8fa2-0eeb-4d45-a5f8-64474ee7e43d" />


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)