### PR TITLE
Harden GitHub Actions workflows and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+/.github/                @PaloAltoNetworks/pan-dev
+/package.json            @PaloAltoNetworks/pan-dev
+/yarn.lock               @PaloAltoNetworks/pan-dev
+/firebase.json           @PaloAltoNetworks/pan-dev
+/.firebaserc             @PaloAltoNetworks/pan-dev
+/docusaurus.config.ts    @PaloAltoNetworks/pan-dev
+/scripts/                @PaloAltoNetworks/pan-dev

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,9 +6,11 @@ on:
   schedule:
     - cron: "0 6 * * 1"  # weekly Monday 6am UTC
 
+permissions: {}
+
 jobs:
   analyze:
-    if: github.repository_owner	 == 'PaloAltoNetworks'
+    if: github.repository_owner == 'PaloAltoNetworks'
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
@@ -22,13 +24,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v3
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
         
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v3
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1

--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: deploy-live
   cancel-in-progress: false
@@ -19,12 +21,12 @@ jobs:
 
       steps:
         - name: Checkout repository
-          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           with:
             persist-credentials: false
 
         - name: Setup node
-          uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
+          uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
           with:
             node-version: '20'
             cache: 'yarn'
@@ -100,12 +102,12 @@ jobs:
 
       steps:
         - name: Checkout repository
-          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+          uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
           with:
             persist-credentials: false
 
         - name: Setup node
-          uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
+          uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
           with:
             node-version: '20'
             cache: 'yarn'
@@ -119,7 +121,7 @@ jobs:
 
         - name: Authenticate to Google Cloud
           id: auth
-          uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+          uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
           with:
             workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
             service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -4,6 +4,12 @@ on:
   pull_request_target:
     branches: [ master ]
 
+permissions: {}
+
+concurrency:
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   precheck:
     if: ${{ github.repository == 'PaloAltoNetworks/pan.dev' }}
@@ -61,19 +67,19 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v3
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v3
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
 
   analyze_unsafe:
     if: github.repository == 'PaloAltoNetworks/pan.dev' && needs.precheck.outputs.is-org-member-result == 'false'
@@ -92,19 +98,19 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v3
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v3
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
 
   build:
     name: Build
@@ -119,13 +125,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
           cache: 'yarn'
@@ -135,7 +141,7 @@ jobs:
         run: echo "YARN_CACHE_DIR=$(yarn cache dir)" >> "${GITHUB_OUTPUT}"
 
       - name: Install dependencies
-        run: yarn --prefer-offline --ignore-scripts
+        run: yarn --prefer-offline --frozen-lockfile --ignore-scripts
 
       - name: Include netsec
         if: contains(github.event.pull_request.labels.*.name, 'netsec')
@@ -249,12 +255,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Setup node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
           cache: 'yarn'
@@ -279,7 +285,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}


### PR DESCRIPTION
## Summary

- Add top-level `permissions: {}` to all three workflows, ensuring new jobs default to zero access
- Add `persist-credentials: false` to CodeQL checkout step
- Add `--frozen-lockfile` to preview build's `yarn install` for dependency pinning
- Add per-PR concurrency group to `deploy-preview.yml` to cancel superseded builds
- Update 17 stale action version tag comments and add missing comments on `google-github-actions/auth`
- Create `CODEOWNERS` for build-critical paths (`.github/`, package manifests, deploy config, scripts)
- Fix pre-existing tab character in CodeQL workflow condition

## Test plan

- [ ] Verify YAML syntax is valid (validated locally with `yaml.safe_load`)
- [ ] Confirm zizmor findings reduced from 43 to 17 (all remaining are contextually mitigated or informational)
- [ ] Verify deploy-live workflow runs correctly on merge to master
- [ ] Verify deploy-preview workflow triggers and deploys previews on PRs
- [ ] Verify CodeQL analysis runs on push to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)