### PR TITLE
Decommission hashicorp blog feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "re-gen": "yarn clean-all && yarn gen-all",
     "getBlogs": "node scripts/feed2json.js https://medium.com/feed/palo-alto-networks-developer-blog > src/components/Medium/blogs.json",
     "getHashicorpBlogs": "node scripts/feed2json.js https://www.hashicorp.com/blog/products/terraform/feed.xml > src/components/ProductLandingPage/Feeds/feeds.json",
-    "getAllFeeds": "yarn --silent getBlogs && yarn --silent getHashicorpBlogs",
+    "getAllFeeds": "yarn --silent getBlogs",
     "start:netsec": "cross-env PRODUCTS_INCLUDE=cdss,threat-vault,dns-security,iot,expedition,cloudngfw,cdl,panos,terraform,ansible,splunk,aiops-ngfw-bpa,email-dlp,dlp,prisma-airs yarn start",
     "start:splunk": "cross-env PRODUCTS_INCLUDE=panos,terraform,ansible,splunk yarn start",
     "start:iot": "cross-env PRODUCTS_INCLUDE=iot yarn start",

--- a/src/components/ProductLandingPage/Feeds/Feeds.js
+++ b/src/components/ProductLandingPage/Feeds/Feeds.js
@@ -89,16 +89,9 @@ function Feeds() {
     <div className="container">
       <section className="feeds-container">
         <header className="feeds-header">
-          <h1>Latest Terraform News from</h1>
+          <h1>Latest Terraform Blogs</h1>
         </header>
-        <Tabs>
-          {/* <TabItem value="HashiCorp" label="HashiCorp">
-            <FeedItem feeds={hashicorpFeeds} imageFeeds={hashicorpImageFeeds} />
-          </TabItem> */}
-          <TabItem value="PAN.dev" label="PAN.dev">
-            <FeedItem feeds={mediumFeeds} imageFeeds={mediumImageFeeds} />
-          </TabItem>
-        </Tabs>
+        <FeedItem feeds={mediumFeeds} imageFeeds={mediumImageFeeds} />
       </section>
     </div>
   );

--- a/src/components/ProductLandingPage/Feeds/Feeds.js
+++ b/src/components/ProductLandingPage/Feeds/Feeds.js
@@ -5,7 +5,7 @@ import TabItem from "@theme/TabItem";
 import "./Feeds.scss";
 
 let mediumFeedsJson;
-let feedsJson;
+// let feedsJson;
 
 try {
   mediumFeedsJson = require("../../Medium/blogs.json");
@@ -13,15 +13,15 @@ try {
   mediumFeedsJson = null;
 }
 
-try {
-  feedsJson = require("./feeds.json");
-} catch (error) {
-  feedsJson = null;
-}
+// try {
+//   feedsJson = require("./feeds.json");
+// } catch (error) {
+//   feedsJson = null;
+// }
 
 function Feeds() {
-  const hashicorpImageFeeds = feedsJson.items.slice(0, 2);
-  const hashicorpFeeds = feedsJson.items.slice(2, 6);
+  // const hashicorpImageFeeds = feedsJson.items.slice(0, 2);
+  // const hashicorpFeeds = feedsJson.items.slice(2, 6);
 
   const filterMediumTerraform = (item) => {
     const title = item.title;
@@ -92,9 +92,9 @@ function Feeds() {
           <h1>Latest Terraform News from</h1>
         </header>
         <Tabs>
-          <TabItem value="HashiCorp" label="HashiCorp">
+          {/* <TabItem value="HashiCorp" label="HashiCorp">
             <FeedItem feeds={hashicorpFeeds} imageFeeds={hashicorpImageFeeds} />
-          </TabItem>
+          </TabItem> */}
           <TabItem value="PAN.dev" label="PAN.dev">
             <FeedItem feeds={mediumFeeds} imageFeeds={mediumImageFeeds} />
           </TabItem>


### PR DESCRIPTION
## Description

Removing Hashicorp blog feed from /terraform page. 

## Motivation and Context

Hashicorp recently enabled Vercel's bot protection which is preventing us from fetching the feed in GitHub Actions. 

## How Has This Been Tested?

deploy preview

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
