### PR TITLE
PCSUP-24473: Compliance Posture V2 API Documentation Fix.

### DIFF
--- a/openapi-specs/cspm/CompliancePosture.json
+++ b/openapi-specs/cspm/CompliancePosture.json
@@ -119,7 +119,7 @@
             "type": "array"
           },
           "type": {
-            "type":"string"
+            "type": "string"
           }
         },
         "type": "object"
@@ -1836,6 +1836,44 @@
         "operationId": "get-compliance-posture-v2",
         "parameters": [
           {
+            "description": "Time type",
+            "in": "query",
+            "name": "timeType",
+            "required": true,
+            "schema": {
+              "enum": [
+                "relative"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of time units",
+            "in": "query",
+            "name": "timeAmount",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Time unit",
+            "in": "query",
+            "name": "timeUnit",
+            "required": true,
+            "schema": {
+              "enum": [
+                "minute",
+                "hour",
+                "day",
+                "week",
+                "month",
+                "year"
+              ],
+              "type": "string"
+            }
+          },
+          {
             "description": "Cloud account",
             "in": "query",
             "name": "cloud.account",
@@ -1919,6 +1957,7 @@
         "description": "Returns a breakdown of the passed/failed statistics and associated policies for compliance standards, requirements, and sections. Also returns a summary for all compliance standards.",
         "operationId": "post-compliance-posture-v2",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {


### PR DESCRIPTION
# PCSUP-24473: Compliance Posture V2 API Documentation Fix

- JIRA: [PCSUP-24473](https://jira-dc.paloaltonetworks.com/browse/PCSUP-24473)
- API Docs: 
  - [GET /v2/compliance/posture](https://pan.dev/prisma-cloud/api/cspm/get-compliance-posture-v-2/)
  - [POST /v2/compliance/posture](https://pan.dev/prisma-cloud/api/cspm/post-compliance-posture-v-2/)

## Issue Summary
Customer reported that the V2 compliance posture endpoints were incorrectly documented as having no required parameters, when in reality they return `400 Bad Request` errors without specific required fields.

## Root Cause
The V2 endpoints (`/v2/compliance/posture`) removed the required parameter specifications that were correctly documented in the V1 endpoints (`/compliance/posture`), making the API appear to work without them when the backend still requires them.

## Changes Made

### 1. GET `/v2/compliance/posture` 
**Added three required query parameters:**
- `timeType` (required: true) - Must be "relative"
- `timeAmount` (required: true) - Number of time units (string)
- `timeUnit` (required: true) - Time unit (minute, hour, day, week, month, year)

**Before:** All parameters were optional
**After:** Time-related parameters are now required, matching V1 behavior

**Customer Evidence:** API returns `400 Bad Request` without `?timeType=relative&timeAmount=1&timeUnit=week`

### 2. POST `/v2/compliance/posture` 
**Marked requestBody as required:**
- Added `"required": true` to the requestBody specification
- Schema remains `BaseFilterModel` (server-side validation handles the filters requirement)

**Before:** Request body was not marked as required
**After:** Request body is now required 

