### PR TITLE
PCSUP-28495 Document unsupported fields in Search Pagination Endpoint

### DIFF
--- a/openapi-specs/cspm/SearchMicroService.json
+++ b/openapi-specs/cspm/SearchMicroService.json
@@ -626,7 +626,7 @@
           "Search"
         ],
         "summary": "Get The Next Config Search Page",
-        "description": "Returns the next page of search results, using a token provided from the previous page. Used for when there are over 100 search results for a given RQL query.\n\nAn initial config search request _([Perform Config Search by Query](https://pan.dev/prisma-cloud/api/cspm/search-config-by-query/),[Perform Config Search V2](https://pan.dev/prisma-cloud/api/cspm/search-config-v-2/))_ will return the `nextPageToken` field when more than 100 results are returned. The value of `nextPageToken` should be used for request parameter `pageToken` to retrieve the next page of results.\n",
+        "description": "Returns the next page of search results, using a token provided from the previous page. Used for when there are over 100 search results for a given RQL query.\n\nAn initial config search request _([Perform Config Search by Query](https://pan.dev/prisma-cloud/api/cspm/search-config-by-query/),[Perform Config Search V2](https://pan.dev/prisma-cloud/api/cspm/search-config-v-2/))_ will return the `nextPageToken` field when more than 100 results are returned. The value of `nextPageToken` should be used for request parameter `pageToken` to retrieve the next page of results.\n\n:::note\nThis endpoint does not support the `resourceTypeId` field or *enhanced* `resourceType` values available in [Perform Config Search V2](https://pan.dev/prisma-cloud/api/cspm/search-config-v-2/).\n:::\n\r",
         "operationId": "search-config-page",
         "requestBody": {
           "description": "Config rule page parameters model",


### PR DESCRIPTION
## PCSUP-28495 Document Unsupported Fields for Paginated Endpoint

> https://jira-dc.paloaltonetworks.com/browse/PCSUP-28495 

> https://pan.dev/prisma-cloud/api/cspm/search-config-page/ 

"We need to update the documentation for the page API to include a note indicating that this endpoint does not support the new resource type values introduced in the v2 version of this API."

![image](https://github.com/user-attachments/assets/78affa6a-baa7-4e33-8e53-ff93d3439861)
