### PR TITLE
Add cooldown period to Dependabot update schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,12 @@ updates:
         patterns:
           - "react"
           - "react-dom"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,28 @@
+name: "Cleanup Preview"
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  cleanup:
+    if: github.repository == 'PaloAltoNetworks/pan.dev'
+    name: Delete preview channel
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Delete Firebase preview channel
+        run: npx firebase-tools hosting:channel:delete "pr$PR_NUMBER" --site pan-dev-f1b58 --force
+        env:
+          PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -11,6 +11,7 @@ jobs:
     if: github.repository == 'PaloAltoNetworks/pan.dev'
     name: Delete preview channel
     runs-on: ubuntu-latest
+    environment: preview
     permissions:
       id-token: write
 
@@ -23,6 +24,10 @@ jobs:
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
       - name: Delete Firebase preview channel
-        run: npx firebase-tools hosting:channel:delete "pr$PR_NUMBER" --site pan-dev-f1b58 --force
+        run: |
+          curl -sf -X DELETE \
+            -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+            "https://firebasehosting.googleapis.com/v1beta1/sites/pan-dev-f1b58/channels/pr${PR_NUMBER}" \
+            || echo "Channel pr${PR_NUMBER} not found or already deleted"
         env:
           PR_NUMBER: ${{ github.event.number }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ src/**/feeds.json
 # playwright
 .playwright-storage.json
 .pw-user-data/
+
+# claude code
+.claude/


### PR DESCRIPTION
## Summary

- Adds a 7-day `cooldown` to both the npm and github-actions Dependabot ecosystems to reduce PR noise from rapid successive version bumps
- Adds `.claude/` to `.gitignore`
- Adds a `cleanup-preview.yml` workflow that automatically deletes Firebase Hosting preview channels when PRs are merged or closed, preventing channel quota exhaustion

## Test plan

- [ ] Verify `dependabot.yml` passes schema validation and Dependabot respects the cooldown on next scheduled run
- [ ] Verify `cleanup-preview.yml` triggers on PR close and successfully deletes the preview channel
- [ ] Confirm WIF auth + REST API call works without `firebase-tools`
- [ ] Confirm `.claude/` directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)