### PR TITLE
Mask credential file path and GCP project number in logs

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -24,6 +24,11 @@ jobs:
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
           export_environment_variables: false
 
+      - name: Mask sensitive values in logs
+        run: |
+          echo "::add-mask::${{ steps.auth.outputs.credentials_file_path }}"
+          echo "::add-mask::${{ secrets.GCP_PROJECT_NUMBER }}"
+
       - name: Delete Firebase preview channel
         run: |
           HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X DELETE \

--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -127,6 +127,11 @@ jobs:
             service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
             export_environment_variables: false
 
+        - name: Mask sensitive values in logs
+          run: |
+            echo "::add-mask::${{ steps.auth.outputs.credentials_file_path }}"
+            echo "::add-mask::${{ secrets.GCP_PROJECT_NUMBER }}"
+
         - name: Read GCP credentials
           id: creds
           run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -291,6 +291,11 @@ jobs:
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
           export_environment_variables: false
 
+      - name: Mask sensitive values in logs
+        run: |
+          echo "::add-mask::${{ steps.auth.outputs.credentials_file_path }}"
+          echo "::add-mask::${{ secrets.GCP_PROJECT_NUMBER }}"
+
       - name: Read GCP credentials
         id: creds
         run: |


### PR DESCRIPTION
## Summary
- Add `::add-mask::` for the auth action's `credentials_file_path` output so the ephemeral credential file path (`gha-creds-*.json`) is redacted in all subsequent steps
- Add `::add-mask::` for `GCP_PROJECT_NUMBER` secret so the numeric GCP project ID is redacted in Firebase API responses
- Applied consistently across `deploy-preview`, `deploy-live`, and `cleanup-preview` workflows

## Follow-up to #1197
PR #1197 removed the hardcoded Firebase project ID and suppressed GCP env var exports. This PR masks the two remaining values that were still visible in logs.

## Required secret
| Secret | Value | Purpose |
|--------|-------|---------|
| `GCP_PROJECT_NUMBER` | *(numeric GCP project ID)* | Mask in Firebase API response output |

## Test plan
- [ ] Add `GCP_PROJECT_NUMBER` secret before merging
- [ ] After merge, verify Deploy Live logs show `***` for credential file paths and project number
- [ ] Verify `gcloud auth print-access-token` still works in cleanup-preview (credential path passed via step env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)