### PR TITLE
PCSUP-29009 add description to POST /uai/v1/asset response property `trueInternetExposure`

### DIFF
--- a/openapi-specs/cspm/AssetMicroService.json
+++ b/openapi-specs/cspm/AssetMicroService.json
@@ -1434,7 +1434,9 @@
             }
           },
           "trueInternetExposure": {
-            "type": "string"
+            "type": "string",
+            "description": "Indicates the asset’s internet exposure level. Possible values are `y`,`n`,`NULL`. `y` means exposed, `n` means no internet exposure, and `NULL` indicates the module does not support or send this attribute.",
+            "example": "y"
           },
           "dataSecurity": {
             "type": "object",


### PR DESCRIPTION

## Description

> [PCSUP-29009](https://jira-dc.paloaltonetworks.com/browse/PCSUP-29009)

Add description to `trueInternetExposure` response property to enumerate possible values.

- Get Asset `POST /uai/v1/asset` [pan.dev link](https://pan.dev/prisma-cloud/api/cspm/get-asset-details-by-id/#responses)
- OperationID: get-asset-details-by-id
- Spec File (pan.dev): AssetMicroService
    - Path: pan.dev/openapi-specs/cspm/AssetMicroService.json


