### PR TITLE
Add SRI integrity hash to FontAwesome v6.2.0 stylesheet

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1268,6 +1268,8 @@ const config = {
       href: "https://use.fontawesome.com/releases/v6.2.0/css/all.css",
       type: "text/css",
       rel: "stylesheet",
+      integrity: "sha384-SOnAn/m2fVJCwnbEYgD4xzrPtvsXdElhOVvR8ND1YjB5nhGNwwf7nBQlhfAwHAZC",
+      crossorigin: "anonymous",
     },
   ],
   onDuplicateRoutes: "warn",


### PR DESCRIPTION
Adds integrity and crossorigin attributes to the FontAwesome CDN stylesheet to prevent tampered assets from being applied.