### PR TITLE
RLP-157119 and PCSUP-29545: Documentation Only fix (cspm): remove features array from cloud account list endpoints

### DIFF
--- a/openapi-specs/cspm/CloudAccountOnboardingMicroServices.json
+++ b/openapi-specs/cspm/CloudAccountOnboardingMicroServices.json
@@ -18,10 +18,6 @@
       "description": "To monitor the resources on your AWS cloud infrastructure, you must first add your AWS accounts to Prisma Cloud. When you add your cloud account to Prisma Cloud, the API integration between AWS and Prisma Cloud is established and you can begin monitoring the resources and identify potential security risks.\n\nThe Cloud Account (AWS) APIs enable you to add and manage AWS accounts on Prisma Cloud. For end to end workflow to onboarding an AWS account using APIs, see [Automate AWS Cloud Account Onboarding](/prisma-cloud/docs/cspm/aws-cloud-account-onboarding/).\n For common operations related to cloud accounts, see [Cloud Accounts (All)](/prisma-cloud/api/cspm/cloud-accounts-all/).\n"
     },
     {
-      "name": "AWS Logging Accounts",
-      "description": "To ingest the VPC flow logs from Amazon S3 buckets to Prisma Cloud, you need an AWS logging account. If you need flow logs ingestion, after onboarding your AWS account, you must onboard the logging account which has the S3 bucket storing VPC flow logs for the monitored account. The APIs in this category can be used to configure and manage these logging accounts."
-    },
-    {
       "name": "Cloud Accounts (All)",
       "description": "You can use the APIs in this category to perform operations that are nonspecific to cloud account types, such as listing all the cloud accounts, listing supported features, and deleting an account.\n\nFor operations that are specific to the cloud type or cloud provider, see:\n* [Cloud Accounts (AWS)](/prisma-cloud/api/cspm/cloud-accounts-aws/)\n* [Cloud Accounts (Azure)](/prisma-cloud/api/cspm/cloud-accounts-azure/) \n* [Cloud Accounts (GCP)](/prisma-cloud/api/cspm/cloud-accounts-gcp/)\n* [Cloud Accounts (OCI and Alibaba)](/prisma-cloud/api/cspm/cloud-accounts-oci-and-alibaba/)\n"
     },
@@ -661,7 +657,7 @@
           "Cloud Accounts (All)"
         ],
         "summary": "Get all Cloud Accounts",
-        "description": "Get summary details of all the cloud accounts onboarded onto Prisma Cloud. This endpoint returns a list view without the features array. To get complete details of a specific cloud account including features, see [Get Cloud Account Details](https://pan.dev/prisma-cloud/api/cspm/get-cloud-account/).",
+        "description": "Get summary details of all the cloud accounts onboarded onto Prisma Cloud. This endpoint returns a list view without the features array. To get complete details of a specific cloud account including features, see [Get Cloud Account Details](/prisma-cloud/api/cspm/get-cloud-account).",
         "operationId": "get-cloud-accounts",
         "parameters": [
           {
@@ -1708,7 +1704,7 @@
           "Cloud Accounts (All)"
         ],
         "summary": "Get Cloud Account Details",
-        "description": "Returns details of a Cloud Account based on cloud type and cloud ID. To get details of all the cloud accounts onboarded to Prisma Cloud, see [List Cloud Accounts](https://pan.dev/prisma-cloud/api/cspm/get-cloud-accounts/).",
+        "description": "Returns details of a Cloud Account based on cloud type and cloud ID. To get details of all the cloud accounts onboarded to Prisma Cloud, see [Get all Cloud Accounts](/prisma-cloud/api/cspm/get-cloud-accounts).",
         "operationId": "get-cloud-account",
         "parameters": [
           {


### PR DESCRIPTION
## Overview

Fixes RLP-157119 and PCSUP-29545
- https://jira-dc.paloaltonetworks.com/browse/RLP-157119
- https://jira-dc.paloaltonetworks.com/browse/PCSUP-29545


The `GET /cloud` and `GET /cloud/{cloud_type}/{id}/project` endpoints documented a 'features' array in their response schemas, but the actual API implementation does not return this field for list operations.

Created a new `CloudAccountListViewModel` schema for these endpoints that match the API's actual response structure _without_ the features array.

- Added `CloudAccountListViewModel` schema
  - Duplicates `CloudAccountViewModel` properties except features array
  - Used by list endpoints that return summary views

- Updated `GET /cloud` endpoint 
  - Changed response schema to CloudAccountListViewModel
  - update description to clarify list vs detail views

- Updated `GET /cloud/{cloud_type}/{id}/project` endpoint 
  - Changed response schema to `CloudAccountListViewModel`
  - update description to clarify list vs detail views

- `openapi-specs/cspm/CloudAccountOnboardingMicroServices.json`


## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes


- Bug fix (DOCS) (non-breaking change which fixes an issue)

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
