### PR TITLE
filter out ChunkLoadError exceptions

### DIFF
--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -20,6 +20,16 @@ export default function Root({ children }) {
       reportUncaughtExceptions: true,
       reportUnhandledPromiseRejections: true,
     });
+
+    const originalReport = errorHandler.report.bind(errorHandler);
+    errorHandler.report = (err, options) => {
+      const msg = typeof err === "string" ? err : err?.message || "";
+      const name = typeof err === "object" && err ? err.name : "";
+      if (name === "ChunkLoadError" || msg.includes("ChunkLoadError")) {
+        return Promise.resolve(null);
+      }
+      return originalReport(err, options);
+    };
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## Description

Filters out ChunkLoadError exceptions from being forwarded to StackDriver

## Motivation and Context

StackDriver error reporting is intended for finding broken pages, or pages that exit with an exception for any reason. ChunkLoadError occurs after a new site deploy, since browser cache needs to "catch up" to the new CDN chunks available, and can be safely ignored.

## How Has This Been Tested?

see deploy preview