### PR TITLE
VC-51819 + VC-51672: Update NGTS Strata spec — remove Application, users, teams, and renewal ops

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -1051,6 +1051,11 @@ const config = {
             outputDir: "products/scm/api/tenancy",
             sidebarOptions: { groupPathsBy: "tag" },
           },
+          ngts: {
+            specPath: "openapi-specs/scm/config/ngts/tlsprotect-cloud.json",
+            outputDir: "products/scm/api/config/ngts",
+            sidebarOptions: { groupPathsBy: "tag" },
+          },
           ciedss: {
             specPath: "openapi-specs/scm/config/ciedss",
             outputDir: "products/scm/api/config/ciedss",

--- a/openapi-specs/scm/config/ngts/tlsprotect-cloud.json
+++ b/openapi-specs/scm/config/ngts/tlsprotect-cloud.json
@@ -1,0 +1,20848 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "TLS Protect Cloud API for Strata Cloud Manager",
+    "description": "Use the TLS Protect Cloud APIs to manage certificates, certificate requests, applications, machine identities, users, teams, event logs, and more. This Open API spec file was created on May 11, 2026. © 2026 Palo Alto Networks, Inc. Palo Alto Networks is a registered trademark of Palo Alto Networks. A list of our trademarks can be found at https://www.paloaltonetworks.com/company/trademarks.html. All other marks mentioned herein may be trademarks of their respective companies.",
+    "version": "1.0.0",
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/license/mit"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://api.strata.paloaltonetworks.com",
+      "description": "Strata Cloud Manager API"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Certificates",
+      "description": "APIs for Certificates."
+    },
+    {
+      "name": "Certificate Installations",
+      "description": "APIs for Certificate Installations."
+    },
+    {
+      "name": "Certificate Discovery",
+      "description": "APIs for Certificate Discovery."
+    },
+    {
+      "name": "Certificate Import",
+      "description": "APIs for Certificate Import."
+    },
+    {
+      "name": "Private Key Import",
+      "description": "APIs for Private Key Import."
+    },
+    {
+      "name": "Certificate Request",
+      "description": "APIs for Certificate Request."
+    },
+    {
+      "name": "Certificate Policy",
+      "description": "APIs for Certificate Policy."
+    },
+    {
+      "name": "Credential Management",
+      "description": "APIs for Credential Management."
+    },
+    {
+      "name": "Machine Identities",
+      "description": "APIs for Machine Identities."
+    },
+    {
+      "name": "Machine Types",
+      "description": "APIs for Machine Types."
+    },
+    {
+      "name": "Machines",
+      "description": "APIs for Machines."
+    },
+    {
+      "name": "Event Logs",
+      "description": "APIs for Event Logs."
+    },
+    {
+      "name": "VSatellite",
+      "description": "APIs for VSatellite."
+    },
+    {
+      "name": "Certificate Inventory Monitoring",
+      "description": "APIs for Certificate Inventory Monitoring."
+    },
+    {
+      "name": "Certificate Auto-renewal Monitoring",
+      "description": "APIs for Certificate Auto-renewal Monitoring."
+    },
+    {
+      "name": "Certificate Expiration Reports",
+      "description": "APIs for Certificate Expiration Reports."
+    },
+    {
+      "name": "Tags",
+      "description": "APIs for Tags."
+    },
+    {
+      "name": "Workload Identity Manager Configurations",
+      "description": "APIs for Workload Identity Manager Configurations."
+    },
+    {
+      "name": "Workload Identity Manager Sub CA Providers",
+      "description": "APIs for Workload Identity Manager Sub CA Providers."
+    },
+    {
+      "name": "Workload Identity Manager Policies",
+      "description": "APIs for Workload Identity Manager Policies."
+    },
+    {
+      "name": "Workload Identity Manager Intermediate Certificates",
+      "description": "APIs for Workload Identity Manager Intermediate Certificates."
+    },
+    {
+      "name": "Certificate Approvals",
+      "description": "APIs for Certificate Approvals."
+    },
+    {
+      "name": "Certificate Revocation Approvals",
+      "description": "APIs for Certificate Revocation Approvals."
+    },
+    {
+      "name": "Plugins",
+      "description": "APIs for Plugins."
+    },
+    {
+      "name": "Service Accounts",
+      "description": "APIs for Service Accounts."
+    }
+  ],
+  "paths": {
+    "/outagedetection/v1/certificates": {
+      "get": {
+        "description": "This endpoint allows you to retrieve all your certificates according to a specified criteria. This API provides a quick way to gather certificate details in order to install the certificates where they are needed.\n\nUse the `subject` query parameter to limit the search based on the certificate subject common name.",
+        "operationId": "certificates_getAll",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "ownershipTree",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "excludeSupersededInstances",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Ability to enter regular expression to match specific criteria.",
+            "in": "query",
+            "name": "subject",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Indicates the maximum integer number of certificates returned.",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "default": 1000,
+              "maximum": 10000,
+              "minimum": 1,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateResponse"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateResponse"
+                }
+              }
+            },
+            "description": "Certificate(s) response."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          }
+        },
+        "summary": "Retrieve all certificate data",
+        "tags": [
+          "Certificates"
+        ]
+      },
+      "post": {
+        "description": "Adds to the inventory one or more certificates to the inventory.the certificates are specified in raw base64-encoded format (PEM without header/footer). Chain CA certificates are optional but may be provided using `issuerCertificates`.",
+        "operationId": "certificateimports_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateImportRequest2"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateImportResponse2"
+                }
+              }
+            },
+            "description": "Certificates were imported; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Import a set of raw certificates",
+        "tags": [
+          "Certificate Import"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificates/{id}": {
+      "get": {
+        "description": "Retrieves the details of the certificate that has the specified `id`.",
+        "operationId": "certificates_getById",
+        "parameters": [
+          {
+            "description": "Indicates whether response should include nested ownership data (e.g., `owningContainers`).",
+            "in": "query",
+            "name": "ownershipTree",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "excludeSupersededInstances",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "UUID of a Certificate.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedCertificateInformation"
+                }
+              }
+            },
+            "description": "Certificate was found; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Certificate was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get a certificate details",
+        "tags": [
+          "Certificates"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificates/{id}/contents": {
+      "get": {
+        "description": "Exports the certificate that has the specified `id` in PEM or DER format. Chain CA certificates are included for PEM format when `chainOrder` is EE_FIRST or ROOT_FIRST.",
+        "operationId": "certificates_getContentsById",
+        "parameters": [
+          {
+            "description": "Specify an 'accept' header parameter's value",
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "enum": [
+                "text/plain",
+                "application/octet-stream"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "UUID of a Certificate.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Format of certificate in response.",
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "enum": [
+                "PEM",
+                "DER"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Order of certificates in response.",
+            "in": "query",
+            "name": "chainOrder",
+            "schema": {
+              "enum": [
+                "EE_ONLY",
+                "EE_FIRST",
+                "ROOT_FIRST"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Raw certificate in response body"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Certificate not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Download a certificate",
+        "tags": [
+          "Certificates"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificates/validation": {
+      "post": {
+        "description": "Submits one or more certificates for TLS validation.",
+        "operationId": "certificates_validation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateValidationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateValidationResponse"
+                }
+              }
+            },
+            "description": "Certificates submitted for validation response."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Request validation for a set of",
+        "tags": [
+          "Certificates"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificates/retirement": {
+      "post": {
+        "description": "This endpoint retires one or more certificates by using the **certificateIds** parameter to match a specified value.",
+        "operationId": "certificateretirement_retireCertificates",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateRetirementRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateResponse"
+                }
+              }
+            },
+            "description": "Certificate retirement response."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          }
+        },
+        "summary": "Retire certificates",
+        "tags": [
+          "Certificates"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificates/recovery": {
+      "post": {
+        "description": "Recover the certificates specified by `certificateIds`, including any previous versions of those certificates.",
+        "operationId": "certificateretirement_recoverCertificates",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateRecoveryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateResponse"
+                }
+              }
+            },
+            "description": "Certificates were recovered. Total number and details are in the response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Recover a set of certificates",
+        "tags": [
+          "Certificates"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificates/deletion": {
+      "post": {
+        "description": "Permanently deletes the retired certificates specified by `certificateIds` from the inventory.",
+        "operationId": "certificateretirement_deleteCertificates",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateDeletionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Certificates were deleted."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Delete a set of retired certificates",
+        "tags": [
+          "Certificates"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificatesearch": {
+      "post": {
+        "description": "This endpoint retrieves certificate data according to specified search criteria based on commonly used field search parameters. Some examples are `signatureHashAlgorithm`, `validityEnd`, and `issuerCN`. For more information, see [common search parameters](https://docs.venafi.cloud/api/about-api-search-fields/).\n",
+        "operationId": "certificates_search_getByExpression",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "ownershipTree",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "excludeSupersededInstances",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Filter2"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateResponse"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateResponse"
+                }
+              }
+            },
+            "description": "Certificate response."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          }
+        },
+        "summary": "Retrieve certificate data matching search criteria",
+        "tags": [
+          "Certificates"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificateinstances": {
+      "get": {
+        "description": "Use this endpoint allows you to retrieve certificate instances according to specified criteria. Total certificate instances are the sum of the number of certificate installations, plus the total number of certificates that have no installations. Trusted CA certificates are not counted. For more information, see [certificate instances](https://docs.venafi.cloud/CSH_view_instances).\n\nUse query parameters to limit your search based on certificate criteria.",
+        "operationId": "certificateinstances_getAll",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source",
+            "schema": {
+              "enum": [
+                "UNKNOWN",
+                "USER_PROVIDED",
+                "USER_IMPORTED",
+                "USER_SCAN",
+                "TRUSTNET_SCAN",
+                "ON_PREM_CA_IMPORT",
+                "EXTERNAL_CA_IMPORT",
+                "FILE_IMPORT",
+                "EXTERNAL_SCAN",
+                "DOMAIN_SCAN",
+                "SMART_SCAN_INTERNAL",
+                "SMART_SCAN_EXTERNAL",
+                "SMART_VALIDATION_INTERNAL",
+                "SMART_VALIDATION_EXTERNAL",
+                "MACHINE_DISCOVERY",
+                "KUBERNETES_DISCOVERY",
+                "AWS_DISCOVERY",
+                "AZURE_DISCOVERY",
+                "GCP_DISCOVERY"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ipAddress",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "hostname",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedCertificateInstanceResponse"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedCertificateInstanceResponse"
+                }
+              }
+            },
+            "description": "Certificate response."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          }
+        },
+        "summary": "Retrieve Certificate Instances",
+        "tags": [
+          "Certificate Installations"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificateinstances/{id}": {
+      "get": {
+        "description": "Retrieves the details of the certificate installation that has the specified `id`.",
+        "operationId": "certificateinstances_getById",
+        "parameters": [
+          {
+            "description": "UUID of a certificate installation.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedCertificateInstanceInformation"
+                }
+              }
+            },
+            "description": "Certificate installation was found; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Certificate installation not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get a certificate installation details",
+        "tags": [
+          "Certificate Installations"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificateinstances/validation": {
+      "post": {
+        "description": "Submits one or more certificate installation for TLS validation.",
+        "operationId": "certificateinstances_validation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateInstanceValidationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            },
+            "description": "Certificate installations were submitted for validation."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Request validation for a set of",
+        "tags": [
+          "Certificate Installations"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificateinstancesearch": {
+      "post": {
+        "description": "Use this endpoint to retrieve certificate instance data according to specified search criteria based on commonly used field search parameters. Some examples are `signatureHashAlgorithm`, `validityEnd`, and `issuerCN`. For more information, see [common search parameters](https://docs.venafi.cloud/api/about-api-search-fields/#common-search-parameters)",
+        "operationId": "certificateinstances_search_getByExpression",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Filter2"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedCertificateInstanceResponse"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedCertificateInstanceResponse"
+                }
+              }
+            },
+            "description": "Certificate Instances Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Retrieve certificate instance data matching search",
+        "tags": [
+          "Certificate Installations"
+        ]
+      }
+    },
+    "/v1/integrationservices": {
+      "get": {
+        "description": "Retrieves the details of all services (Ex: Discovery services and Automated key pair services).",
+        "operationId": "integrationsservices_getAll",
+        "parameters": [
+          {
+            "description": "Total number of services.",
+            "in": "query",
+            "name": "totalCount",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "UUID of VSatellite instance associated to the service if any.",
+            "in": "query",
+            "name": "edgeInstanceId",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationServiceDetailsResponse"
+                }
+              }
+            },
+            "description": "Details of all services in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get a list of services",
+        "tags": [
+          "Certificate Discovery"
+        ]
+      },
+      "post": {
+        "description": "Create a new service ",
+        "operationId": "integrationsservices_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntegrationServiceCreationRequest"
+              }
+            }
+          },
+          "description": "Details of the service to be created",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationServiceInformation"
+                }
+              }
+            },
+            "description": "A service created."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Add a service",
+        "tags": [
+          "Certificate Discovery"
+        ]
+      }
+    },
+    "/v1/integrationservices/{id}": {
+      "get": {
+        "description": "Retrieves the details of the service that has the specified `id`.",
+        "operationId": "integrationsservices_getById",
+        "parameters": [
+          {
+            "description": "UUID of a service",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a service",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationServiceInformation"
+                }
+              }
+            },
+            "description": "Service was found; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Service not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get service details",
+        "tags": [
+          "Certificate Discovery"
+        ]
+      },
+      "delete": {
+        "description": "Deletes the service that has the specified `id`.",
+        "operationId": "integrationsservices_delete",
+        "parameters": [
+          {
+            "description": "UUID of a  service",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a  service",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "retireCertificates\" (boolean): Number of certificates associated to the service that were retired when the service was deleted.",
+            "in": "query",
+            "name": "retireCertificates",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Integration Service Deleted"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Service not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Remove a service",
+        "tags": [
+          "Certificate Discovery"
+        ]
+      },
+      "patch": {
+        "description": "Can be used to update specific fields. Only fields specified in the request will be updated. An empty set of edgeInstancesIds value will clear the set.",
+        "operationId": "integrationsservices_update",
+        "parameters": [
+          {
+            "description": "Integration Service ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Integration Service ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IntegrationServiceUpdateRequest"
+              }
+            }
+          },
+          "description": "Details of the service to be updated",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntegrationServiceInformation"
+                }
+              }
+            },
+            "description": "Integration Service information"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Integration Service Not Found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse9"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Update Service properties",
+        "tags": [
+          "Certificate Discovery"
+        ]
+      }
+    },
+    "/v1/certificates/imports": {
+      "post": {
+        "description": "Import a list of certificates and their associated private key pairs",
+        "operationId": "certificates_import",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateImportRequest1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateImportResponse1"
+                }
+              }
+            },
+            "description": "Certificates and private keys imported"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse4"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse4"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Import a list of certificates and",
+        "tags": [
+          "Private Key Import"
+        ]
+      }
+    },
+    "/v1/certificates/imports/{id}": {
+      "get": {
+        "description": "Retrieve import details",
+        "operationId": "certificatesImport_getByImportId",
+        "parameters": [
+          {
+            "description": "Import id associated with the result of importing a list of certificates and private keys",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateImportStatusDetailResponse"
+                }
+              }
+            },
+            "description": "Import details matching the specified import id"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse4"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse4"
+                }
+              }
+            },
+            "description": "Import details not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse4"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Retrieve import details",
+        "tags": [
+          "Private Key Import"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificaterequests": {
+      "get": {
+        "description": "Retrieves the details of all certificate requests.",
+        "operationId": "certificaterequests_getAll",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRequestResponse"
+                }
+              }
+            },
+            "description": "The response body contains the details of the certificate requests"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the details of all certificate",
+        "tags": [
+          "Certificate Request"
+        ]
+      },
+      "post": {
+        "description": "Creates a certificate request for the specified `applicationId` and using the specified `certificateIssuingTemplateId`.  Indicate a renewal by specifying `existingCertificateId`. Set `isVaaSGenerated` to true, specify `csrAttributes` to request a certificate using *Automated Secure Keypair*. The `validityPeriod` value must be in the ISO8601 format for time duration. Examples of ISO8601 format time duration include _P1Y_ for one year, _P10D_ for ten days, and _PT12H_ for twelve hours.",
+        "operationId": "certificaterequests_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateRequestRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRequestResponse"
+                }
+              }
+            },
+            "description": "A certificate request has been created, and its details can be found in the response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "The request is either incomplete or malformed."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "The request is either incomplete or malformed."
+          }
+        },
+        "summary": "Create a certificate request",
+        "tags": [
+          "Certificate Request"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificaterequests/{id}": {
+      "get": {
+        "description": "Retrieves the details of the certificate request with the specified `id`.",
+        "operationId": "certificaterequests_getById",
+        "parameters": [
+          {
+            "description": "UUID of a Certificate Request",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Certificate Request",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRequestInformation2"
+                }
+              }
+            },
+            "description": "A certificate request has been found, and its details are in the response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "The request is either incomplete or malformed."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "The certificate request was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "The request is either incomplete or malformed."
+          }
+        },
+        "summary": "Get a certificate request details",
+        "tags": [
+          "Certificate Request"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificaterequests/{id}/resubmission": {
+      "post": {
+        "description": "Resubmits the certificate request that has the specified `id`.",
+        "operationId": "certificaterequests_resubmitById",
+        "parameters": [
+          {
+            "description": "UUID of a Certificate Request",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Certificate Request",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateRequestResubmissionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRequestResponse"
+                }
+              }
+            },
+            "description": "Certificate Request was resubmitted; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Certificate Request not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Resubmit a certificate request",
+        "tags": [
+          "Certificate Request"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificaterequests/validation": {
+      "post": {
+        "description": "This operation validates a proposed certificate request without actually submitting it.Checks for compliance with the specified issuing template and verifies all other references are valid (e.g., `existingCertificateId` is the UUID of an inventory certificate).",
+        "operationId": "certificaterequests_validation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateRequestRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificationRequestInformation"
+                }
+              }
+            },
+            "description": "Certificate Request was validated."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Validate a certificate request",
+        "tags": [
+          "Certificate Request"
+        ]
+      }
+    },
+    "/outagedetection/v1/certificaterequestssearch": {
+      "post": {
+        "description": "Retrieves the details of certificate requests that match the specified [search expression](https://docs.venafi.cloud/CSH_api_search).",
+        "operationId": "getCertificateRequestsByExpression",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Filter2"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRequestDocumentResponse"
+                }
+              }
+            },
+            "description": "The response body contains the details of the certificate requests."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "The request is either incomplete or malformed."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "The request is either incomplete or malformed."
+          }
+        },
+        "summary": "Get the details of certificate requests",
+        "tags": [
+          "Certificate Request"
+        ]
+      }
+    },
+    "/v1/certificateissuingtemplates": {
+      "get": {
+        "description": "Retrieves the details of issuing templates ordered by `priority` and `certificateAuthority`.",
+        "operationId": "certificateissuingtemplate_getAll",
+        "parameters": [
+          {
+            "description": "UUID of a Certificate Authority Account.",
+            "in": "query",
+            "name": "certificateAuthorityAccountId",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateIssuingTemplateResponse"
+                }
+              }
+            },
+            "description": "Details of Issuing Templates in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the details of issuing templates",
+        "tags": [
+          "Certificate Policy"
+        ]
+      },
+      "post": {
+        "description": "Creates an issuing template.",
+        "operationId": "certificateissuingtemplate_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateIssuingTemplateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateIssuingTemplateResponse"
+                }
+              }
+            },
+            "description": "Issuing Template was created; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Issuing Template not found."
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Issuing Template already exists."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Add an issuing template",
+        "tags": [
+          "Certificate Policy"
+        ]
+      }
+    },
+    "/v1/certificateissuingtemplates/{id}": {
+      "get": {
+        "description": "Retrieve the details of the issuing template that has the specified `id`.",
+        "operationId": "certificateissuingtemplate_getById",
+        "parameters": [
+          {
+            "description": "UUID of an Issuing Template.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of an Issuing Template.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateIssuingTemplateInformation"
+                }
+              }
+            },
+            "description": "Issuing Template was found; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Issuing Template not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get an issuing template details",
+        "tags": [
+          "Certificate Policy"
+        ]
+      },
+      "put": {
+        "description": "Updates all the details of the issuing template that has the specified `id`.",
+        "operationId": "certificateissuingtemplate_update",
+        "parameters": [
+          {
+            "description": "UUID of an Issuing Template.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of an Issuing Template.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateIssuingTemplateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateIssuingTemplateInformation"
+                }
+              }
+            },
+            "description": "Issuing Template was updated; details in response body."
+          },
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateIssuingTemplateInformation"
+                }
+              }
+            },
+            "description": "Issuing Template exists."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Issuing Template not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Overwrite an issuing template details",
+        "tags": [
+          "Certificate Policy"
+        ]
+      },
+      "delete": {
+        "description": "Deletes the issuing template that has the specified `id`.",
+        "operationId": "certificateissuingtemplate_delete",
+        "parameters": [
+          {
+            "description": "UUID of an Issuing Template.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of an Issuing Template.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Issuing Template was deleted"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Issuing Template not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Remove an issuing template",
+        "tags": [
+          "Certificate Policy"
+        ]
+      }
+    },
+    "/v1/certificateissuingtemplates/domainssynchronization": {
+      "post": {
+        "description": "Loads domain list from CA and updates the issuing templates with it",
+        "operationId": "domainssynchronization",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IssuingTemplatesDomainsSyncRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IssuingTemplateDomainsSyncResponse"
+                }
+              }
+            },
+            "description": "List with the information about the status of the sync of every issuing template"
+          }
+        },
+        "summary": "Synchronize issuing templates domains with CA",
+        "tags": [
+          "Certificate Policy"
+        ]
+      }
+    },
+    "/v1/credentialmanagerconfigurations": {
+      "get": {
+        "description": "Retrieves a set of stored Credential Manager Service configurations.",
+        "operationId": "get-public-cms-conf",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/CMSTypesParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200GetCMSConfigurations"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Retrieves a set of Credential Manager",
+        "tags": [
+          "Credential Management"
+        ]
+      },
+      "post": {
+        "description": "Adds a set of new Credential Manager Service configurations. Only one Credential Manager Service configuration per `cmsType` per company can exist.",
+        "operationId": "post-public-cms-conf",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CreateCMSConfigurationsBodyRequest"
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/201CreateCMSConfigurations"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Add a set of Credential Manager",
+        "tags": [
+          "Credential Management"
+        ]
+      },
+      "put": {
+        "description": "Updates the information of an existing Credential Manager Service configuration.",
+        "operationId": "put-public-cms-conf",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UpdateCMSConfigurationsBodyRequest"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200UpdateCMSConfiguration"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Update a Credential Manager Service configuration",
+        "tags": [
+          "Credential Management"
+        ]
+      }
+    },
+    "/v1/credentialmanagerconfigurations/{id}": {
+      "get": {
+        "description": "Retrieves a Credential Manager Service configuration by the specified `id`.",
+        "operationId": "get-public-cms-conf-id",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200GetCMSConfiguration"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Retrieves a Credential Manager Service configurati",
+        "tags": [
+          "Credential Management"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/CMSConfigIdParam"
+          }
+        ]
+      },
+      "delete": {
+        "description": "Deletes a Credential Manager Service configuration by the specified `id`.",
+        "operationId": "delete-public-cms-conf-id",
+        "responses": {
+          "204": {
+            "description": "The returned HTTP code if the Credential Manager Service configuration was deleted successfully."
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Delete a Credential Manager Service configuration",
+        "tags": [
+          "Credential Management"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/CMSConfigIdParam"
+          }
+        ]
+      }
+    },
+    "/v1/credentialmanagerconfigurations/test": {
+      "post": {
+        "description": "Tests the connection to a configured privileged access management through selected VSatellites.",
+        "operationId": "post-public-cms-conf-test",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/TestCMSConfigurationBodyRequest"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200TestCMSConfiguration"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Test the connection to a privileged",
+        "tags": [
+          "Credential Management"
+        ]
+      }
+    },
+    "/v1/credentialmanagerconfigurations/{id}/test": {
+      "post": {
+        "description": "Tests the connection to a configured privileged access management through selected VSatellites using a specified `id`.",
+        "operationId": "post-public-cms-conf-test-id",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200TestCMSConfiguration"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Test the connection to an external",
+        "tags": [
+          "Credential Management"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/CMSConfigIdParam"
+          }
+        ]
+      }
+    },
+    "/v1/credentials": {
+      "get": {
+        "description": "Retrieves a list of shared credentials for a company.",
+        "operationId": "get-public-cms-credential",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/CMSCredentialDetailsParam"
+          },
+          {
+            "$ref": "#/components/parameters/CMSTypesParam"
+          },
+          {
+            "$ref": "#/components/parameters/CredentialIdsParam"
+          },
+          {
+            "$ref": "#/components/parameters/TeamIdsParam"
+          },
+          {
+            "$ref": "#/components/parameters/AuthTypesParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200GetCredentials"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Retrieves credentials for a company",
+        "tags": [
+          "Credential Management"
+        ]
+      },
+      "post": {
+        "description": "Adds a set of new shared credentials. The `name` for each credential must be unique.",
+        "operationId": "post-public-cms-credential",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/AddCredentialsBodyRequest"
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/201AddCredentials"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Add a set of new shared",
+        "tags": [
+          "Credential Management"
+        ]
+      },
+      "put": {
+        "description": "Updates the information of an existing shared credential.",
+        "operationId": "put-public-cms-credential",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UpdateCredentialBodyRequest"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200UpdateCredential"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Update a shared credential",
+        "tags": [
+          "Credential Management"
+        ]
+      },
+      "delete": {
+        "description": "Deletes existing shared credentials specified in the query parameter list of `ids`.",
+        "operationId": "delete-public-cms-credential",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/CredentialIdsParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200DeleteCredentials"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Delete shared credentials",
+        "tags": [
+          "Credential Management"
+        ]
+      }
+    },
+    "/v1/credentials/{id}": {
+      "get": {
+        "description": "Retrieves the credential matching with provided `id`.",
+        "operationId": "get-public-cms-credential-id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Credential ID.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/CMSCredentialDetailsParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200GetCredential"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Retrieves shared credential by ID",
+        "tags": [
+          "Credential Management"
+        ]
+      },
+      "delete": {
+        "description": "Deletes the shared credential by the specified `id`.",
+        "operationId": "delete-public-cms-credential-id",
+        "responses": {
+          "204": {
+            "description": "The returned http code if the credential was deleted successfully."
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Delete shared credential by ID",
+        "tags": [
+          "Credential Management"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/CredentialIdParam"
+          }
+        ]
+      }
+    },
+    "/v1/credentials/test": {
+      "post": {
+        "description": "Tests the access to a shared credential using a specified `id` or by providing credential values. If both an `id` and parameters are provided, parameters override existing credential values.",
+        "operationId": "post-public-cms-credential-test-id",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/TestCredentialBodyRequest"
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/200TestCredential"
+          },
+          "400": {
+            "$ref": "#/components/responses/400BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/401Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/403Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/404NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/500InternalServerErrorContent"
+          }
+        },
+        "summary": "Test the access to shared credential",
+        "tags": [
+          "Credential Management"
+        ]
+      }
+    },
+    "/v1/machineidentities": {
+      "get": {
+        "description": "Retrieves the details of all machine identities..",
+        "operationId": "machineidentities_getAll",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineIdentityResponse"
+                }
+              }
+            },
+            "description": "All Machine Identities for the company."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the details of all machine",
+        "tags": [
+          "Machine Identities"
+        ]
+      },
+      "post": {
+        "description": "Creates a machine identity for a machine.",
+        "operationId": "machineidentities_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MachineIdentityCreationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineIdentityInformation"
+                }
+              }
+            },
+            "description": "Machine Identity was created; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Add a machine identity to a",
+        "tags": [
+          "Machine Identities"
+        ]
+      }
+    },
+    "/v1/machineidentities/{id}": {
+      "get": {
+        "description": "Retrieves the machine identity that has the specified `id`.",
+        "operationId": "machineidentities_getById",
+        "parameters": [
+          {
+            "description": "UUID of a Machine Identity.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Machine Identity.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineIdentityInformation"
+                }
+              }
+            },
+            "description": "Machine Identity matching specified id"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Machine Identity not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Get a machine identity details",
+        "tags": [
+          "Machine Identities"
+        ]
+      },
+      "delete": {
+        "description": "Deletes the machine identity that has the specified `id`.",
+        "operationId": "machineidentities_delete",
+        "parameters": [
+          {
+            "description": "UUID of a Machine Identity.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Machine Identity.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Machine Identity was deleted."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Machine Identity not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Remove a machine identity",
+        "tags": [
+          "Machine Identities"
+        ]
+      },
+      "patch": {
+        "description": "CUpdates specific details of the machine identity that has the specified `id`.",
+        "operationId": "machineidentities_update",
+        "parameters": [
+          {
+            "description": "UUID of a Machine Identity.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Machine Identity.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MachineIdentityUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineIdentityInformation"
+                }
+              }
+            },
+            "description": "Machine Identity was updated; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Machine Identity not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Update a machine identity details",
+        "tags": [
+          "Machine Identities"
+        ]
+      }
+    },
+    "/v1/machineidentities/{id}/workflows": {
+      "post": {
+        "description": "Used to initiate a workflow like 'testConnection' for the machine that has the specified `id`.",
+        "operationId": "machineidentities_initiateWorkflow",
+        "parameters": [
+          {
+            "description": "UUID of a Machine Identity.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Machine Identity.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MachineIdentityWorkflowRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineIdentityWorkflowInformation"
+                }
+              }
+            },
+            "description": "Workflow was initiated; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Machine identity not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Initiate a machine workflow",
+        "tags": [
+          "Machine Identities"
+        ]
+      }
+    },
+    "/v1/machineidentitysearch": {
+      "post": {
+        "description": "Retrieves the details of machine identities that match the specified [search expression](https://docs.venafi.cloud/CSH_api_search).",
+        "operationId": "getMachineIdentitiesByExpression",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MachineIdentitySearchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineIdentityDocumentResponse"
+                }
+              }
+            },
+            "description": "Details of Machine Identities in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the details of machine identities",
+        "tags": [
+          "Machine Identities"
+        ]
+      }
+    },
+    "/v1/machinetypes": {
+      "get": {
+        "deprecated": true,
+        "description": "Deprecated. This functionality is no longer supported. Use the Plugins API set instead.",
+        "operationId": "machineTypes_getAll",
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": "default response"
+          }
+        },
+        "summary": "List Machine Types",
+        "tags": [
+          "Machine Types"
+        ]
+      }
+    },
+    "/v1/machines": {
+      "get": {
+        "description": "Retrieves the details of all machines.",
+        "operationId": "machines_getAll",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachinesResponse"
+                }
+              }
+            },
+            "description": "Details of Machines in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the details of all machines",
+        "tags": [
+          "Machines"
+        ]
+      },
+      "post": {
+        "description": "Creates a machine corresponding to the specified `pluginId`.",
+        "operationId": "machines_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MachineCreationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineInformation"
+                }
+              }
+            },
+            "description": "Machine was created; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Add a machine",
+        "tags": [
+          "Machines"
+        ]
+      }
+    },
+    "/v1/machines/{id}": {
+      "get": {
+        "description": "Retrieves the details of the machine that matches the specified  `id`.",
+        "operationId": "machines_getById",
+        "parameters": [
+          {
+            "description": "UUID of a Machine",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Machine",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineInformation"
+                }
+              }
+            },
+            "description": "Machine was found; details in the response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Machine not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get a machine details",
+        "tags": [
+          "Machines"
+        ]
+      },
+      "delete": {
+        "description": "Deletes a machine that has the specified `id`.",
+        "operationId": "machines_delete",
+        "parameters": [
+          {
+            "description": "UUID of a Machine.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Machine.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Machine deleted."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Certificate installation not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          }
+        },
+        "summary": "Delete a machine",
+        "tags": [
+          "Machines"
+        ]
+      },
+      "patch": {
+        "description": "Updates specific details of the machine that matches the specified `id`.",
+        "operationId": "machines_update",
+        "parameters": [
+          {
+            "description": "UUID of a Machine.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Machine.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MachineUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineInformation"
+                }
+              }
+            },
+            "description": "Machine was updated; details in the response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Machine not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Update a machine details",
+        "tags": [
+          "Machines"
+        ]
+      }
+    },
+    "/v1/machines/{id}/workflows": {
+      "post": {
+        "description": "Triggers the beginning of the workflow.",
+        "operationId": "machines_initiateWorkflow",
+        "parameters": [
+          {
+            "description": "UUID of a Machine.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Machine.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MachineWorkflowRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineInformation"
+                }
+              }
+            },
+            "description": "Workflow initiated successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          }
+        },
+        "summary": "Initiate the workflow",
+        "tags": [
+          "Machines"
+        ]
+      }
+    },
+    "/v1/machinesearch": {
+      "post": {
+        "description": "Retrieves the details of machines that match the specified [search expression](https://docs.venafi.cloud/CSH_api_search).",
+        "operationId": "getMachinesByExpression",
+        "parameters": [
+          {
+            "description": "Indicates whether response should include nested ownership data (e.g., `owningContainers`)",
+            "in": "query",
+            "name": "ownershipTree",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MachinesSearchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineDocumentResponse"
+                }
+              }
+            },
+            "description": "Details of Machines in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the details of machines matching",
+        "tags": [
+          "Machines"
+        ]
+      }
+    },
+    "/v1/machines/{id}/batchprovisionings/abort": {
+      "post": {
+        "description": "Triggers the abort operation on the current batch provisioning process for the machine with the specified `id`.",
+        "operationId": "abort-v1-batchprovisionings-forMachineId",
+        "parameters": [
+          {
+            "description": "UUID of a Machine.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Machine.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Batch provisioning abort success."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Operation forbidden."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Active batch provisioning not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Abort batch provisioning not allowed."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Internal server error."
+          }
+        },
+        "summary": "Abort active batch provisioning for a",
+        "tags": [
+          "Machines"
+        ]
+      }
+    },
+    "/v1/machines/{id}/discovery": {
+      "get": {
+        "description": "Retrieves the details of the machine's discovery.",
+        "operationId": "machineDiscoveryResults_getByMachineId",
+        "parameters": [
+          {
+            "description": "UUID of a Machine.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Machine.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineDiscoveryResultInformation"
+                }
+              }
+            },
+            "description": "Discovery result for machine was found; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "The discovery result for the machine was not found. It is possible that discovery was never initiated. Run discovery and try again."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the discovery results for a",
+        "tags": [
+          "Machines"
+        ]
+      }
+    },
+    "/v1/machines/{id}/discovery/abort": {
+      "post": {
+        "description": "Aborts an active discovery.",
+        "operationId": "machineDiscoveryResults_abortdiscovery",
+        "parameters": [
+          {
+            "description": "UUID of a Machine.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of a Machine.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineInformation"
+                }
+              }
+            },
+            "description": "Abort discovery success."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Operation forbidden."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Active discovery not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse6"
+                }
+              }
+            },
+            "description": "Abort discovery not allowed."
+          }
+        },
+        "summary": "Abort machine discovery",
+        "tags": [
+          "Machines"
+        ]
+      }
+    },
+    "/v1/activitylogsearch": {
+      "post": {
+        "description": "Request specific event log data that matches your filter criteria and include a total count of entries in the response.",
+        "operationId": "activitylogs_getByExpression",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActivityLogFilter"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityLogEntriesResponse"
+                }
+              }
+            },
+            "description": "Total count and list of matching log entries."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse1"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse1"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Retrieve count and activity log entries",
+        "tags": [
+          "Event Logs"
+        ]
+      }
+    },
+    "/v1/activitylogsearch/export": {
+      "post": {
+        "description": "Request specific event log data that matches your filter criteria. You can even specify the format in the header as either JSON or CSV.",
+        "operationId": "activitylogs_getAllByExpression",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActivityLogFilter"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ExportedActivityLogEntryInformation"
+                  },
+                  "type": "array"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "List of matching log entries."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse1"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse1"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse1"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse1"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Export filtered event log data to",
+        "tags": [
+          "Event Logs"
+        ]
+      }
+    },
+    "/v1/activitytypes": {
+      "get": {
+        "description": "Retrieve types of activities used for event logging, such as failed login attempts or events that are critical. Learn more about [event logging](https://docs.venafi.cloud/vaas/logging/c-about-activity-logging/).",
+        "operationId": "activitylogtypes_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityLogType"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Types of activities in event logging; details in response body"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse1"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse1"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Retrieve types of activities used for",
+        "tags": [
+          "Event Logs"
+        ]
+      }
+    },
+    "/v1/edgeinstances/{id}/update": {
+      "post": {
+        "description": "Triggering an update for a satellite instance (manual)",
+        "operationId": "create-edgeinstances-update",
+        "parameters": [
+          {
+            "description": "Satellite Instance ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Satellite Instance ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Satellite Start Manual Update"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Satellite Instance Not Found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Trigger manual update of Satellite Instance",
+        "tags": [
+          "VSatellite"
+        ]
+      }
+    },
+    "/v1/edgeencryptionkeys": {
+      "get": {
+        "description": "Retrieve the list of satellite encryption keys based on query parameters",
+        "operationId": "edgeencryptionkeys_getAll",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "edgeInstanceId",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EncryptionKeysResponse"
+                }
+              }
+            },
+            "description": "List of SatelliteEncryption keys"
+          }
+        },
+        "summary": "Retrieve Satellite Encryption Keys",
+        "tags": [
+          "VSatellite"
+        ]
+      }
+    },
+    "/v1/edgeencryptionkeys/{id}": {
+      "get": {
+        "description": "Retrieve satellite encryption key with 'id' attribute matching specified value; specified value should be string not numeric",
+        "operationId": "edgeencryptionkeys_getById",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EncryptionKeyInformation"
+                }
+              }
+            },
+            "description": "Encryption key information"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Encryption key not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Retrieve SatelliteEncryption Key By Id",
+        "tags": [
+          "VSatellite"
+        ]
+      }
+    },
+    "/v1/edgeinstances": {
+      "get": {
+        "description": "Retrieve list of all satellite instances for company",
+        "operationId": "edgeinstances_getAll",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "environmentId",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeInstanceResponse"
+                }
+              }
+            },
+            "description": "Satelliteinstances matching specified id"
+          }
+        },
+        "summary": "Retrieve Satellite Instances",
+        "tags": [
+          "VSatellite"
+        ]
+      }
+    },
+    "/v1/edgeinstances/{id}": {
+      "get": {
+        "description": "Retrieve satellite instance with 'id' attribute matching specified value; specified value should be uuid not numeric",
+        "operationId": "edgeinstances_getById",
+        "parameters": [
+          {
+            "description": "Satellite Instance ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Satellite Instance ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "statusDetails",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeInstanceInformation"
+                }
+              }
+            },
+            "description": "Satellite instance matching specified id"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Satellite instance not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Retrieve Satellite Instance By Id",
+        "tags": [
+          "VSatellite"
+        ]
+      },
+      "put": {
+        "description": "Update satellite instance with specified new value",
+        "operationId": "edgeinstances_update",
+        "parameters": [
+          {
+            "description": "Satellite Instance ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Satellite Instance ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EdgeInstanceRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeInstanceInformation"
+                }
+              }
+            },
+            "description": "Satellite Instance Updated"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Satellite Instance Not Found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Update Satellite Instance",
+        "tags": [
+          "VSatellite"
+        ]
+      }
+    },
+    "/v1/pairingcodes/satellite": {
+      "post": {
+        "description": "Generate new pairing code for satellite instance registration",
+        "operationId": "pairingcodes_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PairingCodeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairingCodeInformation"
+                }
+              }
+            },
+            "description": "Pairing Code Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Create Pairing Code for Satellite Instance",
+        "tags": [
+          "VSatellite"
+        ]
+      }
+    },
+    "/v1/recoverycodes/satellite": {
+      "post": {
+        "description": "Generate new recovery code for satellite instance restoration",
+        "operationId": "recoverycodes_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecoveryCodeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecoveryCodeInformation"
+                }
+              }
+            },
+            "description": "Recovery Code Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Create Recovery Code for Satellite Instance",
+        "tags": [
+          "VSatellite"
+        ]
+      }
+    },
+    "/v1/edgeworkers": {
+      "get": {
+        "description": "Retrieve list of all satellite workers for company",
+        "operationId": "edgeworkers_getAll",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "edgeInstanceId",
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeWorkersResponse"
+                }
+              }
+            },
+            "description": "List of Satellite workers"
+          }
+        },
+        "summary": "Retrieve Satellite Workers",
+        "tags": [
+          "VSatellite"
+        ]
+      },
+      "post": {
+        "description": "Create satellite worker and generate the pairing information",
+        "operationId": "edgeworkers_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EdgeWorkerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeWorkerInformation"
+                }
+              }
+            },
+            "description": "Satellite worker information"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request conditions failed"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request conditions failed"
+          }
+        },
+        "summary": "Create Satellite Worker",
+        "tags": [
+          "VSatellite"
+        ]
+      }
+    },
+    "/v1/edgeworkers/{id}/pair": {
+      "post": {
+        "operationId": "edgeworkers_pair",
+        "parameters": [
+          {
+            "description": "EdgeWorker ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "EdgeWorker ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EdgeWorkerRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeWorkerInformation"
+                }
+              }
+            },
+            "description": "Satellite worker paired with Satellitehub"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request conditions failed"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request conditions failed"
+          }
+        },
+        "summary": "Pair Satellite Worker with Satellite Instance",
+        "tags": [
+          "VSatellite"
+        ]
+      }
+    },
+    "/v1/edgeworkers/{id}": {
+      "delete": {
+        "description": "Delete satellite worker",
+        "operationId": "edgeworker_delete",
+        "parameters": [
+          {
+            "description": "EdgeWorker ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "EdgeWorker ID",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EdgeWorkerDeleteResponse"
+                }
+              }
+            },
+            "description": "Satellite worker deleted"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Satellite worker not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse7"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Delete Satellite Worker",
+        "tags": [
+          "VSatellite"
+        ]
+      }
+    },
+    "/v1/updatesconfig": {
+      "get": {
+        "description": "Retrieve updates configuration for tenant",
+        "operationId": "updatesconfig_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdatesConfigResponse"
+                }
+              }
+            },
+            "description": "Tenant updates configuration"
+          }
+        },
+        "summary": "Retrieve Updates configuration",
+        "tags": [
+          "VSatellite"
+        ]
+      },
+      "patch": {
+        "description": "Create or update updates configuration. The default update window is set to daily, with a start time at 12:00 AM and duration of 24 hours. This schedule allows updates to be performed on demand as soon as they become available.\n    **Example Default Request Body:**\n\n    ```json\n    {\n        \"updateConfigSchedulerPattern\": {\n            \"recurrenceType\": \"DAY\",\n            \"startTime\": \"00:00:00\",\n            \"duration\": \"PT24H\"\n        }\n    }\n    ```\n",
+        "operationId": "updatesconfig_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatesConfigRequest"
+              }
+            }
+          },
+          "description": "Modify updates configuration using patch behavior. All top level properties are optional",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdatesConfigResponse"
+                }
+              }
+            },
+            "description": "Updates configuration created/updated"
+          }
+        },
+        "summary": "Create or Update Configuration",
+        "tags": [
+          "VSatellite"
+        ]
+      }
+    },
+    "/outagedetection/v1/inventorymonitoringconfig/{type}": {
+      "get": {
+        "description": "Retrieves the details of the inventory monitoring configuration by configuration type",
+        "operationId": "inventorymonitoringconfiguration_getByType",
+        "parameters": [
+          {
+            "description": "Configuration type",
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "description": "Configuration type",
+              "enum": [
+                "CERTIFICATE_EXPIRATION"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryMonitoringConfigurationResponse"
+                }
+              }
+            },
+            "description": "Details of inventory monitoring configuration in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Inventory monitoring configuration not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the details of the current",
+        "tags": [
+          "Certificate Inventory Monitoring"
+        ]
+      },
+      "put": {
+        "description": "Updates existing inventory monitoring configuration",
+        "operationId": "inventorymonitoringconfiguration_update",
+        "parameters": [
+          {
+            "description": "Configuration type",
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "description": "Type of the configuration",
+              "enum": [
+                "CERTIFICATE_EXPIRATION"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InventoryMonitoringConfigRequest"
+              }
+            }
+          },
+          "description": "Updates properties of the inventory monitoring configuration.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryMonitoringConfigurationResponse"
+                }
+              }
+            },
+            "description": "Inventory monitoring configuration was updated."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Updates existing inventory monitoring configuratio",
+        "tags": [
+          "Certificate Inventory Monitoring"
+        ]
+      }
+    },
+    "/outagedetection/v1/inventorymonitoringconfig/{type}/scheduler": {
+      "put": {
+        "description": "Update inventory monitoring scheduler by type",
+        "operationId": "inventorymonitoringconfigurationscheduler_update",
+        "parameters": [
+          {
+            "description": "Configuration type",
+            "in": "path",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "description": "Configuration type",
+              "enum": [
+                "CERTIFICATE_EXPIRATION"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Start the scheduler now",
+            "in": "query",
+            "name": "runNow",
+            "schema": {
+              "default": true,
+              "description": "Start the scheduler now",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryMonitoringSchedulerInformation"
+                }
+              }
+            },
+            "description": "Inventory monitoring scheduler was updated."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse2"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Update inventory monitoring scheduler by type",
+        "tags": [
+          "Certificate Inventory Monitoring"
+        ]
+      }
+    },
+    "/v1/expirationnotifications/tenantconfiguration": {
+      "get": {
+        "description": "Retrieve the certificate expiration notification configuration for the current tenant",
+        "operationId": "get-v1-tenant-expiration-notification-configuration",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantExpirationNotificationConfiguration"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Retrieve the certificate expiration notification c",
+        "tags": [
+          "Certificate Inventory Monitoring"
+        ]
+      },
+      "put": {
+        "description": "Update the certificate expiration notification configuration for the current tenant",
+        "operationId": "put-v1-tenant-expiration-notification-configuration",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantExpirationNotificationConfiguration"
+              }
+            }
+          },
+          "description": "The options to apply",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantExpirationNotificationConfiguration"
+                }
+              }
+            },
+            "description": "Success. The tenant configuration was successfully updated."
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Update the certificate expiration notification con",
+        "tags": [
+          "Certificate Inventory Monitoring"
+        ]
+      }
+    },
+    "/v1/autorenewal/tenantconfiguration": {
+      "get": {
+        "description": "Retrieve the certificate expiration monitoring configuration for the current tenant",
+        "operationId": "get-v1-tenant-renewal-configuration",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "12a05220-4352-11ee-ac28-c1379e5decf9",
+                  "renewalWindow": {
+                    "days": 30
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TenantRenewalConfiguration"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Retrieve the monitoring configuration",
+        "tags": [
+          "Certificate Auto-renewal Monitoring"
+        ]
+      },
+      "put": {
+        "description": "Update the certificate expiration monitoring configuration for the current tenant",
+        "operationId": "put-v1-tenant-renewal-configuration",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantRenewalConfiguration"
+              }
+            }
+          },
+          "description": "The options to apply",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantRenewalConfiguration"
+                }
+              }
+            },
+            "description": "Success. The tenant configuration was successfully updated."
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Update the monitoring configuration",
+        "tags": [
+          "Certificate Auto-renewal Monitoring"
+        ]
+      }
+    },
+    "/v1/autorenewal/trigger": {
+      "post": {
+        "description": "The certificate renewal check is normally scheduled to run daily. This operation attempts to start the process for the current tenant now.",
+        "operationId": "post-v1-run-autorenewal",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            },
+            "description": "Success. The auto-renewal check process was triggered."
+          }
+        },
+        "summary": "Attempt to initiate the certificate renewal",
+        "tags": [
+          "Certificate Auto-renewal Monitoring"
+        ]
+      }
+    },
+    "/v1/autorenewal/status": {
+      "get": {
+        "description": "Get details about the status of the certificate auto-renewal monitoring process.",
+        "operationId": "get-v1-status",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Get the current certificate auto-renewal monitorin",
+        "tags": [
+          "Certificate Auto-renewal Monitoring"
+        ]
+      }
+    },
+    "/v1/expirationreports/tenantconfiguration": {
+      "get": {
+        "description": "Retrieve the certificate expiration reports configuration for the current tenant",
+        "operationId": "get-v1-tenant-expiration-reports-configuration",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantExpirationReportsConfiguration"
+                }
+              }
+            },
+            "description": "Success"
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Retrieve the certificate expiration reports config",
+        "tags": [
+          "Certificate Expiration Reports"
+        ]
+      },
+      "put": {
+        "description": "Update the certificate expiration reports configuration for the current tenant",
+        "operationId": "put-v1-tenant-expiration-reports-configuration",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TenantExpirationReportsConfiguration"
+              }
+            }
+          },
+          "description": "The options to apply",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantExpirationReportsConfiguration"
+                }
+              }
+            },
+            "description": "Success. The tenant configuration was successfully updated."
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Update the certificate expiration reports configur",
+        "tags": [
+          "Certificate Expiration Reports"
+        ]
+      }
+    },
+    "/v1/expirationreports/trigger": {
+      "post": {
+        "description": "The certificate reports job is normally scheduled per the tenant configuration. This operation attempts to start the process for the current tenant now.",
+        "operationId": "post-v1-run-reports",
+        "responses": {
+          "204": {
+            "description": "Success. The reports check process was triggered."
+          }
+        },
+        "summary": "Attempt to initiate the certificate reports",
+        "tags": [
+          "Certificate Expiration Reports"
+        ]
+      }
+    },
+    "/v1/tags": {
+      "get": {
+        "description": "Retrieve details of all available tags",
+        "operationId": "tags_getAll",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResponse"
+                }
+              }
+            },
+            "description": "Details of tags in response body"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Retrieve all tags",
+        "tags": [
+          "Tags"
+        ]
+      },
+      "post": {
+        "description": "Create tag with optional values",
+        "operationId": "tags_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagRequest"
+              }
+            }
+          },
+          "description": "Properties of the new tag.",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagInformation"
+                }
+              }
+            },
+            "description": "Tag is created. Details in response body"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Create a tag",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/v1/tags/{name}": {
+      "get": {
+        "description": "Retrieve a tag with 'name' attribute matching a specified value",
+        "operationId": "tags_getByName",
+        "parameters": [
+          {
+            "description": "Name of the tag.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "Name of the tag.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagInformation"
+                }
+              }
+            },
+            "description": "Details of tag in response body"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Tag not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Retrieve tag by name",
+        "tags": [
+          "Tags"
+        ]
+      },
+      "delete": {
+        "description": "Delete a tag with 'name' attribute matching a specified value",
+        "operationId": "tags_deleteByName",
+        "parameters": [
+          {
+            "description": "Name of the tag.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "Name of the tag.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Tag is deleted"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Tag not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Delete tag by name",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/v1/tags/{name}/values": {
+      "get": {
+        "description": "Retrieve tag values for a tag with 'name' attribute matching specified value",
+        "operationId": "tags_get_values",
+        "parameters": [
+          {
+            "description": "Name of the tag.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "Name of the tag.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagValuesResponse"
+                }
+              }
+            },
+            "description": "Tag values in response body"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Tag not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Retrieve values for a tag",
+        "tags": [
+          "Tags"
+        ]
+      },
+      "post": {
+        "description": "Create tag values for a tag with 'name' attribute matching specified value",
+        "operationId": "tag_values_create",
+        "parameters": [
+          {
+            "description": "Name of the tag.",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "Name of the tag.",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagValuesRequest"
+              }
+            }
+          },
+          "description": "The values of the tag.",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagValuesResponse"
+                }
+              }
+            },
+            "description": "Tag values created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Create tag values",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/v1/tags/{name}/values/{value}": {
+      "delete": {
+        "description": "Delete a value associated with a tag",
+        "operationId": "tags_deleteValueByName",
+        "parameters": [
+          {
+            "description": "Name of the tag",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "Name of the tag",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Name of the value to delete",
+            "in": "path",
+            "name": "value",
+            "required": true,
+            "schema": {
+              "description": "Name of the value to delete",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Tag value deleted"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Tag not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Delete a tag value",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/v1/tags/values": {
+      "get": {
+        "description": "Retrieve tag values for all tags",
+        "operationId": "tags_getAllValues",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagValuesResponse"
+                }
+              }
+            },
+            "description": "Tag values in response body"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Retrieve values for all tags",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/v1/tags/creation": {
+      "post": {
+        "description": "Create tags in bulk with optional values",
+        "operationId": "tags_bulk_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagsBulkRequest"
+              }
+            }
+          },
+          "description": "Properties of the new tags.",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagsAndValuesResponse"
+                }
+              }
+            },
+            "description": "Tags are created. Details in response body"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Create tags in bulk",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/v1/tags/deletion": {
+      "post": {
+        "description": "Delete tags in bulk by specified keys and values",
+        "operationId": "tags_bulk_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagsBulkRequest"
+              }
+            }
+          },
+          "description": "Properties of the tags to delete.",
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Tags are deleted"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Tags not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Delete tags in bulk",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/v1/tagsassignment": {
+      "patch": {
+        "description": "Replace, add, or delete one or more tags or tag values to/from one or more entities",
+        "operationId": "tags_assignToEntities",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagsAssignRequest"
+              }
+            }
+          },
+          "description": "Properties of the assignments.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagsAssignResponse"
+                }
+              }
+            },
+            "description": "Tag assign response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Replace Add Or Delete Tags",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/v1/tagsassignment/aggregates": {
+      "post": {
+        "description": "Bulk operation to retrieve number of entities per tag",
+        "operationId": "tags_assignmentAggregates",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagsAssignmentAggregatesRequest"
+              }
+            }
+          },
+          "description": "Entity Type and list of tags and/or tag:value pairs.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagsAssignmentAggregatesResponse"
+                }
+              }
+            },
+            "description": "Entity type and total count per tag in response body"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Bulk operation to retrieve number of",
+        "tags": [
+          "Tags"
+        ]
+      }
+    },
+    "/v1/distributedissuers/configurations": {
+      "post": {
+        "description": "Adds a new Issuer Configuration, which links the following together - Sub CA Provider, Policies used to determine which certificates can be issued, and the IdP (Identity Provider) the Issuer should trust when receiving signed JWTs from its clients.",
+        "operationId": "configurations_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfigurationCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedConfigurationInformation"
+                }
+              }
+            },
+            "description": "Issuer configuration successfully created; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Create a new Issuer configuration",
+        "tags": [
+          "Workload Identity Manager Configurations"
+        ]
+      },
+      "get": {
+        "description": "Retrieves a list of all Issuer Configurations. Configurations link together Sub CA Providers, Workload Issuance Policies and Identity Provider information. Together these allow an instance of an Issuer to obtain a Sub CA certificate and use it to issue certificates.",
+        "operationId": "configurations_getAll",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigurationResponse"
+                }
+              }
+            },
+            "description": "All Issuer configurations."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the details of all Issuer",
+        "tags": [
+          "Workload Identity Manager Configurations"
+        ]
+      }
+    },
+    "/v1/distributedissuers/configurations/{id}": {
+      "get": {
+        "description": "Retrieves the details of the existing Issuer configuration for the specified `id`.",
+        "operationId": "configurations_getById",
+        "parameters": [
+          {
+            "description": "Issuer configuration UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedConfigurationInformation"
+                }
+              }
+            },
+            "description": "Specified Issuer configuration found; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Specified Issuer configuration was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get configurations details for a specific",
+        "tags": [
+          "Workload Identity Manager Configurations"
+        ]
+      },
+      "patch": {
+        "description": "Updates (replaces) fields on an Issuer configuration that has the specified `id`. Only fields specified in the request will be updated. Fields not specified in the request are not modified.",
+        "operationId": "configurations_update",
+        "parameters": [
+          {
+            "description": "Issuer configuration UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfigurationUpdateRequest"
+              }
+            }
+          },
+          "description": "Issuer configuration's details to update.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedConfigurationInformation"
+                }
+              }
+            },
+            "description": "Specified Issuer configuration updated; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Specified Issuer configuration was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Update an Issuer configuration details",
+        "tags": [
+          "Workload Identity Manager Configurations"
+        ]
+      },
+      "delete": {
+        "description": "Deletes the Issuer configuration for the specified `id`. Before deleting a configuration, be sure no Issuer instances use that configuration, or they will no longer function.",
+        "operationId": "configurations_delete",
+        "parameters": [
+          {
+            "description": "Issuer configuration UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConfigurationDeleteResponse"
+                }
+              }
+            },
+            "description": "Specified Issuer configuration was deleted."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Issuer configuration was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Remove an Issuer configuration",
+        "tags": [
+          "Workload Identity Manager Configurations"
+        ]
+      }
+    },
+    "/v1/distributedissuers/subcaproviders": {
+      "post": {
+        "description": "Creates a sub ca provider",
+        "operationId": "subcaproviders_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubCaProviderCreateRequest"
+              }
+            }
+          },
+          "description": "Details of the new sub CA provider.",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubCaProviderInformation"
+                }
+              }
+            },
+            "description": "Sub CA Provider was created; details in response body;"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Create a new Sub CA provider",
+        "tags": [
+          "Workload Identity Manager Sub CA Providers"
+        ]
+      },
+      "get": {
+        "description": "Returns a list of all the subordinate CA providers along with their details.",
+        "operationId": "subcaprovider_getAll",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubCaProviderResponse"
+                }
+              }
+            },
+            "description": "All Sub CA providers with details."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the details of all Sub",
+        "tags": [
+          "Workload Identity Manager Sub CA Providers"
+        ]
+      }
+    },
+    "/v1/distributedissuers/subcaproviders/{id}": {
+      "get": {
+        "description": "Retrieves the details of the subordinate CA provider that has the specified `id`.",
+        "operationId": "subcaproviders_getById",
+        "parameters": [
+          {
+            "description": "Sub CA provider UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubCaProviderInformation"
+                }
+              }
+            },
+            "description": "Specified sub CA provider found; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Specified sub CA provider was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get a Sub CA provider details",
+        "tags": [
+          "Workload Identity Manager Sub CA Providers"
+        ]
+      },
+      "patch": {
+        "description": "Updates (replaces) details of the subordinate CA provider that has the specified `id`. Only fields specified in the request will be updated.",
+        "operationId": "subcaproviders_update",
+        "parameters": [
+          {
+            "description": "Sub CA provider UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubCaProviderUpdateRequest"
+              }
+            }
+          },
+          "description": "Sub CA provider's details to update.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubCaProviderInformation"
+                }
+              }
+            },
+            "description": "Sub CA provider updated; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Specified Sub CA provider was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Update a Sub CA provider details",
+        "tags": [
+          "Workload Identity Manager Sub CA Providers"
+        ]
+      },
+      "delete": {
+        "description": "Deletes the subordinate CA provider that has the specified `id`.",
+        "operationId": "subcaproviders_delete",
+        "parameters": [
+          {
+            "description": "Sub CA provider UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubCaProviderDeleteResponse"
+                }
+              }
+            },
+            "description": "Specified Sub CA provider was deleted."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Specified sub CA provider was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Remove a Sub CA provider",
+        "tags": [
+          "Workload Identity Manager Sub CA Providers"
+        ]
+      }
+    },
+    "/v1/distributedissuers/policies": {
+      "post": {
+        "description": "Add a new a Workload Issuance Policy for an Issuer to use to ensure compliance with company restrictions for creating certificates.",
+        "operationId": "policies_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PolicyCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedPolicyInformation"
+                }
+              }
+            },
+            "description": "Workload Issuance policy was created; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Create a new Workload Issuance policy",
+        "tags": [
+          "Workload Identity Manager Policies"
+        ]
+      },
+      "get": {
+        "description": "Retrieves all policy details for all Workload Issuance policies. Policies are sets of rules that constrain how certificates can be issued, as well as set default values for some fields.",
+        "operationId": "policies_getAll",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyResponse"
+                }
+              }
+            },
+            "description": "All Workload Issuance policies; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the details of all Workload",
+        "tags": [
+          "Workload Identity Manager Policies"
+        ]
+      }
+    },
+    "/v1/distributedissuers/policies/{id}": {
+      "get": {
+        "description": "Retrieves the details of the Workload Issuance policy with the specified `id`.",
+        "operationId": "policies_getById",
+        "parameters": [
+          {
+            "description": "Workload Issuance policy UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedPolicyInformation"
+                }
+              }
+            },
+            "description": "Specified Workload Issuance policy found; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Specified Workload Issuance policy was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get a Workload Issuance policy details",
+        "tags": [
+          "Workload Identity Manager Policies"
+        ]
+      },
+      "patch": {
+        "description": "Updates (replaces) details of the Workload Issuance policy that has the specified `id`. Only fields specified in the request will be updated. Fields not included in the request will be ignored.",
+        "operationId": "policies_update",
+        "parameters": [
+          {
+            "description": "Workload Issuance policy UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PolicyUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtendedPolicyInformation"
+                }
+              }
+            },
+            "description": "Workload Issuance policy updated."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Workload Issuance policy was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Update a Workload Issuance policy details",
+        "tags": [
+          "Workload Identity Manager Policies"
+        ]
+      },
+      "delete": {
+        "description": "Deletes the Workload Issuance policy that has the specified `id`.",
+        "operationId": "policies_delete",
+        "parameters": [
+          {
+            "description": "Workload Issuance policy UUID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyDeleteResponse"
+                }
+              }
+            },
+            "description": "Specified Workload Issuance policy was deleted"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Specified Workload Issuance policy was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Remove a Workload Issuance policy",
+        "tags": [
+          "Workload Identity Manager Policies"
+        ]
+      }
+    },
+    "/v1/distributedissuers/intermediatecertificates": {
+      "get": {
+        "description": "Retrieves the details of all Issuer intermediate certificates. These are the CA certificates issued to the Issuer instances that allow them to issue short-lived certificates.",
+        "operationId": "intermediatecertificates_getAll",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IntermediateCertificateResponse"
+                }
+              }
+            },
+            "description": "All Issuer intermediate certificates and details."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get the details of all Issuer",
+        "tags": [
+          "Workload Identity Manager Intermediate Certificates"
+        ]
+      }
+    },
+    "/v1/certificaterequests/{id}/approval/{decision}": {
+      "post": {
+        "description": "Approve or reject certificate request that is waiting for user action",
+        "operationId": "certificaterequests_approve",
+        "parameters": [
+          {
+            "description": "UUID of a Certificate Request",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "User's decision - either approve or reject",
+            "in": "path",
+            "name": "decision",
+            "required": true,
+            "schema": {
+              "enum": [
+                "APPROVE",
+                "REJECT"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalDecisionRequest"
+              }
+            }
+          },
+          "description": "In case of rejection contains the reason for that"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRequestInformation1"
+                }
+              }
+            },
+            "description": "Certificate Request approved/rejected"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Certificate Request not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Approve or reject pending certificate request",
+        "tags": [
+          "Certificate Approvals"
+        ]
+      }
+    },
+    "/v1/certificaterequests/approval/bulk/{decision}": {
+      "post": {
+        "description": "Initiate approval or rejection of multiple certificate requests that are waiting for user action",
+        "operationId": "certificaterequests_bulk_approve",
+        "parameters": [
+          {
+            "description": "User's decision - either approve or reject",
+            "in": "path",
+            "name": "decision",
+            "required": true,
+            "schema": {
+              "enum": [
+                "APPROVE",
+                "REJECT"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkApprovalRequest"
+              }
+            }
+          },
+          "description": "In case of rejection contains the reason for that."
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkApprovalResponse"
+                }
+              }
+            },
+            "description": "Bulk Approval of Certificate Request is accepted and processing"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Approve or reject multiple pending approval",
+        "tags": [
+          "Certificate Approvals"
+        ]
+      }
+    },
+    "/v1/certificaterequests/approvalrules": {
+      "post": {
+        "description": "Create certificate request workflow approval rule",
+        "operationId": "certificaterequests_approval_rule_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateRequestApprovalRulesRequest"
+              }
+            }
+          },
+          "description": "Properties of the new approval rule.",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRequestApprovalRuleOpenApi"
+                }
+              }
+            },
+            "description": "Approval rule is created. Details in response body"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Create an approval rule for certificate",
+        "tags": [
+          "Certificate Approvals"
+        ]
+      },
+      "get": {
+        "description": "Retrieve all certificate request workflow approval rules for the current company.",
+        "operationId": "certificaterequests_approval_rules_getAll",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRequestApprovalRulesResponseOpenApi"
+                }
+              }
+            },
+            "description": "All approval rules for the current company; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get all approval rules",
+        "tags": [
+          "Certificate Approvals"
+        ]
+      }
+    },
+    "/v1/certificaterequests/approvalrules/{id}": {
+      "get": {
+        "description": "Retrieve certificate request workflow approval rule with 'id' attribute matching specified value; specified value should be uuid not numeric",
+        "operationId": "certificaterequests_approval_rule_getById",
+        "parameters": [
+          {
+            "description": "UUID of an approval rule.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of an approval rule.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRequestApprovalRuleOpenApi"
+                }
+              }
+            },
+            "description": "Approval rule matching specified id"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Approval rule not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Retrieve approval rule by id",
+        "tags": [
+          "Certificate Approvals"
+        ]
+      },
+      "put": {
+        "description": "Can be used to update specific fields of the approval rule that has the specified `id`",
+        "operationId": "certificaterequests_approval_rule_update",
+        "parameters": [
+          {
+            "description": "UUID of an approval rule.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of an approval rule.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateRequestApprovalRulesUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRequestApprovalRuleOpenApi"
+                }
+              }
+            },
+            "description": "Approval rule updated"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Approval rule Not Found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Update certificate request workflow approval rule",
+        "tags": [
+          "Certificate Approvals"
+        ]
+      },
+      "delete": {
+        "description": "Delete certificate request workflow approval rule with 'id' attribute matching specified value; specified value should be uuid not numeric",
+        "operationId": "certificaterequests_approval_rule_delete",
+        "parameters": [
+          {
+            "description": "UUID of an approval rule.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRequestApprovalRuleDeleteResponseOpenApi"
+                }
+              }
+            },
+            "description": "Specified approval rule was deleted"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Specified approval rule was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Delete certificate request workflow approval rule",
+        "tags": [
+          "Certificate Approvals"
+        ]
+      }
+    },
+    "/v1/certificaterequests/approvalrequests/{entityId}": {
+      "get": {
+        "description": "Retrieve approval request by specified certificate request id",
+        "operationId": "certificaterequests_approvalrequest",
+        "parameters": [
+          {
+            "description": "Entity UUID of the approval request",
+            "in": "path",
+            "name": "entityId",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalRequestInformation"
+                }
+              }
+            },
+            "description": "Approval Request information"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Approval Request not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request"
+          }
+        },
+        "summary": "Retrieve approval request for specific certificate",
+        "tags": [
+          "Certificate Approvals"
+        ]
+      }
+    },
+    "/v1/certificates/revocations/approvalrules": {
+      "post": {
+        "description": "Create certificate revocation workflow approval rule",
+        "operationId": "certificaterevocations_approval_rule_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateRevocationApprovalRulesRequest"
+              }
+            }
+          },
+          "description": "Properties of the new approval rule.",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRevocationApprovalRuleOpenApi"
+                }
+              }
+            },
+            "description": "Approval rule is created. Details in response body"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Create an approval rule for certificate",
+        "tags": [
+          "Certificate Revocation Approvals"
+        ]
+      },
+      "get": {
+        "description": "Retrieve all certificate revocation workflow approval rules for the current company.",
+        "operationId": "certificaterevocations_approval_rules_getAll",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRevocationApprovalRulesResponseOpenApi"
+                }
+              }
+            },
+            "description": "All approval rules for the current company; details in response body."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Get all certificate revocation approval rules",
+        "tags": [
+          "Certificate Revocation Approvals"
+        ]
+      }
+    },
+    "/v1/certificates/revocations/approvalrules/{id}": {
+      "get": {
+        "description": "Retrieve certificate revocation workflow approval rule with 'id' attribute matching specified value; specified value should be uuid not numeric",
+        "operationId": "certificaterevocations_approval_rule_getById",
+        "parameters": [
+          {
+            "description": "UUID of an approval rule.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of an approval rule.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRevocationApprovalRuleOpenApi"
+                }
+              }
+            },
+            "description": "Approval rule matching specified id"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Approval rule not found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Retrieve certificate revocation approval rule by",
+        "tags": [
+          "Certificate Revocation Approvals"
+        ]
+      },
+      "put": {
+        "description": "Can be used to update specific fields of the approval rule that has the specified `id`",
+        "operationId": "certificaterevocations_approval_rule_update",
+        "parameters": [
+          {
+            "description": "UUID of an approval rule.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "UUID of an approval rule.",
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CertificateRevocationApprovalRulesUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRevocationApprovalRuleOpenApi"
+                }
+              }
+            },
+            "description": "Approval rule updated"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Approval rule Not Found"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Request Conditions Failed"
+          }
+        },
+        "summary": "Update certificate revocation workflow approval ru",
+        "tags": [
+          "Certificate Revocation Approvals"
+        ]
+      },
+      "delete": {
+        "description": "Delete certificate revocation workflow approval rule with 'id' attribute matching specified value; specified value should be uuid not numeric",
+        "operationId": "certificaterevocations_approval_rule_delete",
+        "parameters": [
+          {
+            "description": "UUID of an approval rule.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CertificateRevocationApprovalRuleDeleteResponseOpenApi"
+                }
+              }
+            },
+            "description": "Specified approval rule was deleted"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Specified approval rule was not found."
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse5"
+                }
+              }
+            },
+            "description": "Incomplete or malformed request."
+          }
+        },
+        "summary": "Delete certificate revocation workflow approval ru",
+        "tags": [
+          "Certificate Revocation Approvals"
+        ]
+      }
+    },
+    "/v1/plugins": {
+      "get": {
+        "description": "Retrieve all the plugins for the tenant.",
+        "operationId": "get-v1-plugins",
+        "parameters": [
+          {
+            "description": "Filter by provided plugin type.",
+            "in": "query",
+            "name": "pluginTypes",
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/PluginType"
+              },
+              "minItems": 1,
+              "type": "array",
+              "uniqueItems": true
+            }
+          },
+          {
+            "description": "Include disabled plugins if set to true.",
+            "in": "query",
+            "name": "includeDisabled",
+            "schema": {
+              "default": false,
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "plugins": {
+                      "items": {
+                        "$ref": "#/components/schemas/Plugin"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "plugins"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Success. All plugins retrieved."
+          }
+        },
+        "summary": "Retrieve all plugins",
+        "tags": [
+          "Plugins"
+        ]
+      },
+      "post": {
+        "description": "Create a custom plugin for your tenant's exclusive use. The user must be a SYSTEM_ADMIN or a PKI_ADMIN.",
+        "operationId": "post-v1-plugins",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublicPluginCreationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginResponse"
+                }
+              }
+            },
+            "description": "Success. Plugin created."
+          }
+        },
+        "summary": "Create a local plugin",
+        "tags": [
+          "Plugins"
+        ]
+      }
+    },
+    "/v1/plugins/{id}": {
+      "get": {
+        "description": "Retrieve a plugin with the specified ID.",
+        "operationId": "get-v1-plugins-id",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Plugin"
+                }
+              }
+            },
+            "description": "Success. Plugin retrieved."
+          }
+        },
+        "summary": "Retrieve plugin by ID",
+        "tags": [
+          "Plugins"
+        ],
+        "parameters": [
+          {
+            "description": "Plugin ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "patch": {
+        "description": "Update a plugin with specified ID. Plugin must be owned by the tenant and the user must be a SYSTEM_ADMIN or a PKI_ADMIN.",
+        "operationId": "patch-v1-plugins-id",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublicPluginUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success. Plugin updated."
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "summary": "Update a local plugin",
+        "tags": [
+          "Plugins"
+        ],
+        "parameters": [
+          {
+            "description": "Plugin ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "delete": {
+        "description": "Delete a plugin with the specified ID. Plugin must be owned by the tenant and the user must be a SYSTEM_ADMIN or a PKI_ADMIN.",
+        "operationId": "delete-v1-plugins-id",
+        "responses": {
+          "204": {
+            "description": "No Content."
+          }
+        },
+        "summary": "Delete a local plugin",
+        "tags": [
+          "Plugins"
+        ],
+        "parameters": [
+          {
+            "description": "Plugin ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/v1/plugins/{id}/disablements": {
+      "post": {
+        "description": "Set a plugin to be disabled for your tenant.",
+        "operationId": "post-v1-plugins-id-exclusions",
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginResponse"
+                }
+              }
+            },
+            "description": "Successfully disabled the plugin for the current tenant."
+          }
+        },
+        "summary": "Disable a plugin",
+        "tags": [
+          "Plugins"
+        ],
+        "parameters": [
+          {
+            "description": "Plugin ID that is currently marked as disabled.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "delete": {
+        "description": "Remove a plugin exclusion from your tenant.",
+        "operationId": "delete-v1-plugins-id-exclusions",
+        "responses": {
+          "204": {
+            "description": "No Content. Successfully deleted the plugin disablement."
+          }
+        },
+        "summary": "Remove plugin disablement",
+        "tags": [
+          "Plugins"
+        ],
+        "parameters": [
+          {
+            "description": "Plugin ID that is currently marked as disabled.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/v1/plugins/disablements": {
+      "get": {
+        "description": "Retrieve all the disabled plugins for the current tenant.",
+        "operationId": "get-v1-plugins-exclusions",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginResponse"
+                }
+              }
+            },
+            "description": "Successfully retrieved all the disabled plugins for the current tenant."
+          }
+        },
+        "summary": "Retrieve all disabled plugins",
+        "tags": [
+          "Plugins"
+        ]
+      }
+    },
+    "/v1/serviceaccounts": {
+      "get": {
+        "description": "Retrieves all the Service Accounts the user has access to",
+        "operationId": "get-v1-serviceaccounts",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetServiceAccountsResponseBody"
+                }
+              }
+            },
+            "description": "The list of all Service Account details the user has access to"
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Retrieves all the Service Accounts the",
+        "tags": [
+          "Service Accounts"
+        ]
+      },
+      "post": {
+        "description": "Creates a Service Account with the information provided. The service account is later used for machine to machine authentication. For rsaKey authentication service accounts publicKey key is required. Provide authenticationType field for creating other service accounts with another type of authentication.",
+        "operationId": "create-v1-serviceaccounts",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateServiceAccountRequestBody"
+              }
+            }
+          },
+          "description": "The Service Account data",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateServiceAccountResponseBody"
+                }
+              }
+            },
+            "description": "The id assigned to the created Service Account. If the Service Account has CyberArk registry purpose and is created with ociToken authentication type, the ociRegistryToken and ociAccountName are returned in the response."
+          },
+          "400": {
+            "description": "BadRequest. Return ErrInvalidPayload when creating rsaKey authentication service accounts and publicKey not provided."
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Creates a Service Account",
+        "tags": [
+          "Service Accounts"
+        ]
+      }
+    },
+    "/v1/serviceaccounts/{id}": {
+      "get": {
+        "description": "Retrieves the information of an Service Account associated to the given id",
+        "operationId": "get-v1-serviceaccounts-byId",
+        "parameters": [
+          {
+            "description": "The ID corresponding to the Service Account you want to retrieve",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "933507dd-0286-11ef-bc25-8a00a468403f",
+              "format": "UUID",
+              "type": "string",
+              "x-go-type": "uuid.UUID",
+              "x-go-type-import": {
+                "path": "github.com/google/uuid"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetServiceAccountsByClientIDResponseBody"
+                }
+              }
+            },
+            "description": "The Service Account details for the given id"
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Gets a Service Account",
+        "tags": [
+          "Service Accounts"
+        ]
+      },
+      "patch": {
+        "description": "Updates the specified fields for a given service account matching the provided id. Providing either a new credentialLifetime or a new publicKey will result of the corresponding credentials associated to this Service Account",
+        "operationId": "patch-v1-serviceaccounts-byId",
+        "parameters": [
+          {
+            "description": "The ID corresponding to the Service Account you want to update",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "933507dd-0286-11ef-bc25-8a00a468403f",
+              "format": "UUID",
+              "type": "string",
+              "x-go-type": "uuid.UUID",
+              "x-go-type-import": {
+                "path": "github.com/google/uuid"
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PatchServiceAccountByClientIDRequestBody"
+              }
+            }
+          },
+          "description": "The data to update",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "The Service Account was updated successfully"
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Updates a Service Account",
+        "tags": [
+          "Service Accounts"
+        ]
+      },
+      "delete": {
+        "description": "Deletes the Service Account corresponding to the provided id. Deleting a Service Account also invalidates its associated credentials.",
+        "operationId": "delete-v1-serviceaccounts-byId",
+        "parameters": [
+          {
+            "description": "The ID corresponding to the Service Account you want to delete",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "933507dd-0286-11ef-bc25-8a00a468403f",
+              "format": "UUID",
+              "type": "string",
+              "x-go-type": "uuid.UUID",
+              "x-go-type-import": {
+                "path": "github.com/google/uuid"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The Service Account was deleted successfully"
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Deletes a Service Account",
+        "tags": [
+          "Service Accounts"
+        ]
+      }
+    },
+    "/v1/serviceaccounts/scopes": {
+      "get": {
+        "description": "Retrieves all the Service Accounts Scopes available for the user",
+        "operationId": "get-v1-serviceaccountscopes",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetServiceAccountScopesResponseBody"
+                }
+              }
+            },
+            "description": "The list of all Service Account Scopes available for the user"
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Retrieves all the Service Accounts Scopes",
+        "tags": [
+          "Service Accounts"
+        ]
+      }
+    },
+    "/v1/serviceaccounts/{id}/ocitoken": {
+      "put": {
+        "description": "Regenerate the OCI registry token for a given service account matching the provided id. Providing a new OCI registry token to this Service Account and sending it back to the client back. Calling this endpoint will remove the current token for the service account and create a new one. Old token can not be used.",
+        "operationId": "put-v1-serviceaccounts-byId-ocitoken",
+        "parameters": [
+          {
+            "description": "The ID corresponding to the Service Account you want to regenerate the OCI registry token",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "933507dd-0286-11ef-bc25-8a00a468403f",
+              "format": "UUID",
+              "type": "string",
+              "x-go-type": "uuid.UUID",
+              "x-go-type-import": {
+                "path": "github.com/google/uuid"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutServiceAccountByClientIDOCITokenResponseBody"
+                }
+              }
+            },
+            "description": "The Service Account OCI registry token has been regenerated"
+          },
+          "400": {
+            "description": "BadRequest. This also happens when trying to regenerate token for account without token based authentication"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Regenerate the OCI registry token for",
+        "tags": [
+          "Service Accounts"
+        ]
+      }
+    },
+    "/v1/serviceaccounts/{id}/credentials": {
+      "put": {
+        "description": "Updates the specified credentials for a given service account matching the provided id. Providing either a new credentialLifetime or a new publicKey will result of the corresponding credentials associated to this Service Account",
+        "operationId": "put-v1-serviceaccounts-byId-credentials",
+        "parameters": [
+          {
+            "description": "The ID corresponding to the Service Account you want to update",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "933507dd-0286-11ef-bc25-8a00a468403f",
+              "format": "UUID",
+              "type": "string",
+              "x-go-type": "uuid.UUID",
+              "x-go-type-import": {
+                "path": "github.com/google/uuid"
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PutServiceAccountByClientIDCredentialsRequestBody"
+              }
+            }
+          },
+          "description": "The data to update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PutServiceAccountByClientIDCredentialsResponseBody"
+                }
+              }
+            },
+            "description": "The Service Account Credentials were updated successfully"
+          },
+          "400": {
+            "description": "BadRequest"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "InternalServerError"
+          }
+        },
+        "summary": "Updates a Service Account credentials",
+        "tags": [
+          "Service Accounts"
+        ]
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "AuthTypesParam": {
+        "description": "The authentication types separated by commas.",
+        "explode": false,
+        "in": "query",
+        "name": "authTypes",
+        "schema": {
+          "items": {
+            "$ref": "#/components/schemas/AuthType"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "CMSConfigIdParam": {
+        "description": "The id of the Credential Manager Service configuration.",
+        "in": "path",
+        "name": "id",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/CMSConfId"
+        }
+      },
+      "CMSCredentialDetailsParam": {
+        "description": "The option of whether or not return full credential details. Only Admin users can use this parameter.",
+        "in": "query",
+        "name": "details",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "CMSTypesParam": {
+        "description": "The privileged access management types separated by commas.",
+        "explode": false,
+        "in": "query",
+        "name": "cmsTypes",
+        "schema": {
+          "items": {
+            "$ref": "#/components/schemas/CMSType"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "CredentialIdParam": {
+        "description": "The credential Id.",
+        "in": "path",
+        "name": "id",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/CredentialId"
+        }
+      },
+      "CredentialIdsParam": {
+        "description": "The credential Ids separated by commas.",
+        "explode": false,
+        "in": "query",
+        "name": "ids",
+        "schema": {
+          "items": {
+            "$ref": "#/components/schemas/CredentialId"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      },
+      "TeamIdsParam": {
+        "description": "The team Ids separated by commas.",
+        "explode": false,
+        "in": "query",
+        "name": "teamIds",
+        "schema": {
+          "items": {
+            "$ref": "#/components/schemas/TeamId"
+          },
+          "minItems": 1,
+          "type": "array"
+        }
+      }
+    },
+    "requestBodies": {
+      "AddCredentialsBodyRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AddCredentialsRequest"
+            }
+          }
+        },
+        "description": "The body request to add credentials to existing Credential Manager Service configurations."
+      },
+      "CreateCMSConfigurationsBodyRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CreateCMSConfigurationsRequest"
+            }
+          }
+        },
+        "description": "The body request to create the given Credential Manager Service configuration using their details."
+      },
+      "TestCMSConfigurationBodyRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TestCMSConfigurationRequest"
+            }
+          }
+        },
+        "description": "The body request to test the given Credential Manager Service configuration using their details."
+      },
+      "TestCredentialBodyRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TestCredentialRequest"
+            }
+          }
+        },
+        "description": "The body request to test the given credential."
+      },
+      "UpdateCMSConfigurationsBodyRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/UpdateCMSConfigurationRequest"
+            }
+          }
+        },
+        "description": "The body request to update the given Credential Manager Service configuration using their details."
+      },
+      "UpdateCredentialBodyRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/UpdateCredentialRequest"
+            }
+          }
+        },
+        "description": "The body request to update the given credential."
+      }
+    },
+    "responses": {
+      "200DeleteCredentials": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/DeleteCredentialsResponse"
+            }
+          }
+        },
+        "description": "The credentials deleted successfully."
+      },
+      "200GetCMSConfiguration": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CMSConfigurationResponse"
+            }
+          }
+        },
+        "description": "The Credential Manager Service configuration received."
+      },
+      "200GetCMSConfigurations": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/GetCMSConfigurationsResponse"
+            }
+          }
+        },
+        "description": "The Credential Manager Service configurations received."
+      },
+      "200GetCredential": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CredentialResponse"
+            }
+          }
+        },
+        "description": "The retrieved credential."
+      },
+      "200GetCredentials": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/GetCredentialsResponse"
+            }
+          }
+        },
+        "description": "The retrieved credentials for a company."
+      },
+      "200TestCMSConfiguration": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TestCMSConfigurationResponse"
+            }
+          }
+        },
+        "description": "Ok. Contains the result of testing the Credential Manager Service configuration."
+      },
+      "200TestCredential": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TestCredentialResponse"
+            }
+          }
+        },
+        "description": "Connection test to credential successful."
+      },
+      "200UpdateCMSConfiguration": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CMSConfigurationResponse"
+            }
+          }
+        },
+        "description": "The Credential Manager Service configurations updated."
+      },
+      "200UpdateCredential": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CredentialResponse"
+            }
+          }
+        },
+        "description": "The credentials updated successfully."
+      },
+      "201AddCredentials": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AddCredentialsResponse"
+            }
+          }
+        },
+        "description": "The credentials added successfully."
+      },
+      "201CreateCMSConfigurations": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CreateCMSConfigurationsResponse"
+            }
+          }
+        },
+        "description": "The Credential Manager Service configurations created."
+      },
+      "400BadRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse3"
+            }
+          }
+        },
+        "description": "Bad request."
+      },
+      "401Unauthorized": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse3"
+            }
+          }
+        },
+        "description": "Unauthorized. Missing or invalid credentials."
+      },
+      "403Forbidden": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse3"
+            }
+          }
+        },
+        "description": "Forbidden. The user does not have the permission to do this action."
+      },
+      "404NotFound": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse3"
+            }
+          }
+        },
+        "description": "Not found. The resource was not found."
+      },
+      "500InternalServerErrorContent": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse3"
+            }
+          }
+        },
+        "description": "Internal Server Error."
+      }
+    },
+    "schemas": {
+      "ActivityLogCondition": {
+        "description": "A Condition for filtering",
+        "properties": {
+          "field": {
+            "description": "Represents a field for filtering",
+            "example": "activityType",
+            "type": "string"
+          },
+          "operator": {
+            "$ref": "#/components/schemas/ActivityLogFilterOperator"
+          },
+          "value": {
+            "description": "represents a field's value",
+            "example": "Authentication",
+            "type": "string"
+          },
+          "values": {
+            "description": "represents a field's values",
+            "example": [
+              "Authentication",
+              "Users"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ActivityLogEntriesResponse": {
+        "properties": {
+          "activityLogEntries": {
+            "description": "A collection of activity log entries",
+            "items": {
+              "$ref": "#/components/schemas/ActivityLogEntryInformation"
+            },
+            "type": "array"
+          },
+          "count": {
+            "description": "The number of activity log entries.",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "ActivityLogEntryInformation": {
+        "properties": {
+          "activityDate": {
+            "description": "The date when a log entry was produced",
+            "example": "2023-01-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "activityName": {
+            "description": "An activity name",
+            "example": "Login Succeeded",
+            "type": "string"
+          },
+          "activityType": {
+            "description": "An activity type",
+            "example": "Authentication",
+            "type": "string"
+          },
+          "companyId": {
+            "description": "UUID of a company",
+            "example": "85595df0-8e14-11ed-87e3-755db050f29d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "criticality": {
+            "description": "An activity criticality",
+            "example": 0,
+            "format": "int32",
+            "type": "integer"
+          },
+          "id": {
+            "description": "UUID of a log entry",
+            "example": "2eb29780-9046-11ed-8e50-b994b27d2ece",
+            "format": "uuid",
+            "type": "string"
+          },
+          "message": {
+            "description": "An activity log message",
+            "example": "user logged in",
+            "type": "string"
+          },
+          "payload": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "tsgId": {
+            "description": "TSG ID of a company",
+            "example": "1234567890",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ActivityLogFilter": {
+        "properties": {
+          "expression": {
+            "$ref": "#/components/schemas/BaseActivityLogFilter"
+          },
+          "ordering": {
+            "$ref": "#/components/schemas/BaseActivityLogOrdering"
+          },
+          "paging": {
+            "$ref": "#/components/schemas/Page1"
+          }
+        },
+        "type": "object"
+      },
+      "ActivityLogFilterOperand": {
+        "properties": {
+          "operand": {
+            "$ref": "#/components/schemas/ActivityLogCondition"
+          },
+          "operator": {
+            "$ref": "#/components/schemas/UnaryOperator"
+          }
+        },
+        "type": "object"
+      },
+      "ActivityLogFilterOperands": {
+        "properties": {
+          "operands": {
+            "description": "A list of conditions that will be used for filtering",
+            "example": [
+              {
+                "field": "activityType",
+                "operator": "EQ",
+                "value": "Authentication"
+              },
+              {
+                "field": "activityName",
+                "operator": "EQ",
+                "value": "Login Succeeded"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/BaseActivityLogFilter"
+            },
+            "type": "array"
+          },
+          "operator": {
+            "$ref": "#/components/schemas/NaryOperator"
+          }
+        },
+        "type": "object"
+      },
+      "ActivityLogFilterOperator": {
+        "description": "An operator for filtering",
+        "enum": [
+          "EQ",
+          "LT",
+          "LTE",
+          "GT",
+          "GTE",
+          "IN"
+        ],
+        "example": "EQ",
+        "type": "string"
+      },
+      "ActivityLogName": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "readableName": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ActivityLogOrder": {
+        "properties": {
+          "direction": {
+            "$ref": "#/components/schemas/Direction"
+          },
+          "field": {
+            "description": "A field, that will be used for ordering",
+            "example": "activityDate",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ActivityLogType": {
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "readableName": {
+            "type": "string"
+          },
+          "values": {
+            "items": {
+              "$ref": "#/components/schemas/ActivityLogName"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "AddCredentialRequest": {
+        "description": "The properties representing a credential to add.",
+        "properties": {
+          "authType": {
+            "$ref": "#/components/schemas/AuthType"
+          },
+          "cmsConfigId": {
+            "$ref": "#/components/schemas/CMSConfId"
+          },
+          "cmsType": {
+            "$ref": "#/components/schemas/CMSType"
+          },
+          "credentialDetails": {
+            "$ref": "#/components/schemas/CreateCredentialDetails"
+          },
+          "name": {
+            "$ref": "#/components/schemas/CredentialName"
+          },
+          "teamsIds": {
+            "$ref": "#/components/schemas/TeamsIds"
+          }
+        },
+        "required": [
+          "name",
+          "cmsType",
+          "authType",
+          "credentialDetails"
+        ],
+        "type": "object"
+      },
+      "AddCredentialsRequest": {
+        "description": "Array of credentials to add.",
+        "properties": {
+          "credentials": {
+            "items": {
+              "$ref": "#/components/schemas/AddCredentialRequest"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "credentials"
+        ],
+        "type": "object"
+      },
+      "AddCredentialsResponse": {
+        "description": "The response for the add credentials action.",
+        "properties": {
+          "count": {
+            "type": "integer"
+          },
+          "credentialsAdded": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialResponse"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "credentialsAdded",
+          "count"
+        ],
+        "type": "object"
+      },
+      "AdvancedSettingsInformation": {
+        "properties": {
+          "enableIssuanceAuditLog": {
+            "description": "Whether audit log entries must be generated for each issued certificate",
+            "example": false,
+            "type": "boolean"
+          },
+          "includeRawCertDataInAuditLog": {
+            "description": "Whether the raw certificate data must be included in the audit log entry",
+            "example": false,
+            "type": "boolean"
+          },
+          "requireFIPSCompliantBuild": {
+            "description": "Whether FIPS-compliant build is required",
+            "example": false,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "AnyValue1": {
+        "description": "Can be any value - string, number, boolean, array or object."
+      },
+      "AnyValue2": {
+        "description": "Can be any value - string, number, boolean, array or object."
+      },
+      "AnyValue3": {
+        "description": "Can be any value - string, number, boolean, array or object."
+      },
+      "AnyValue4": {
+        "description": "Can be any value - string, number, boolean, array or object."
+      },
+      "AnyValue5": {
+        "description": "Can be any value - string, number, boolean, array or object."
+      },
+      "AnyValue6": {
+        "description": "Can be any value - string, number, boolean, array or object."
+      },
+      "AnyValue7": {
+        "description": "Can be any value - string, number, boolean, array or object."
+      },
+      "AnyValue8": {
+        "description": "Can be any value - string, number, boolean, array or object."
+      },
+      "AnyValue9": {
+        "description": "Can be any value - string, number, boolean, array or object."
+      },
+      "ApiClientInformation": {
+        "description": "Represents the information of the client that is calling the API",
+        "example": {
+          "identifier": "192.168.1.63",
+          "type": "Venafi VCert CLI"
+        },
+        "properties": {
+          "identifier": {
+            "description": "Client identifier",
+            "example": "199.121.8.74",
+            "type": "string"
+          },
+          "type": {
+            "description": "Client type",
+            "example": "Venafi VCert CLI",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "AppId": {
+        "description": "The application ID from the CyberArk provider.",
+        "type": "string"
+      },
+      "AppRoleAuthenticationData": {
+        "properties": {
+          "roleId": {
+            "description": "The Role ID used for authentication with the underlying credentials provider.",
+            "type": "string"
+          },
+          "secretId": {
+            "description": "The Secret ID used for authentication with the underlying credentials provider.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Application": {
+        "description": "Application ID to associate with the service account",
+        "format": "UUID",
+        "type": "string",
+        "x-go-type": "uuid.UUID",
+        "x-go-type-import": {
+          "path": "github.com/google/uuid"
+        }
+      },
+      "ApprovalDecisionRequest": {
+        "properties": {
+          "reason": {
+            "description": "Reason for user's decision",
+            "example": "I reject this request because the certificate won't be needed anymore.",
+            "maxLength": 1024,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ApprovalRequestInformation": {
+        "properties": {
+          "approvalRule": {
+            "$ref": "#/components/schemas/CertificateRequestApprovalRuleOpenApi"
+          },
+          "approvers": {
+            "description": "A collection of approvers specified by type and id",
+            "items": {
+              "$ref": "#/components/schemas/ApproverProperty"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "approversOutcome": {
+            "description": "A collection of approver outcomes",
+            "items": {
+              "$ref": "#/components/schemas/ApproverOutcomeInformation"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "autoRejectionThreshold": {
+            "description": "Auto rejection threshold. After the defined number of days since request creation, the request is automatically rejected, if it is not approved",
+            "example": 5,
+            "maximum": 99,
+            "minimum": 1,
+            "type": "number"
+          },
+          "companyId": {
+            "description": "UUID of a company",
+            "example": "03eb6e61-9806-11ed-84f2-c747fb71e467",
+            "format": "uuid",
+            "type": "string"
+          },
+          "creationDate": {
+            "description": "The date a approval request was created",
+            "example": "2023-01-10T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "entityId": {
+            "description": "UUID of a certificate request",
+            "example": "5ece3180-b1e0-11ed-862d-ad36b18e787b",
+            "format": "uuid",
+            "type": "string"
+          },
+          "finalApprover": {
+            "$ref": "#/components/schemas/ApproverPropertyOpenApi"
+          },
+          "id": {
+            "description": "UUID of a approval request",
+            "example": "5ece3180-b1e0-11ed-862d-ad36b18e787d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "The date a approval request was modified",
+            "example": "2023-01-11T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "requestorId": {
+            "description": "UUID of a requestor",
+            "example": "8268d820-a08d-11ed-bbc0-252385d6d389",
+            "format": "uuid",
+            "type": "string"
+          },
+          "requiredApprovalsCount": {
+            "description": "Count of a required approvals",
+            "example": 2,
+            "format": "int32",
+            "type": "integer"
+          },
+          "status": {
+            "description": "Status of an approval request",
+            "enum": [
+              "NOT_REQUIRED",
+              "PENDING_APPROVAL",
+              "PENDING_FINAL_APPROVAL",
+              "APPROVED",
+              "REJECTED",
+              "EXPIRED",
+              "AUTO_APPROVED"
+            ],
+            "example": "PENDING_APPROVAL",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ApproverOutcomeInformation": {
+        "properties": {
+          "companyId": {
+            "description": "UUID of a company",
+            "example": "03eb6e61-9806-11ed-84f2-c747fb71e467",
+            "format": "uuid",
+            "type": "string"
+          },
+          "creationDate": {
+            "description": "The date a approver outcome was created",
+            "example": "2023-01-10T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of an approver outcome",
+            "example": "5ece3180-b1e0-11ed-862d-ad36b18e787c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "reason": {
+            "description": "Reason of an outcome",
+            "example": "Not needed",
+            "type": "string"
+          },
+          "status": {
+            "description": "Status of an approval request",
+            "enum": [
+              "APPROVED",
+              "REJECTED"
+            ],
+            "example": "APPROVED",
+            "type": "string"
+          },
+          "userId": {
+            "description": "UUID of a user",
+            "example": "8268d820-a08d-11ed-bbc0-252385d6d389",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ApproverProperty": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "USER",
+              "TEAM"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ApproverPropertyOpenApi": {
+        "description": "Approver with id that can be only user type",
+        "properties": {
+          "id": {
+            "description": "UUID specific to the approver user/team",
+            "example": "8268d820-a08d-11ed-bbc0-252385d6d389",
+            "format": "uuid",
+            "type": "string"
+          },
+          "type": {
+            "description": "Approver type",
+            "example": "USER",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "AuthType": {
+        "description": "The type of the authentication:\n  * `password`\n  * `username_password`\n",
+        "enum": [
+          "password",
+          "username_password"
+        ],
+        "type": "string"
+      },
+      "AwsCloudProviderInformation": {
+        "properties": {
+          "accountIds": {
+            "description": "Array of AWS account IDs each of which should be a 12-digit identifier",
+            "example": [
+              "123456789012"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "regions": {
+            "description": "Array of AWS regions",
+            "example": [
+              "us-west-1"
+            ],
+            "items": {
+              "enum": [
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2",
+                "af-south-1",
+                "ap-east-1",
+                "ap-south-2",
+                "ap-southeast-3",
+                "ap-southeast-4",
+                "ap-south-1",
+                "ap-northeast-3",
+                "ap-northeast-2",
+                "ap-southeast-1",
+                "ap-southeast-2",
+                "ap-northeast-1",
+                "ca-central-1",
+                "eu-central-1",
+                "eu-west-1",
+                "eu-west-2",
+                "eu-south-1",
+                "eu-west-3",
+                "eu-south-2",
+                "eu-north-1",
+                "eu-central-2",
+                "me-south-1",
+                "me-central-1",
+                "sa-east-1",
+                "us-gov-east-1",
+                "us-gov-west-1"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "accountIds",
+          "regions"
+        ],
+        "type": "object"
+      },
+      "AzureCloudProviderInformation": {
+        "properties": {
+          "subscriptionIds": {
+            "description": "Array of Azure subscription IDs each of which should be UUID",
+            "example": [
+              "8d10da13-8125-4ba9-a717-bf7490507b3d"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "subscriptionIds"
+        ],
+        "type": "object"
+      },
+      "BaseActivityLogFilter": {
+        "description": "Root expression for filtering",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ActivityLogFilterOperands"
+          },
+          {
+            "$ref": "#/components/schemas/ActivityLogFilterOperand"
+          },
+          {
+            "$ref": "#/components/schemas/ActivityLogCondition"
+          }
+        ],
+        "type": "object"
+      },
+      "BaseActivityLogOrdering": {
+        "description": "Specify the ordering of a search result",
+        "properties": {
+          "orders": {
+            "items": {
+              "$ref": "#/components/schemas/ActivityLogOrder"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "BaseFilter": {
+        "description": "Root expression for filtering",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/FilterOperands"
+          },
+          {
+            "$ref": "#/components/schemas/FilterOperand"
+          },
+          {
+            "$ref": "#/components/schemas/Condition"
+          }
+        ],
+        "type": "object"
+      },
+      "BaseOrdering": {
+        "description": "Specify the ordering of a search result",
+        "properties": {
+          "orders": {
+            "items": {
+              "$ref": "#/components/schemas/Order"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "BulkApprovalRequest": {
+        "properties": {
+          "ids": {
+            "description": "Set of UUIDs of the certificate requests",
+            "example": [
+              "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c"
+            ],
+            "items": {
+              "description": "Set of UUIDs of the certificate requests",
+              "format": "uuid",
+              "type": "string"
+            },
+            "maxItems": 100,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "reason": {
+            "description": "Reason for user's decision",
+            "example": "I reject this request because the certificate won't be needed anymore.",
+            "maxLength": 1024,
+            "type": "string"
+          },
+          "wsClientId": {
+            "description": "The ws client id, that will be used when the execution finishes",
+            "example": "someid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ids"
+        ],
+        "type": "object"
+      },
+      "BulkApprovalResponse": {
+        "properties": {
+          "operationId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CMSAuthenticationType": {
+        "description": "The authentication type for the privileged access management:\n  * `certificate` - For authentication with a Certificate bundle\n  * `userPassword` - For authentication with user and password\n  * `token` - For authentication with token\n  * `appRole` - For authentication with AppRole\n",
+        "enum": [
+          "certificate",
+          "userPassword",
+          "token",
+          "appRole"
+        ],
+        "type": "string"
+      },
+      "CMSConfId": {
+        "description": "The Credential Manager Service configuration ID.",
+        "example": "72e4c1f6-d85f-11ed-afa1-0242ac120002",
+        "format": "uuid",
+        "type": "string"
+      },
+      "CMSConfigurationResponse": {
+        "description": "The information representing a Credential Manager Service configuration for response.",
+        "properties": {
+          "cmsDetails": {
+            "$ref": "#/components/schemas/ResponseCMSDetails"
+          },
+          "cmsType": {
+            "$ref": "#/components/schemas/CMSType"
+          },
+          "companyId": {
+            "$ref": "#/components/schemas/CompanyId"
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/CreatedBy"
+          },
+          "createdOn": {
+            "$ref": "#/components/schemas/CreatedOn"
+          },
+          "id": {
+            "$ref": "#/components/schemas/CMSConfId"
+          },
+          "lastModifiedBy": {
+            "$ref": "#/components/schemas/LastModifiedBy"
+          },
+          "lastModifiedOn": {
+            "$ref": "#/components/schemas/LastModifiedOn"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "vSatelliteIds": {
+            "$ref": "#/components/schemas/VSatelliteIds"
+          }
+        },
+        "type": "object"
+      },
+      "CMSType": {
+        "description": "The type of the privileged access management:\n  * `cyberark` - For CyberArk privileged access management\n  * `hashicorp` - For HashiCorp privileged access management\n",
+        "enum": [
+          "cyberark",
+          "hashicorp"
+        ],
+        "type": "string"
+      },
+      "CMSURL": {
+        "description": "The baseUrl of the privileged access management provider.",
+        "format": "uri",
+        "type": "string"
+      },
+      "CSRAttributesInformation": {
+        "description": "Represents CSR attributes for certificate requests. Required when isVaaSGenerated is set to true and reuseCSR to false.",
+        "example": {
+          "commonName": "localhost",
+          "country": "MX",
+          "keyTypeParameters": {
+            "keyCurve": "P256",
+            "keyLength": 4096,
+            "keyType": "RSA"
+          },
+          "locality": "Merida",
+          "organization": "venafi",
+          "organizationalUnits": [
+            "devops"
+          ],
+          "state": "Yucatan",
+          "subjectAlternativeNamesByType": {
+            "dnsNames": [
+              "localhost"
+            ]
+          }
+        },
+        "properties": {
+          "commonName": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "keyTypeParameters": {
+            "$ref": "#/components/schemas/KeyTypeParameters2"
+          },
+          "locality": {
+            "type": "string"
+          },
+          "organization": {
+            "type": "string"
+          },
+          "organizationalUnits": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "state": {
+            "type": "string"
+          },
+          "subjectAlternativeNamesByType": {
+            "$ref": "#/components/schemas/SubjectAlternativeNamesByType"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateAuthorityProductInformation": {
+        "description": "Product specific for external certificate authority",
+        "discriminator": {
+          "propertyName": "certificateAuthority"
+        },
+        "properties": {
+          "certificateAuthority": {
+            "type": "string"
+          },
+          "certificateType": {
+            "enum": [
+              "OTHER",
+              "DOMAIN_VALIDATED_SSL"
+            ],
+            "type": "string"
+          },
+          "hashAlgorithm": {
+            "enum": [
+              "MD5",
+              "SHA1",
+              "MD2",
+              "SHA224",
+              "SHA256",
+              "SHA384",
+              "SHA512",
+              "UNKNOWN",
+              "GOSTR3411_94",
+              "SHA3_224",
+              "SHA3_256",
+              "SHA3_384",
+              "SHA3_512",
+              "RIPEMD128",
+              "RIPEMD160",
+              "RIPEMD256",
+              "SHA512_224",
+              "SHA512_256",
+              "SM3",
+              "GOSTR3411_2012_256",
+              "GOSTR3411_2012_512",
+              "SHAKE128",
+              "SHAKE256"
+            ],
+            "type": "string"
+          },
+          "productName": {
+            "type": "string"
+          },
+          "productTypes": {
+            "items": {
+              "enum": [
+                "SSL",
+                "CODESIGN"
+              ],
+              "type": "string"
+            },
+            "readOnly": true,
+            "type": "array"
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "PnYnMnDTnHnMnS",
+            "type": "string"
+          }
+        },
+        "required": [
+          "certificateAuthority"
+        ],
+        "type": "object"
+      },
+      "CertificateCredentialData": {
+        "properties": {
+          "certificateBundle": {
+            "description": "The Base64 encoding certificate bundle encrypted content.",
+            "format": "byte",
+            "type": "string"
+          },
+          "certificateId": {
+            "description": "The Id of the certificate selected from the Certificate Inventory",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificatePassword": {
+            "description": "The password to decrypt the certificate bundle.",
+            "format": "password",
+            "type": "string"
+          },
+          "fingerprint": {
+            "description": "The fingerprint of the certificate selected from the Certificate Inventory",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateDeletionRequest": {
+        "properties": {
+          "certificateIds": {
+            "description": "A collection of certificates UUIDs",
+            "example": [
+              "f2b42d60-df9c-11ed-b8ab-4788d83ace9f",
+              "f2c173d0-df9c-11ed-b8ab-4788d83ace9f"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "certificateIds"
+        ],
+        "type": "object"
+      },
+      "CertificateExpirationInventoryMonitoringConfig": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/InventoryMonitoringConfig"
+          },
+          {
+            "properties": {
+              "applicationIds": {
+                "description": "Application IDs that the webhook applies to",
+                "items": {
+                  "description": "Application IDs that the webhook applies to",
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array",
+                "uniqueItems": true
+              },
+              "enabled": {
+                "description": "Enables or disables webhook messages.",
+                "type": "boolean"
+              },
+              "includeUnassignedCertificates": {
+                "description": "Enables or disables notifications for unassigned certificates.",
+                "type": "boolean"
+              },
+              "thresholds": {
+                "description": "Array of certificate expiration thresholds, in days, for when notifications will be sent. Limit is 3 values.",
+                "items": {
+                  "description": "Array of certificate expiration thresholds, in days, for when notifications will be sent. Limit is 3 values.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "object"
+      },
+      "CertificateImportInfo": {
+        "description": "Base64 encoding certificate content.",
+        "properties": {
+          "apiClientInformation": {
+            "$ref": "#/components/schemas/ApiClientInformation"
+          },
+          "applicationIds": {
+            "description": "A collection of application IDs",
+            "example": [
+              "47c9d920-da21-11ed-a63c-d508f08eeaa0",
+              "9303e940-df9d-11ed-8850-f18176fc5513"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "certificate": {
+            "description": "Certificate base64 encoded format (PEM without header/footer",
+            "type": "string"
+          },
+          "certificateUsageMetadata": {
+            "description": "A collection of certificate request metadata",
+            "example": [
+              {
+                "appName": "venafi app1",
+                "automationMetadata": "automation data 008",
+                "nodeName": "venafi node 007"
+              },
+              {
+                "appName": "venafi app2",
+                "automationMetadata": "automation data 0013",
+                "nodeName": "venafi node 005"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CertificateUsageMetadata"
+            },
+            "type": "array"
+          },
+          "issuerCertificates": {
+            "description": "A collection of issuer certificates",
+            "example": [
+              "Venafi issuer",
+              "QA Venafi issuer"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "certificate"
+        ],
+        "type": "object"
+      },
+      "CertificateImportInformation": {
+        "description": "List of the certificates and private key pairs to import",
+        "properties": {
+          "certificate": {
+            "description": "Certificate to import",
+            "type": "string"
+          },
+          "dekEncryptedPassword": {
+            "description": "Password to decrypt the certificate",
+            "type": "string"
+          },
+          "dekEncryptedPrivateKey": {
+            "description": "Format of the private key",
+            "type": "string"
+          },
+          "passwordEncryptedPrivateKey": {
+            "description": "Private key for certificate to import",
+            "type": "string"
+          },
+          "pkcs12Keystore": {
+            "description": "pkcs12 keystore base64 encoded string",
+            "type": "string"
+          }
+        },
+        "required": [
+          "certificate",
+          "dekEncryptedPrivateKey",
+          "passwordEncryptedPrivateKey"
+        ],
+        "type": "object"
+      },
+      "CertificateImportRequest1": {
+        "properties": {
+          "edgeInstanceId": {
+            "description": "Id for edge instance",
+            "format": "uuid",
+            "type": "string"
+          },
+          "encryptionKeyId": {
+            "description": "Id for data encryption key",
+            "minLength": 1,
+            "type": "string"
+          },
+          "importInformation": {
+            "description": "List of the certificates and private key pairs to import",
+            "items": {
+              "$ref": "#/components/schemas/CertificateImportInformation"
+            },
+            "maxItems": 100,
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "edgeInstanceId",
+          "encryptionKeyId",
+          "importInformation"
+        ],
+        "type": "object"
+      },
+      "CertificateImportRequest2": {
+        "properties": {
+          "certificates": {
+            "description": "Base64 encoding certificate content.",
+            "items": {
+              "$ref": "#/components/schemas/CertificateImportInfo"
+            },
+            "type": "array"
+          },
+          "overrideBlocklist": {
+            "description": "Imports the certificate even if it's present in the Certificates blocklist.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "certificates"
+        ],
+        "type": "object"
+      },
+      "CertificateImportResponse1": {
+        "properties": {
+          "creationDate": {
+            "description": "Import creation date of certificates and private keys",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Import id used to check the status of the bulk operation",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateImportResponse2": {
+        "properties": {
+          "certificateInformations": {
+            "description": "A collection of information about certificates that were newly imported.",
+            "items": {
+              "$ref": "#/components/schemas/ImportedCertificateInformation"
+            },
+            "type": "array"
+          },
+          "statistics": {
+            "additionalProperties": {
+              "description": "Certificate import statistics",
+              "format": "int32",
+              "type": "integer"
+            },
+            "description": "Certificate import statistics",
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateImportStatusDetail": {
+        "description": "Status detail information for each certificate and private key imported related to the import id",
+        "properties": {
+          "certificateBytes": {
+            "description": "Bytes of the imported certificate",
+            "format": "byte",
+            "type": "string"
+          },
+          "fingerprint": {
+            "description": "Unique identifier for the imported certificate",
+            "type": "string"
+          },
+          "reason": {
+            "description": "Reason for the status result",
+            "type": "string"
+          },
+          "status": {
+            "description": "Result status for the import",
+            "enum": [
+              "IMPORTED",
+              "FAILED",
+              "SKIPPED",
+              "PROCESSING"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateImportStatusDetailResponse": {
+        "properties": {
+          "id": {
+            "description": "Import id",
+            "format": "uuid",
+            "type": "string"
+          },
+          "results": {
+            "description": "Status detail information for each certificate and private key imported related to the import id",
+            "items": {
+              "$ref": "#/components/schemas/CertificateImportStatusDetail"
+            },
+            "type": "array"
+          },
+          "status": {
+            "description": "Status of bulk import",
+            "enum": [
+              "PROCESSING",
+              "COMPLETED",
+              "WAITING",
+              "FAILED"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateInformation": {
+        "properties": {
+          "applicationIds": {
+            "description": "A collection of application IDs",
+            "example": [
+              "561baf7c-98b7-49af-ab9c-7b3a9fea3028",
+              "4adeba6f-0c94-4595-a5b6-babea458249f"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "archivedDate": {
+            "description": "The date a certificate was archived",
+            "example": "2022-05-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "authorityKeyIdentifierHash": {
+            "description": "An authority key identifier hash",
+            "example": "40572B10F85DDAF18BFF987372178532AB875BCA",
+            "type": "string"
+          },
+          "certificateAuthorityAccountId": {
+            "description": "UUID  of a certificate authority account",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateName": {
+            "description": "A certificate name",
+            "example": "venafi.com",
+            "type": "string"
+          },
+          "certificateRequestId": {
+            "description": "UUID  of a certificate request",
+            "example": "2e8964a0-9046-11ed-8e50-b994b27d2ece",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateStatus": {
+            "description": "Certificate's status",
+            "enum": [
+              "ACTIVE",
+              "RETIRED",
+              "DELETED"
+            ],
+            "example": "ACTIVE",
+            "type": "string"
+          },
+          "companyId": {
+            "description": "UUID  of a company",
+            "example": "85595df0-8e14-11ed-87e3-755db050f29d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "dekHash": {
+            "description": "A certificate dek hash",
+            "example": "RaBDrLmQ69hACXOrPU6542RBT-M-yZOkw4XKsT-r55i=",
+            "type": "string"
+          },
+          "encryptionType": {
+            "description": "A certificate encryption type",
+            "enum": [
+              "RSA",
+              "DSA",
+              "EC",
+              "GOST3410",
+              "ECGOST3410",
+              "RESERVED3",
+              "UNKNOWN"
+            ],
+            "example": "EC",
+            "type": "string"
+          },
+          "extendedKeyUsage": {
+            "description": "A collection of certificate extended key usages",
+            "example": [
+              "1.3.6.1.5.5.7.3.2",
+              "1.3.6.1.5.5.7.3.1"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "fingerprint": {
+            "description": "A certificate fingerprint",
+            "example": "6D4C95512C117B004191F1A096ECAD13242FCD9F",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of a certificate",
+            "example": "2eb29780-9046-11ed-8e50-b994b27d2ece",
+            "format": "uuid",
+            "type": "string"
+          },
+          "inhibitAnyPolicy": {
+            "description": "Inhibit any policy",
+            "example": 150,
+            "format": "int32",
+            "type": "integer"
+          },
+          "inhibitPolicyMapping": {
+            "description": "Inhibit policy mapping",
+            "example": 200,
+            "format": "int32",
+            "type": "integer"
+          },
+          "instances": {
+            "description": "A collection of certificate instances information",
+            "example": [
+              {
+                "certificateId": "7ec12010-9051-11ed-8e50-b994b27d2ece",
+                "certificateInstanceId": "7ec1bc50-9051-11ed-8e50-b994b27d2ece",
+                "certificateSource": "USER_SCAN",
+                "deploymentStatus": "IN_USE",
+                "hostname": "venafi.com",
+                "instanceChainValidationStatus": [
+                  "OK"
+                ],
+                "ipAddress": "23.185.0.2",
+                "lastScanDate": "2023-01-09T19:12:05.314+00:00",
+                "lastValidatedAttempt": "2023-01-09T19:12:05.446+00:00",
+                "modificationDate": "2023-01-09T19:12:14.865+00:00",
+                "port": 443,
+                "serviceIds": [
+                  "1d61e9e0-9046-11ed-bf12-53a1b041cf25"
+                ],
+                "sslProtocols": [
+                  "TLSv1.3",
+                  "TLSv1.2"
+                ],
+                "sslValidationErrorArguments": [],
+                "sslValidationStatus": "OK"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CertificateInstanceInformation"
+            },
+            "type": "array"
+          },
+          "issuerAlternativeNameDns": {
+            "description": "A collection of certificate issuer alternative names DNs",
+            "example": [
+              "venafi.com",
+              "www.venafi.com"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuerAlternativeNameNonDns": {
+            "description": "A collection of certificate issuer alternative name none DNs",
+            "example": [
+              "venafi issuer doman"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuerC": {
+            "description": "A certificate issues Country",
+            "example": "US",
+            "type": "string"
+          },
+          "issuerCN": {
+            "description": "A collection of certificate issuer Common names",
+            "example": [
+              "HydrantID SSL CA G3"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuerCertificateIds": {
+            "description": "A collection of issuer certificate IDs",
+            "example": [
+              "2e8964a0-9046-11ed-8e50-b994b27d2ece",
+              "d5b418a0-297e-11eb-bc4c-8b24e5a66fb6"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuerDN": {
+            "description": "A certificate issue DN",
+            "example": "cn=HydrantID SSL CA G3,o=HydrantID (Avalanche Cloud Corporation),c=US",
+            "type": "string"
+          },
+          "issuerL": {
+            "description": "A certificate issues Locality",
+            "example": "Salt Lake City",
+            "type": "string"
+          },
+          "issuerOU": {
+            "description": "A collection of certificate issuer Organization units",
+            "example": [
+              "Issuer CA"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuerST": {
+            "description": "A certificate issuer State",
+            "example": "Utah",
+            "type": "string"
+          },
+          "keyCurve": {
+            "description": "A certificate key curve",
+            "enum": [
+              "P256",
+              "P384",
+              "P521",
+              "ED25519",
+              "UNKNOWN"
+            ],
+            "example": "P256",
+            "type": "string"
+          },
+          "keyStrength": {
+            "description": "A certificate key strength",
+            "example": 2048,
+            "format": "int32",
+            "type": "integer"
+          },
+          "keyUsage": {
+            "description": "A collection of certificate key usages",
+            "example": [
+              "digitalSignature",
+              "keyEncipherment"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "lastNotification": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "managedCertificateId": {
+            "description": "UUID  of a managed certificate",
+            "example": "2f0e7320-9046-11ed-8ab8-19e0a618d9cd",
+            "format": "uuid",
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "The last date a certificate was modified",
+            "example": "2022-03-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "ocspNoCheck": {
+            "description": "If a certificate no ocsp check",
+            "example": false,
+            "type": "boolean"
+          },
+          "ownership": {
+            "$ref": "#/components/schemas/CertificateOwnership"
+          },
+          "pathLength": {
+            "description": "A certificate path length",
+            "example": 3,
+            "format": "int32",
+            "type": "integer"
+          },
+          "requireExplicitPolicy": {
+            "description": "Required explicit policy is required",
+            "example": 1,
+            "format": "int32",
+            "type": "integer"
+          },
+          "selfSigned": {
+            "description": "If the certificate is self singed",
+            "example": true,
+            "type": "boolean"
+          },
+          "serialNumber": {
+            "description": "A certificate serial number",
+            "example": "0C51A562B02A19A222FFB4730C47A8E2",
+            "type": "string"
+          },
+          "signatureAlgorithm": {
+            "description": "A certificate signature algorithm",
+            "enum": [
+              "MD2_WITH_RSA_ENCRYPTION",
+              "MD5_WITH_RSA_ENCRYPTION",
+              "SHA1_WITH_RSA_ENCRYPTION",
+              "SHA1_WITH_RSA_ENCRYPTION2",
+              "SHA256_WITH_RSA_ENCRYPTION",
+              "SHA384_WITH_RSA_ENCRYPTION",
+              "SHA512_WITH_RSA_ENCRYPTION",
+              "ID_DSA_WITH_SHA1",
+              "dsaWithSHA1",
+              "EC_DSA_WITH_SHA1",
+              "EC_DSA_WITH_SHA224",
+              "EC_DSA_WITH_SHA256",
+              "EC_DSA_WITH_SHA384",
+              "EC_DSA_WITH_SHA512",
+              "UNKNOWN",
+              "SHA1_WITH_RSAandMGF1",
+              "GOST_R3411_94_WITH_GOST_R3410_2001",
+              "GOST_R3411_94_WITH_GOST_R3410_94"
+            ],
+            "example": "SHA256_WITH_RSA_ENCRYPTION",
+            "type": "string"
+          },
+          "signatureHashAlgorithm": {
+            "description": "A certificate signature hash algorithm",
+            "enum": [
+              "MD5",
+              "SHA1",
+              "MD2",
+              "SHA224",
+              "SHA256",
+              "SHA384",
+              "SHA512",
+              "UNKNOWN",
+              "GOSTR3411_94"
+            ],
+            "example": "SHA256",
+            "type": "string"
+          },
+          "statusModificationDate": {
+            "description": "The date a certificate's status was modified",
+            "example": "2022-04-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "statusModificationUserId": {
+            "description": "UUID of the user that modified the certificate installation",
+            "example": "3c9964a0-9046-11ed-8e50-b994b27d2ece",
+            "format": "uuid",
+            "type": "string"
+          },
+          "subjectAlternativeNameDns": {
+            "description": "A collection of certificate subject alternative names DNs",
+            "example": [
+              "venafi.com",
+              "www.venafi.com"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectAlternativeNameNonDns": {
+            "description": "A collection of certificate subject alternative name none DNs",
+            "example": [
+              "venafi domain"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectAlternativeNamesByType": {
+            "$ref": "#/components/schemas/GeneralNamesData2"
+          },
+          "subjectC": {
+            "description": "A certificate subject Country",
+            "example": "US",
+            "type": "string"
+          },
+          "subjectCN": {
+            "description": "A collection of certificate subject CNs",
+            "example": [
+              "venafi.com",
+              "cloud.venafi"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectDN": {
+            "description": "A certificate subject DN",
+            "example": "cn=www.venafi.com,o=Venafi, Inc.,c=US,st=Utah,l=Salt Lake City",
+            "type": "string"
+          },
+          "subjectKeyIdentifierHash": {
+            "description": "A subject key identifier hash",
+            "example": "4E0CE93D3240561F468C33A85F08FCD3B04CC9DC",
+            "type": "string"
+          },
+          "subjectL": {
+            "description": "A certificate subject Locality",
+            "example": "Salt Lake City",
+            "type": "string"
+          },
+          "subjectO": {
+            "description": "A certificate subject Organization",
+            "example": "Venafi, Inc.",
+            "type": "string"
+          },
+          "subjectOU": {
+            "description": "A collection of certificate subject Organization units",
+            "example": [
+              "devops",
+              "test"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectST": {
+            "description": "A certificate subject State",
+            "example": "Utah",
+            "type": "string"
+          },
+          "tags": {
+            "description": "A collection of tags",
+            "example": [
+              "owner:test.user",
+              "90-day"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "totalActiveInstanceCount": {
+            "description": "total active instances of a certificate",
+            "example": 50,
+            "format": "int32",
+            "type": "integer"
+          },
+          "totalInstanceCount": {
+            "description": "total instances of a certificate",
+            "example": 100,
+            "format": "int32",
+            "type": "integer"
+          },
+          "validityEnd": {
+            "description": "The date a certificate validity ends",
+            "example": "2023-01-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "validityStart": {
+            "description": "The date a certificate validity starts",
+            "example": "2022-01-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "versionType": {
+            "description": "A certificate version type",
+            "enum": [
+              "OLD",
+              "CURRENT"
+            ],
+            "example": "CURRENT",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateInstanceInformation": {
+        "properties": {
+          "applicationIds": {
+            "description": "A collection of application IDs",
+            "example": [
+              "d3cce873-6957-4071-a65e-7676c0ae1123",
+              "322bcd99-286a-47ea-8dcd-8291ec5bff14"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "certificateId": {
+            "description": "UUID of a certificate",
+            "example": "2eb29780-9046-11ed-8e50-b994b27d2ece",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateInstanceId": {
+            "description": "UUID of a certificate instance",
+            "example": "f68daf30-4690-45bc-85b3-bb327024735e",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateSource": {
+            "description": "Certificate source",
+            "enum": [
+              "UNKNOWN",
+              "USER_PROVIDED",
+              "USER_IMPORTED",
+              "USER_SCAN",
+              "TRUSTNET_SCAN",
+              "ON_PREM_CA_IMPORT",
+              "EXTERNAL_CA_IMPORT",
+              "FILE_IMPORT",
+              "EXTERNAL_SCAN",
+              "DOMAIN_SCAN",
+              "SMART_SCAN_INTERNAL",
+              "SMART_SCAN_EXTERNAL",
+              "SMART_VALIDATION_INTERNAL",
+              "SMART_VALIDATION_EXTERNAL",
+              "MACHINE_DISCOVERY",
+              "KUBERNETES_DISCOVERY",
+              "AWS_DISCOVERY",
+              "AZURE_DISCOVERY",
+              "GCP_DISCOVERY"
+            ],
+            "example": "USER_SCAN",
+            "type": "string"
+          },
+          "deploymentStatus": {
+            "description": "The deployment status",
+            "enum": [
+              "UNKNOWN",
+              "IN_USE",
+              "SUPERSEDED"
+            ],
+            "example": "IN_USE",
+            "type": "string"
+          },
+          "hostname": {
+            "description": "A hostname",
+            "example": "venafi.com",
+            "type": "string"
+          },
+          "instanceChainValidationStatus": {
+            "description": "A collection of the instance chain validation status",
+            "example": [
+              "OK"
+            ],
+            "items": {
+              "enum": [
+                "OK",
+                "CHAIN_BUILDING_FAILED",
+                "INCOMPLETE_CHAIN",
+                "CHAIN_EXPIRE_BEFORE_EE",
+                "DISTRUSTED",
+                "UNKNOWN_ERROR",
+                "SELF_SIGNED"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ipAddress": {
+            "description": "An ip address",
+            "example": "14.183.1.32",
+            "type": "string"
+          },
+          "lastScanDate": {
+            "description": "The last scan date",
+            "example": "2023-01-10T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "lastValidatedAttempt": {
+            "description": "The last validation attempt date",
+            "example": "2023-01-11T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "The last modification date",
+            "example": "2023-01-10T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "port": {
+            "description": "A port number",
+            "example": 443,
+            "format": "int32",
+            "type": "integer"
+          },
+          "serviceIds": {
+            "description": "A collection of service IDs",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sslProtocols": {
+            "description": "A collection of ssl protocols",
+            "example": [
+              "TLSv1.1",
+              "TLSv1.2"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sslValidationErrorArguments": {
+            "description": "A collection of ssl validation error arguments",
+            "example": [
+              "B69950CC5F51EDDF55F36AD2BC898767BC43CC2A",
+              "24E5796GA7298E78EDE47D6FAED0790E8F464G54"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sslValidationStatus": {
+            "description": "SSL validation status",
+            "enum": [
+              "HOSTNAME_NOT_RESOLVABLE",
+              "NO_CERTIFICATE_PRESENTED",
+              "INVALID_CERTIFICATE_FOUND",
+              "UNEXPECTED_CERTIFICATE_FOUND",
+              "OLD_VERSION_CERTIFICATE_FOUND",
+              "TARGET_UNREACHABLE",
+              "UNKNOWN_ERROR",
+              "OK"
+            ],
+            "example": "OK",
+            "type": "string"
+          },
+          "sslValidationStatusMessage": {
+            "description": "SSL validation status message",
+            "example": "Certificate installation is using older versions of certificate",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateInstanceValidationRequest": {
+        "properties": {
+          "instanceIds": {
+            "description": "Unique certificate instance id(s) containing numbers, letters and dashes.",
+            "example": [
+              "7860eedb-c140-4354-b0ad-991cc7a7b4d1",
+              "0b0f6424-30bc-4ed8-ae83-cdeca3eaf60e"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "instanceIds"
+        ],
+        "type": "object"
+      },
+      "CertificateIssuingTemplateInformation": {
+        "properties": {
+          "certificateAuthority": {
+            "enum": [
+              "MOCKCA",
+              "DIGICERT",
+              "GLOBALSIGN",
+              "BUILTIN",
+              "ENTRUST",
+              "MICROSOFT",
+              "ACME",
+              "ZTPKI",
+              "GLOBALSIGNMSSL",
+              "TPP",
+              "CONNECTOR"
+            ],
+            "type": "string"
+          },
+          "certificateAuthorityAccountId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateAuthorityProductOptionId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "consumerTsgIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "creationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "csrUploadAllowed": {
+            "type": "boolean"
+          },
+          "description": {
+            "type": "string"
+          },
+          "driverGeneratedCsr": {
+            "type": "boolean"
+          },
+          "driverId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "everyoneIsConsumer": {
+            "type": "boolean"
+          },
+          "extendedKeyUsageValues": {
+            "items": {
+              "enum": [
+                "SERVER",
+                "CLIENT"
+              ],
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "keyGeneratedByVenafiAllowed": {
+            "type": "boolean"
+          },
+          "keyPairId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "keyReuse": {
+            "type": "boolean"
+          },
+          "keyTypes": {
+            "items": {
+              "$ref": "#/components/schemas/KeyTypeInformation"
+            },
+            "type": "array"
+          },
+          "locationId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "modificationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "priority": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "product": {
+            "$ref": "#/components/schemas/CertificateAuthorityProductInformation"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "recommendedSettings": {
+            "$ref": "#/components/schemas/RecommendedSettingsInformation"
+          },
+          "referencingApplicationIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "resourceConsumerTeamIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "resourceConsumerUserIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "sanDnsNameRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sanIpAddressRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sanRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sanRfc822NameRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sanUniformResourceIdentifierRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "shareWithAll": {
+            "type": "boolean"
+          },
+          "status": {
+            "enum": [
+              "AVAILABLE",
+              "UNAVAILABLE"
+            ],
+            "type": "string"
+          },
+          "subjectCNRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectCValues": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectLRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectORegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectOURegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectSTRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "systemGenerated": {
+            "type": "boolean"
+          },
+          "trackingData": {
+            "$ref": "#/components/schemas/TrackingDataInformation"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateIssuingTemplateRequest": {
+        "properties": {
+          "certificateAuthority": {
+            "enum": [
+              "MOCKCA",
+              "DIGICERT",
+              "GLOBALSIGN",
+              "BUILTIN",
+              "ENTRUST",
+              "MICROSOFT",
+              "ACME",
+              "ZTPKI",
+              "GLOBALSIGNMSSL",
+              "TPP",
+              "CONNECTOR"
+            ],
+            "type": "string"
+          },
+          "certificateAuthorityProductOptionId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "consumerTsgIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "csrUploadAllowed": {
+            "type": "boolean"
+          },
+          "description": {
+            "maxLength": 1024,
+            "type": "string"
+          },
+          "driverGeneratedCsr": {
+            "type": "boolean"
+          },
+          "driverId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "everyoneIsConsumer": {
+            "type": "boolean"
+          },
+          "extendedKeyUsageValues": {
+            "items": {
+              "enum": [
+                "SERVER",
+                "CLIENT"
+              ],
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "keyGeneratedByVenafiAllowed": {
+            "type": "boolean"
+          },
+          "keyPairId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "keyReuse": {
+            "type": "boolean"
+          },
+          "keyTypes": {
+            "items": {
+              "$ref": "#/components/schemas/KeyTypeParameters1"
+            },
+            "type": "array"
+          },
+          "locationId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "priority": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "product": {
+            "$ref": "#/components/schemas/CertificateAuthorityProductInformation"
+          },
+          "recommendedSettings": {
+            "$ref": "#/components/schemas/RecommendedSettingsRequest"
+          },
+          "resourceConsumerTeamIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "resourceConsumerUserIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "sanIpAddressRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sanRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sanRfc822NameRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sanUniformResourceIdentifierRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "shareWithAll": {
+            "type": "boolean"
+          },
+          "subjectCNRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectCValues": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectLRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectORegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectOURegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectSTRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "trackingData": {
+            "$ref": "#/components/schemas/TrackingDataInformation"
+          }
+        },
+        "required": [
+          "certificateAuthority",
+          "certificateAuthorityProductOptionId",
+          "keyReuse",
+          "keyTypes",
+          "name",
+          "product"
+        ],
+        "type": "object"
+      },
+      "CertificateIssuingTemplateResponse": {
+        "properties": {
+          "certificateIssuingTemplates": {
+            "items": {
+              "$ref": "#/components/schemas/CertificateIssuingTemplateInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateOwnership": {
+        "properties": {
+          "owningContainers": {
+            "items": {
+              "$ref": "#/components/schemas/ExtendedApplicationOwnership"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRecoveryRequest": {
+        "properties": {
+          "applicationIds": {
+            "description": "A collection of applications UUIDs",
+            "example": [
+              "47c9d920-da21-11ed-a63c-d508f08eeaa0",
+              "9303e940-df9d-11ed-8850-f18176fc5513"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "certificateIds": {
+            "description": "A collection of certificates UUIDs",
+            "example": [
+              "f2b42d60-df9c-11ed-b8ab-4788d83ace9f",
+              "f2c173d0-df9c-11ed-b8ab-4788d83ace9f"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "certificateIds"
+        ],
+        "type": "object"
+      },
+      "CertificateRequestApprovalConditionsFilterRuleInformation": {
+        "properties": {
+          "applicationIds": {
+            "description": "A collection of application ids the rule will be applicable to",
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "certificateAuthorityAccountIds": {
+            "description": "A collection of certificate authority account ids the rule will be applicable to",
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "certificateIssuingTemplateIds": {
+            "description": "A collection of certificate issuing template ids the rule will be applicable to",
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRequestApprovalExceptionsFilterRuleInformation": {
+        "properties": {
+          "applicationIds": {
+            "description": "A collection of application ids the rule won't be applied to",
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "requestors": {
+            "description": "A collection of approvers, specified by type and id, for which the rule won't be applied",
+            "items": {
+              "$ref": "#/components/schemas/ApproverProperty"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRequestApprovalRuleDeleteResponseOpenApi": {
+        "properties": {
+          "id": {
+            "description": "Approval rule `id`",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Approval rule name",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRequestApprovalRuleOpenApi": {
+        "properties": {
+          "approvers": {
+            "description": "A collection of approvers specified by type and id",
+            "items": {
+              "$ref": "#/components/schemas/ApproverProperty"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "atLeast": {
+            "description": "If the type of the approval is AT_LEAST then specify how many people have to approve",
+            "format": "int32",
+            "type": "integer"
+          },
+          "autoApproveOnRenew": {
+            "default": false,
+            "description": "Automatically approve when renew a certificate",
+            "type": "boolean"
+          },
+          "autoRejectionThreshold": {
+            "description": "Auto rejection threshold. After the defined number of days since request creation, the request is automatically rejected, if it is not approved",
+            "example": 5,
+            "maximum": 99,
+            "minimum": 1,
+            "type": "number"
+          },
+          "conditions": {
+            "$ref": "#/components/schemas/CertificateRequestApprovalConditionsFilterRuleInformation"
+          },
+          "creationDate": {
+            "description": "The date a approval rule was created",
+            "example": "2023-01-10T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "exceptions": {
+            "$ref": "#/components/schemas/CertificateRequestApprovalExceptionsFilterRuleInformation"
+          },
+          "finalApprover": {
+            "$ref": "#/components/schemas/ApproverPropertyOpenApi"
+          },
+          "id": {
+            "description": "Approval rule `id`",
+            "format": "uuid",
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "The date a approval rule was modified",
+            "example": "2023-01-11T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "description": "Approval rule name",
+            "type": "string"
+          },
+          "priority": {
+            "description": "Priority of the rule",
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": {
+            "description": "The type of the approval rule",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRequestApprovalRulesRequest": {
+        "properties": {
+          "approvers": {
+            "description": "A collection of approvers specified by type and id",
+            "items": {
+              "$ref": "#/components/schemas/ApproverProperty"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "atLeast": {
+            "description": "If the type of the approval is AT_LEAST then specify how many people have to approve",
+            "example": 2,
+            "format": "int32",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "autoApproveOnRenew": {
+            "default": false,
+            "description": "Automatically approve when renew a certificate",
+            "type": "boolean"
+          },
+          "autoRejectionThreshold": {
+            "description": "Auto rejection threshold. After the defined number of days since request creation, the request is automatically rejected, if it is not approved",
+            "example": 5,
+            "maximum": 99,
+            "minimum": 1,
+            "type": "number"
+          },
+          "conditions": {
+            "$ref": "#/components/schemas/CertificateRequestApprovalConditionsFilterRuleInformation"
+          },
+          "continueProcessingOnException": {
+            "default": false,
+            "description": "Continue with next approval rules when match an approval rule exception condition",
+            "type": "boolean"
+          },
+          "exceptions": {
+            "$ref": "#/components/schemas/CertificateRequestApprovalExceptionsFilterRuleInformation"
+          },
+          "finalApprover": {
+            "description": "UUID of the final approver",
+            "example": "8268d820-a08d-11ed-bbc0-252385d6d390",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Approval rule name",
+            "example": "Approval rule for built in CA",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of the approval rule",
+            "enum": [
+              "ALL",
+              "AT_LEAST"
+            ],
+            "example": "AT_LEAST",
+            "type": "string"
+          }
+        },
+        "required": [
+          "approvers",
+          "conditions",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "CertificateRequestApprovalRulesResponseOpenApi": {
+        "properties": {
+          "approvalRules": {
+            "items": {
+              "$ref": "#/components/schemas/CertificateRequestApprovalRuleOpenApi"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRequestApprovalRulesUpdateRequest": {
+        "properties": {
+          "approvers": {
+            "description": "A collection of approvers specified by type and id",
+            "items": {
+              "$ref": "#/components/schemas/ApproverProperty"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "atLeast": {
+            "description": "If the type of the approval is AT_LEAST then specify how many people have to approve",
+            "example": 2,
+            "format": "int32",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "autoApproveOnRenew": {
+            "default": false,
+            "description": "Automatically approve when renew a certificate",
+            "type": "boolean"
+          },
+          "autoRejectionThreshold": {
+            "description": "Auto rejection threshold. After the defined number of days since request creation, the request is automatically rejected, if it is not approved",
+            "example": 5,
+            "maximum": 99,
+            "minimum": 1,
+            "type": "number"
+          },
+          "conditions": {
+            "$ref": "#/components/schemas/CertificateRequestApprovalConditionsFilterRuleInformation"
+          },
+          "continueProcessingOnException": {
+            "default": false,
+            "description": "Continue with next approval rules when match an approval rule exception condition",
+            "type": "boolean"
+          },
+          "exceptions": {
+            "$ref": "#/components/schemas/CertificateRequestApprovalExceptionsFilterRuleInformation"
+          },
+          "finalApprover": {
+            "description": "UUID of the final approver",
+            "example": "8268d820-a08d-11ed-bbc0-252385d6d390",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Approval rule name",
+            "example": "Approval rule for built in CA",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "priority": {
+            "description": "Rule priority. The order in which the rules will be executed. Starts from 1 (highest priority).",
+            "example": 5,
+            "minimum": 1,
+            "type": "number"
+          },
+          "type": {
+            "description": "The type of the approval rule",
+            "enum": [
+              "ALL",
+              "AT_LEAST"
+            ],
+            "example": "AT_LEAST",
+            "type": "string"
+          }
+        },
+        "required": [
+          "approvers",
+          "conditions",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "CertificateRequestDocumentInformation": {
+        "properties": {
+          "applicationId": {
+            "description": "UUID of an application ID",
+            "example": "dc6eb020-9131-11ed-9ce4-1d9554d648cd",
+            "format": "uuid",
+            "type": "string"
+          },
+          "approvedIds": {
+            "description": "A collection of IDs of all users that have already approved",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "approverTeamIds": {
+            "description": "A collection of all team IDs that are configured as approvers",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "approverUserIds": {
+            "description": "A collection of all user IDs that are configured as approvers",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "caOrderId": {
+            "description": "A CA order ID",
+            "example": "63364861",
+            "type": "string"
+          },
+          "certificateIds": {
+            "description": "A collection of certificate ids",
+            "example": [
+              "1441c6f0-9136-11ed-bd65-ed926a033704",
+              "12257370-9132-11ed-bd65-ed926a033704"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "certificateIssuingTemplateId": {
+            "description": "UUID of certificate issuing template",
+            "example": "ce9c2cc0-9131-11ed-a8f1-bf0e7991f912",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateOwnerUserId": {
+            "description": "UUID of the certificate request's owner",
+            "example": "88932c30-8e14-11ed-87e3-755db050f29d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "companyId": {
+            "description": "UUID of a company",
+            "example": "85595df0-8e14-11ed-87e3-755db050f29d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "creationDate": {
+            "description": "The date a certificate request was created",
+            "example": "2022-01-20T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "customAttributes": {
+            "$ref": "#/components/schemas/CustomAttributes2"
+          },
+          "errorInformation": {
+            "$ref": "#/components/schemas/ErrorInformation2"
+          },
+          "finalApproverId": {
+            "description": "UUID of the final approver if configured",
+            "example": "dc6eb020-9131-11ed-9ce4-1d9554d648cd",
+            "format": "uuid",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of a certificate request",
+            "example": "fa4a2210-9135-11ed-a8f1-bf0e7991f912",
+            "format": "uuid",
+            "type": "string"
+          },
+          "keyCurve": {
+            "description": "Certificate request key curve",
+            "enum": [
+              "P256",
+              "P384",
+              "P521",
+              "ED25519",
+              "UNKNOWN"
+            ],
+            "example": "P521",
+            "type": "string"
+          },
+          "keyLength": {
+            "description": "Certificate request key length",
+            "example": 2048,
+            "format": "int32",
+            "type": "integer"
+          },
+          "keyType": {
+            "description": "Certificate request key type",
+            "enum": [
+              "RSA",
+              "DSA",
+              "EC",
+              "GOST3410",
+              "ECGOST3410",
+              "RESERVED3",
+              "UNKNOWN"
+            ],
+            "example": "RSA",
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "The date a certificate request was modified",
+            "example": "2023-01-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of the certificate request",
+            "enum": [
+              "NEW",
+              "PENDING",
+              "PENDING_APPROVAL",
+              "PENDING_FINAL_APPROVAL",
+              "REJECTED_APPROVAL",
+              "REQUESTED",
+              "ISSUED",
+              "REJECTED",
+              "CANCELLED",
+              "REVOKED",
+              "FAILED",
+              "DELETED"
+            ],
+            "example": "ISSUED",
+            "type": "string"
+          },
+          "subjectAlternativeNamesByType": {
+            "$ref": "#/components/schemas/GeneralNamesData2"
+          },
+          "subjectCN": {
+            "description": "Certificate request subject CN",
+            "example": "venafi.com",
+            "type": "string"
+          },
+          "subjectDN": {
+            "description": "Certificate request subject DN",
+            "example": "cn=venafi.com,ou=devops,o=venafi,c=US,st=Utah,l=Salt Lake City",
+            "type": "string"
+          },
+          "tags": {
+            "description": "A collection of tags",
+            "example": [
+              "test",
+              "category:security"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "P10M",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRequestDocumentResponse": {
+        "properties": {
+          "certificateRequests": {
+            "description": "A collection of certificate request information",
+            "example": [
+              {
+                "applicationId": "813700b0-c357-11ed-aea1-99c5a9067cde",
+                "caOrderId": "3a:5f:7e:9f:8c:e4:b6:f7:25:a7:81:0d:f0:ac:28:ec:fe:05:9b:30",
+                "certificateIds": [
+                  "a27dfc10-c357-11ed-946f-7db55f9ae03e",
+                  "a275beb0-c357-11ed-946f-7db55f9ae03e",
+                  "a24c16a0-c357-11ed-946f-7db55f9ae03e"
+                ],
+                "certificateIssuingTemplateId": "73a22290-c357-11ed-a00c-e3953fcf04eb",
+                "certificateOwnerUserId": "9bf1e760-b797-11ed-a508-c13aa0641666",
+                "companyId": "98996d90-b797-11ed-a508-c13aa0641666",
+                "creationDate": "2023-03-15T17:34:26.466+00:00",
+                "id": "a1c0c690-c357-11ed-a00c-e3953fcf04eb",
+                "keyLength": 4096,
+                "keyType": "RSA",
+                "modificationDate": "2023-03-15T17:34:27.479+00:00",
+                "status": "ISSUED",
+                "subjectAlternativeNamesByType": {
+                  "dNSName": [
+                    "localhost"
+                  ]
+                },
+                "subjectCN": "localhost",
+                "subjectDN": "cn=localhost,ou=devops,o=venafi,c=MX,st=Yucatan,l=Merida",
+                "validityPeriod": "P10D"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CertificateRequestDocumentInformation"
+            },
+            "type": "array"
+          },
+          "numFound": {
+            "description": "The number of certificate requests that were found",
+            "example": 10,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRequestInformation1": {
+        "properties": {
+          "caOrderId": {
+            "description": "A CA order ID",
+            "example": "63364861",
+            "type": "string"
+          },
+          "certificateIds": {
+            "description": "A collection of certificate IDs",
+            "example": [
+              "1441c6f0-9136-11ed-bd65-ed926a033704",
+              "12257370-9132-11ed-bd65-ed926a033704"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "certificateIssuingTemplateId": {
+            "description": "UUID of a certificate issuing template",
+            "example": "ce9c2cc0-9131-11ed-a8f1-bf0e7991f912",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateName": {
+            "description": "A certificate name",
+            "example": "venafi.com",
+            "type": "string"
+          },
+          "certificateOwnerUserId": {
+            "description": "UUID of the certificate request's owner",
+            "example": "88932c30-8e14-11ed-87e3-755db050f29d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateSigningRequest": {
+            "description": "A certificate signing request (CSR) in PEM format",
+            "type": "string"
+          },
+          "companyId": {
+            "description": "UUID of a company",
+            "example": "85595df0-8e14-11ed-87e3-755db050f29d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "creationDate": {
+            "description": "The date a certificate request was created",
+            "example": "2023-01-10T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "customAttributes": {
+            "$ref": "#/components/schemas/CustomAttributes1"
+          },
+          "dekHash": {
+            "description": "A certificate dek hash",
+            "example": "RaBDrLmQ69hACXOrPU6542RBT-M-yZOkw4XKsT-r55i=",
+            "type": "string"
+          },
+          "encryptedPrivateKey": {
+            "format": "byte",
+            "type": "string"
+          },
+          "encryptionDetails": {
+            "$ref": "#/components/schemas/EncryptionDetails"
+          },
+          "errorInformation": {
+            "$ref": "#/components/schemas/ErrorInformation4"
+          },
+          "id": {
+            "description": "UUID of a certificate request",
+            "example": "fa4a2210-9135-11ed-a8f1-bf0e7991f912",
+            "format": "uuid",
+            "type": "string"
+          },
+          "keyCurve": {
+            "description": "Certificate request key curve",
+            "enum": [
+              "P256",
+              "P384",
+              "P521",
+              "ED25519",
+              "UNKNOWN"
+            ],
+            "example": "P521",
+            "type": "string"
+          },
+          "keyLength": {
+            "description": "Certificate request key length",
+            "example": 2048,
+            "format": "int32",
+            "type": "integer"
+          },
+          "keyType": {
+            "description": "Certificate request key type",
+            "enum": [
+              "RSA",
+              "DSA",
+              "EC",
+              "GOST3410",
+              "ECGOST3410",
+              "RESERVED3",
+              "UNKNOWN"
+            ],
+            "example": "RSA",
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "The date a certificate request was modified",
+            "example": "2023-01-11T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "product": {
+            "$ref": "#/components/schemas/CertificateAuthorityProductInformation"
+          },
+          "productEntitlement": {
+            "enum": [
+              "ANY",
+              "MIRA",
+              "DEVOPS",
+              "OUTAGE_DETECTION",
+              "CODESIGN"
+            ],
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of a certificate request",
+            "enum": [
+              "NEW",
+              "PENDING",
+              "PENDING_APPROVAL",
+              "PENDING_FINAL_APPROVAL",
+              "REJECTED_APPROVAL",
+              "REQUESTED",
+              "ISSUED",
+              "REJECTED",
+              "CANCELLED",
+              "REVOKED",
+              "FAILED",
+              "DELETED"
+            ],
+            "example": "ISSUED",
+            "type": "string"
+          },
+          "subjectAlternativeNamesByType": {
+            "$ref": "#/components/schemas/GeneralNamesData1"
+          },
+          "subjectDN": {
+            "description": "Certificate request subject DN",
+            "example": "cn=venafi.com,ou=devops,o=venafi,c=US,st=Utah,l=Salt Lake City",
+            "type": "string"
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "P10M",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRequestInformation2": {
+        "properties": {
+          "apiClientInformation": {
+            "$ref": "#/components/schemas/ApiClientInformation"
+          },
+          "applicationId": {
+            "description": "UUID of an application ID",
+            "example": "dc6eb020-9131-11ed-9ce4-1d9554d648cd",
+            "format": "uuid",
+            "type": "string"
+          },
+          "approvedIds": {
+            "description": "A collection of IDs of all users that have already approved",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "approverTeamIds": {
+            "description": "A collection of all team IDs that are configured as approvers",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "approverUserIds": {
+            "description": "A collection of all user IDs that are configured as approvers",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "caOrderId": {
+            "description": "A CA order ID",
+            "example": "63364861",
+            "type": "string"
+          },
+          "certificateIds": {
+            "description": "A collection of certificate IDs",
+            "example": [
+              "1441c6f0-9136-11ed-bd65-ed926a033704",
+              "12257370-9132-11ed-bd65-ed926a033704"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "certificateIssuingTemplateId": {
+            "description": "UUID of a certificate issuing template",
+            "example": "ce9c2cc0-9131-11ed-a8f1-bf0e7991f912",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateOwnerUserId": {
+            "description": "UUID of the certificate request's owner",
+            "example": "88932c30-8e14-11ed-87e3-755db050f29d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateSigningRequest": {
+            "description": "A certificate signing request (CSR) in PEM format",
+            "type": "string"
+          },
+          "certificateUsageMetadata": {
+            "description": "A collection of certificate request metadata",
+            "example": [
+              {
+                "appName": "venafi app1",
+                "automationMetadata": "automation data 008",
+                "nodeName": "venafi node 007"
+              },
+              {
+                "appName": "venafi app2",
+                "automationMetadata": "automation data 0013",
+                "nodeName": "venafi node 005"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CertificateUsageMetadata"
+            },
+            "type": "array"
+          },
+          "companyId": {
+            "description": "UUID of a company",
+            "example": "85595df0-8e14-11ed-87e3-755db050f29d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "creationDate": {
+            "description": "The date a certificate request was created",
+            "example": "2023-01-10T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "customAttributesInformation": {
+            "$ref": "#/components/schemas/CustomAttributesInformation"
+          },
+          "errorInformation": {
+            "$ref": "#/components/schemas/ErrorInformation2"
+          },
+          "finalApproverId": {
+            "description": "UUID of the final approver if configured",
+            "example": "dc6eb020-9131-11ed-9ce4-1d9554d648cd",
+            "format": "uuid",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of a certificate request",
+            "example": "fa4a2210-9135-11ed-a8f1-bf0e7991f912",
+            "format": "uuid",
+            "type": "string"
+          },
+          "keyCurve": {
+            "description": "Certificate request key curve",
+            "enum": [
+              "P256",
+              "P384",
+              "P521",
+              "ED25519",
+              "UNKNOWN"
+            ],
+            "example": "P521",
+            "type": "string"
+          },
+          "keyLength": {
+            "description": "Certificate request key length",
+            "example": 2048,
+            "format": "int32",
+            "type": "integer"
+          },
+          "keyType": {
+            "description": "Certificate request key type",
+            "enum": [
+              "RSA",
+              "DSA",
+              "EC",
+              "GOST3410",
+              "ECGOST3410",
+              "RESERVED3",
+              "UNKNOWN"
+            ],
+            "example": "RSA",
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "The date a certificate request was modified",
+            "example": "2023-01-11T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "The status of a certificate request",
+            "enum": [
+              "NEW",
+              "PENDING",
+              "PENDING_APPROVAL",
+              "PENDING_FINAL_APPROVAL",
+              "REJECTED_APPROVAL",
+              "REQUESTED",
+              "ISSUED",
+              "REJECTED",
+              "CANCELLED",
+              "REVOKED",
+              "FAILED",
+              "DELETED"
+            ],
+            "example": "ISSUED",
+            "type": "string"
+          },
+          "subjectAlternativeNamesByType": {
+            "$ref": "#/components/schemas/GeneralNamesData2"
+          },
+          "subjectDN": {
+            "description": "Certificate request subject DN",
+            "example": "cn=venafi.com,ou=devops,o=venafi,c=US,st=Utah,l=Salt Lake City",
+            "type": "string"
+          },
+          "tags": {
+            "description": "A collection of tags",
+            "example": [
+              "test",
+              "category:security"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "P10M",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRequestRequest": {
+        "properties": {
+          "apiClientInformation": {
+            "$ref": "#/components/schemas/ApiClientInformation"
+          },
+          "applicationId": {
+            "description": "Application UUID",
+            "example": "b00701b0-886f-11ed-9f39-3d586ab80cf2",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateIssuingTemplateId": {
+            "description": "Certificate issuing template UUID",
+            "example": "a305d810-886f-11ed-9ccf-0dbf748eb1ae",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateOwnerUserId": {
+            "description": "Certificate owner UUID",
+            "example": "a305d810-886f-11ed-9ccf-0dbf748eb1ae",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateSigningRequest": {
+            "description": "A certificate signing request(CSR) in PEM format. Required when reuseCSR and isVaaSGenerated are set to false.",
+            "type": "string"
+          },
+          "certificateUsageMetadata": {
+            "description": "A collection of certificate request metadata",
+            "example": [
+              {
+                "appName": "venafi app1",
+                "automationMetadata": "automation data 008",
+                "nodeName": "venafi node 007"
+              },
+              {
+                "appName": "venafi app2",
+                "automationMetadata": "automation data 0013",
+                "nodeName": "venafi node 005"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CertificateUsageMetadata"
+            },
+            "type": "array"
+          },
+          "csrAttributes": {
+            "$ref": "#/components/schemas/CSRAttributesInformation"
+          },
+          "customAttributes": {
+            "$ref": "#/components/schemas/CustomAttributesInformation"
+          },
+          "existingCertificateId": {
+            "description": "Existing certificate UUID. Required when reuseCSR is set to true.",
+            "example": "b505d810-886f-11ed-9ccf-0dbf748eb1ae",
+            "format": "uuid",
+            "type": "string"
+          },
+          "isVaaSGenerated": {
+            "description": "Specify whether VaaS should generate the request.",
+            "example": true,
+            "type": "boolean"
+          },
+          "reuseCSR": {
+            "description": "Specifies whether an existing CSR is reused",
+            "example": true,
+            "type": "boolean"
+          },
+          "tags": {
+            "description": "A collection of tags",
+            "example": [
+              "test",
+              "category:security"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "P10M",
+            "type": "string"
+          }
+        },
+        "required": [
+          "applicationId",
+          "certificateIssuingTemplateId",
+          "isVaaSGenerated"
+        ],
+        "type": "object"
+      },
+      "CertificateRequestResponse": {
+        "properties": {
+          "certificateRequests": {
+            "description": "A collection of certificate information",
+            "example": [
+              {
+                "applicationId": "813700b0-c357-11ed-aea1-99c5a9067cde",
+                "caOrderId": "3a:5f:7e:9f:8c:e4:b6:f7:25:a7:81:0d:f0:ac:28:ec:fe:05:9b:30",
+                "certificateIds": [
+                  "a27dfc10-c357-11ed-946f-7db55f9ae03e",
+                  "a275beb0-c357-11ed-946f-7db55f9ae03e",
+                  "a24c16a0-c357-11ed-946f-7db55f9ae03e"
+                ],
+                "certificateIssuingTemplateId": "73a22290-c357-11ed-a00c-e3953fcf04eb",
+                "certificateOwnerUserId": "9bf1e760-b797-11ed-a508-c13aa0641666",
+                "companyId": "98996d90-b797-11ed-a508-c13aa0641666",
+                "creationDate": "2023-03-15T17:34:26.466+00:00",
+                "id": "a1c0c690-c357-11ed-a00c-e3953fcf04eb",
+                "keyLength": 4096,
+                "keyType": "RSA",
+                "modificationDate": "2023-03-15T17:34:27.479+00:00",
+                "status": "ISSUED",
+                "subjectAlternativeNamesByType": {
+                  "dNSName": [
+                    "localhost"
+                  ]
+                },
+                "subjectCN": "localhost",
+                "subjectDN": "cn=localhost,ou=devops,o=venafi,c=MX,st=Yucatan,l=Merida",
+                "validityPeriod": "P10D"
+              },
+              {
+                "applicationId": "813700b0-c357-11ed-aea1-99c5a9067cde",
+                "caOrderId": "6f:b7:27:c8:2c:bd:1a:b0:6f:43:fb:8a:6b:5b:a3:a6:c2:52:38:85",
+                "certificateIds": [
+                  "b767aef0-c357-11ed-946f-7db55f9ae03e",
+                  "a275beb0-c357-11ed-946f-7db55f9ae03e",
+                  "a24c16a0-c357-11ed-946f-7db55f9ae03e"
+                ],
+                "certificateIssuingTemplateId": "73a22290-c357-11ed-a00c-e3953fcf04eb",
+                "certificateOwnerUserId": "9bf1e760-b797-11ed-a508-c13aa0641666",
+                "companyId": "98996d90-b797-11ed-a508-c13aa0641666",
+                "creationDate": "2023-03-15T17:35:02.384+00:00",
+                "id": "b7502f50-c357-11ed-a00c-e3953fcf04eb",
+                "keyLength": 4096,
+                "keyType": "RSA",
+                "modificationDate": "2023-03-15T17:35:02.544+00:00",
+                "status": "ISSUED",
+                "subjectAlternativeNamesByType": {
+                  "dNSName": [
+                    "venafi.com"
+                  ]
+                },
+                "subjectCN": "venafi.com",
+                "subjectDN": "cn=venafi.com,ou=devops,o=venafi,c=MX,st=Yucatan,l=Merida",
+                "validityPeriod": "P12D"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CertificateRequestInformation2"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRequestResubmissionRequest": {
+        "properties": {
+          "certificateIssuingTemplateId": {
+            "description": "Certificate issuing template UUID",
+            "example": "a305d810-886f-11ed-9ccf-dbf748eb1ae0",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateOwnerUserId": {
+            "description": "Certificate owner UUID",
+            "example": "a305d810-886f-11ed-4bbe-dbf748eb1ae0",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateUsageMetadata": {
+            "description": "A collection of certificate request metadata",
+            "example": [
+              {
+                "appName": "venafi app1",
+                "automationMetadata": "automation data 008",
+                "nodeName": "venafi node 007"
+              },
+              {
+                "appName": "venafi app2",
+                "automationMetadata": "automation data 0013",
+                "nodeName": "venafi node 005"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CertificateUsageMetadata"
+            },
+            "type": "array"
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "P10M",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateResponse": {
+        "properties": {
+          "certificates": {
+            "description": "A collection of certificates",
+            "items": {
+              "$ref": "#/components/schemas/CertificateInformation"
+            },
+            "type": "array"
+          },
+          "count": {
+            "description": "The number of certificates.",
+            "example": 2,
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRetirementRequest": {
+        "properties": {
+          "addToBlocklist": {
+            "description": "This parameter ensures the deleted certificate will not be discovered again.",
+            "example": true,
+            "type": "boolean"
+          },
+          "certificateIds": {
+            "description": "A collection of certificates UUIDs",
+            "example": [
+              "f2b42d60-df9c-11ed-b8ab-4788d83ace9f",
+              "f2c173d0-df9c-11ed-b8ab-4788d83ace9f"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "certificateIds"
+        ],
+        "type": "object"
+      },
+      "CertificateRevocationApprovalConditionsFilterRuleInformation": {
+        "properties": {
+          "certificateAuthorityAccountIds": {
+            "description": "A collection of certificate authority account ids the rule will be applicable to",
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "certificateAuthorityAccountIds"
+        ],
+        "type": "object"
+      },
+      "CertificateRevocationApprovalExceptionsFilterRuleInformation": {
+        "properties": {
+          "applicationIds": {
+            "description": "A collection of application ids the rule won't be applied to",
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "requestors": {
+            "description": "A collection of approvers, specified by type and id, for which the rule won't be applied",
+            "items": {
+              "$ref": "#/components/schemas/ApproverProperty"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRevocationApprovalRuleDeleteResponseOpenApi": {
+        "properties": {
+          "id": {
+            "description": "Approval rule `id`",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Approval rule name",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRevocationApprovalRuleOpenApi": {
+        "properties": {
+          "approvers": {
+            "description": "A collection of approvers specified by type and id",
+            "items": {
+              "$ref": "#/components/schemas/ApproverProperty"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "atLeast": {
+            "description": "If the type of the approval is AT_LEAST then specify how many people have to approve",
+            "format": "int32",
+            "type": "integer"
+          },
+          "autoRejectionThreshold": {
+            "description": "Auto rejection threshold. After the defined number of days since revoke request creation, the request is automatically rejected, if it is not approved",
+            "example": 5,
+            "maximum": 99,
+            "minimum": 1,
+            "type": "number"
+          },
+          "conditions": {
+            "$ref": "#/components/schemas/CertificateRevocationApprovalConditionsFilterRuleInformation"
+          },
+          "creationDate": {
+            "description": "The date a approval rule was created",
+            "example": "2023-01-10T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "exceptions": {
+            "$ref": "#/components/schemas/CertificateRevocationApprovalExceptionsFilterRuleInformation"
+          },
+          "finalApprover": {
+            "$ref": "#/components/schemas/ApproverPropertyOpenApi"
+          },
+          "id": {
+            "description": "Approval rule `id`",
+            "format": "uuid",
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "The date a approval rule was modified",
+            "example": "2023-01-11T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "description": "Approval rule name",
+            "type": "string"
+          },
+          "priority": {
+            "description": "Priority of the rule",
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": {
+            "description": "The type of the approval rule",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRevocationApprovalRulesRequest": {
+        "properties": {
+          "approvers": {
+            "description": "A collection of approvers specified by type and id",
+            "items": {
+              "$ref": "#/components/schemas/ApproverProperty"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "atLeast": {
+            "description": "If the type of the approval is AT_LEAST then specify how many people have to approve",
+            "example": 2,
+            "format": "int32",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "autoRejectionThreshold": {
+            "description": "Auto rejection threshold. After the defined number of days since revocation request creation, the request is automatically rejected, if it is not approved",
+            "example": 5,
+            "maximum": 99,
+            "minimum": 1,
+            "type": "number"
+          },
+          "conditions": {
+            "$ref": "#/components/schemas/CertificateRevocationApprovalConditionsFilterRuleInformation"
+          },
+          "continueProcessingOnException": {
+            "default": false,
+            "description": "Continue with next approval rules when match an approval rule exception condition",
+            "type": "boolean"
+          },
+          "exceptions": {
+            "$ref": "#/components/schemas/CertificateRevocationApprovalExceptionsFilterRuleInformation"
+          },
+          "finalApprover": {
+            "description": "UUID of the final approver",
+            "example": "8268d820-a08d-11ed-bbc0-252385d6d390",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Approval rule name",
+            "example": "Approval rule for built in CA",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of the approval rule",
+            "enum": [
+              "ALL",
+              "AT_LEAST"
+            ],
+            "example": "AT_LEAST",
+            "type": "string"
+          }
+        },
+        "required": [
+          "approvers",
+          "conditions",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "CertificateRevocationApprovalRulesResponseOpenApi": {
+        "properties": {
+          "approvalRules": {
+            "items": {
+              "$ref": "#/components/schemas/CertificateRevocationApprovalRuleOpenApi"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateRevocationApprovalRulesUpdateRequest": {
+        "properties": {
+          "approvers": {
+            "description": "A collection of approvers specified by type and id",
+            "items": {
+              "$ref": "#/components/schemas/ApproverProperty"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "atLeast": {
+            "description": "If the type of the approval is AT_LEAST then specify how many people have to approve",
+            "example": 2,
+            "format": "int32",
+            "minimum": 1,
+            "type": "integer"
+          },
+          "autoRejectionThreshold": {
+            "description": "Auto rejection threshold. After the defined number of days since revocation request creation, the request is automatically rejected, if it is not approved",
+            "example": 5,
+            "maximum": 99,
+            "minimum": 1,
+            "type": "number"
+          },
+          "conditions": {
+            "$ref": "#/components/schemas/CertificateRevocationApprovalConditionsFilterRuleInformation"
+          },
+          "continueProcessingOnException": {
+            "default": false,
+            "description": "Continue with next approval rules when match an approval rule exception condition",
+            "type": "boolean"
+          },
+          "exceptions": {
+            "$ref": "#/components/schemas/CertificateRevocationApprovalExceptionsFilterRuleInformation"
+          },
+          "finalApprover": {
+            "description": "UUID of the final approver",
+            "example": "8268d820-a08d-11ed-bbc0-252385d6d390",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Approval rule name",
+            "example": "Approval rule for built in CA",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "priority": {
+            "description": "Rule priority. The order in which the rules will be executed. Starts from 1 (highest priority).",
+            "example": 5,
+            "minimum": 1,
+            "type": "number"
+          },
+          "type": {
+            "description": "The type of the approval rule",
+            "enum": [
+              "ALL",
+              "AT_LEAST"
+            ],
+            "example": "AT_LEAST",
+            "type": "string"
+          }
+        },
+        "required": [
+          "approvers",
+          "conditions",
+          "name",
+          "type"
+        ],
+        "type": "object"
+      },
+      "CertificateUsageMetadata": {
+        "properties": {
+          "appName": {
+            "type": "string"
+          },
+          "automationMetadata": {
+            "type": "string"
+          },
+          "nodeName": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateValidationRequest": {
+        "properties": {
+          "certificateIds": {
+            "description": "A collection of certificates UUIDs  ",
+            "example": [
+              "f2b42d60-df9c-11ed-b8ab-4788d83ace9f",
+              "f2c173d0-df9c-11ed-b8ab-4788d83ace9f"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "certificateIds"
+        ],
+        "type": "object"
+      },
+      "CertificateValidationResponse": {
+        "properties": {
+          "fingerprints": {
+            "description": "A collection of certificate's fingerprints",
+            "example": [
+              "2C85B0AD64F55AA70BAC75F69711578DC505C3F9",
+              "051ECFBD202B0383A7745F479F978C8E9FA9ADE1"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "CertificationRequestInformation": {
+        "properties": {
+          "hashAlgorithm": {
+            "description": "A certificate request signature hash algorithm",
+            "enum": [
+              "MD5",
+              "SHA1",
+              "MD2",
+              "SHA224",
+              "SHA256",
+              "SHA384",
+              "SHA512",
+              "UNKNOWN",
+              "GOSTR3411_94"
+            ],
+            "example": "SHA256",
+            "type": "string"
+          },
+          "keyCurve": {
+            "description": "Certificate request key length",
+            "enum": [
+              "P256",
+              "P384",
+              "P521",
+              "ED25519",
+              "UNKNOWN"
+            ],
+            "example": "P256",
+            "type": "string"
+          },
+          "keyLength": {
+            "description": "Certificate request key length",
+            "example": 2048,
+            "format": "int32",
+            "type": "integer"
+          },
+          "keyType": {
+            "description": "Certificate request key type",
+            "enum": [
+              "RSA",
+              "DSA",
+              "EC",
+              "GOST3410",
+              "ECGOST3410",
+              "RESERVED3",
+              "UNKNOWN"
+            ],
+            "example": "RSA",
+            "type": "string"
+          },
+          "publicKeyHash": {
+            "description": "A certificate request public hash key",
+            "example": "0048AA1D7E2F0017F9CA2E687D8776A1A340553D",
+            "type": "string"
+          },
+          "signatureAlgorithm": {
+            "description": "A certificate request signature algorithm",
+            "enum": [
+              "MD2_WITH_RSA_ENCRYPTION",
+              "MD5_WITH_RSA_ENCRYPTION",
+              "SHA1_WITH_RSA_ENCRYPTION",
+              "SHA1_WITH_RSA_ENCRYPTION2",
+              "SHA256_WITH_RSA_ENCRYPTION",
+              "SHA384_WITH_RSA_ENCRYPTION",
+              "SHA512_WITH_RSA_ENCRYPTION",
+              "ID_DSA_WITH_SHA1",
+              "dsaWithSHA1",
+              "EC_DSA_WITH_SHA1",
+              "EC_DSA_WITH_SHA224",
+              "EC_DSA_WITH_SHA256",
+              "EC_DSA_WITH_SHA384",
+              "EC_DSA_WITH_SHA512",
+              "UNKNOWN",
+              "SHA1_WITH_RSAandMGF1",
+              "GOST_R3411_94_WITH_GOST_R3410_2001",
+              "GOST_R3411_94_WITH_GOST_R3410_94"
+            ],
+            "example": "SHA256_WITH_RSA_ENCRYPTION",
+            "type": "string"
+          },
+          "subjectAlternativeNamesByType": {
+            "$ref": "#/components/schemas/GeneralNamesData2"
+          },
+          "subjectDN": {
+            "description": "A certificate request subject DN",
+            "example": "cn=www.venafi.com,o=Venafi, Inc.,c=US,st=Utah,l=Salt Lake City",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Channel": {
+        "enum": [
+          "email"
+        ],
+        "type": "string"
+      },
+      "ChartDetails": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ClientAuthenticationInformation": {
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/JwtStandardClaimsAuthenticationInformation"
+          },
+          {
+            "$ref": "#/components/schemas/JwtJwksAuthenticationInformation"
+          },
+          {
+            "$ref": "#/components/schemas/JwtOidcAuthenticationInformation"
+          }
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "ClientAuthenticationOpenApi": {
+        "discriminator": {
+          "mapping": {
+            "JWT_JWKS": "#/components/schemas/JwtJwksAuthenticationOpenApi",
+            "JWT_OIDC": "#/components/schemas/JwtOidcAuthenticationOpenApi",
+            "JWT_STANDARD_CLAIMS": "#/components/schemas/JwtStandardClaimsAuthenticationOpenApi"
+          },
+          "propertyName": "type"
+        },
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ClientAuthenticationRequestOpenApi": {
+        "properties": {
+          "clientAuthentication": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/JwtStandardClaimsAuthenticationOpenApi"
+              },
+              {
+                "$ref": "#/components/schemas/JwtJwksAuthenticationOpenApi"
+              },
+              {
+                "$ref": "#/components/schemas/JwtOidcAuthenticationOpenApi"
+              }
+            ],
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ClientAuthorizationInformation": {
+        "properties": {
+          "customClaimsAliases": {
+            "$ref": "#/components/schemas/CustomClaimsAliasesInformation"
+          }
+        },
+        "type": "object"
+      },
+      "CloudProvidersInformation": {
+        "properties": {
+          "aws": {
+            "$ref": "#/components/schemas/AwsCloudProviderInformation"
+          },
+          "azure": {
+            "$ref": "#/components/schemas/AzureCloudProviderInformation"
+          },
+          "google": {
+            "$ref": "#/components/schemas/GoogleCloudProviderInformation"
+          }
+        },
+        "type": "object"
+      },
+      "CompanyId": {
+        "description": "The company ID",
+        "format": "uuid",
+        "readOnly": true,
+        "type": "string"
+      },
+      "Condition": {
+        "description": "A Condition for filtering",
+        "properties": {
+          "field": {
+            "description": "Represents a field for filtering",
+            "example": "certificateName",
+            "type": "string"
+          },
+          "operator": {
+            "description": "An operator for filtering",
+            "enum": [
+              "EQ",
+              "LT",
+              "LTE",
+              "GT",
+              "GTE",
+              "MATCH",
+              "FIND",
+              "IN"
+            ],
+            "example": "EQ",
+            "type": "string"
+          },
+          "value": {
+            "description": "represents a field's value",
+            "example": "venafi.com",
+            "type": "string"
+          },
+          "values": {
+            "description": "represents a field's values",
+            "example": [
+              "venafi.com",
+              "www.venafi.com"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ConfigurationCreateRequest": {
+        "properties": {
+          "advancedSettings": {
+            "$ref": "#/components/schemas/AdvancedSettingsInformation"
+          },
+          "clientAuthentication": {
+            "$ref": "#/components/schemas/ClientAuthenticationInformation"
+          },
+          "clientAuthorization": {
+            "$ref": "#/components/schemas/ClientAuthorizationInformation"
+          },
+          "cloudProviders": {
+            "$ref": "#/components/schemas/CloudProvidersInformation"
+          },
+          "minTlsVersion": {
+            "description": "Minimum required TLS protocol version",
+            "enum": [
+              "TLS12",
+              "TLS13"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the configuration",
+            "example": "Some configuration",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "policyIds": {
+            "description": "Array of UUIDs of policies to associate with the new configuration",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "serviceAccountIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subCaProviderId": {
+            "description": "UUID of Sub CA provider to associate with the new configuration",
+            "example": "2f3c6030-b1e0-11ed-a3ed-e3dbaf56a746",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "policyIds",
+          "subCaProviderId"
+        ],
+        "type": "object"
+      },
+      "ConfigurationDeleteResponse": {
+        "properties": {
+          "id": {
+            "description": "UUID of the configuration",
+            "example": "7268d820-a08d-11ed-bbc0-252385d6d389",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the configuration",
+            "example": "Some configuration",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ConfigurationInformation": {
+        "properties": {
+          "advancedSettings": {
+            "$ref": "#/components/schemas/AdvancedSettingsInformation"
+          },
+          "clientAuthentication": {
+            "$ref": "#/components/schemas/ClientAuthenticationInformation"
+          },
+          "clientAuthorization": {
+            "$ref": "#/components/schemas/ClientAuthorizationInformation"
+          },
+          "cloudProviders": {
+            "$ref": "#/components/schemas/CloudProvidersInformation"
+          },
+          "companyId": {
+            "description": "UUID specific to your company",
+            "example": "03eb6e61-9806-11ed-84f2-c747fb71e467",
+            "format": "uuid",
+            "type": "string"
+          },
+          "controllerAllowedPolicyIds": {
+            "description": "Array of UUIDs of policies that the kubernetes controller is permitted to use",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "creationDate": {
+            "description": "When the configuration was initially created",
+            "example": "2022-10-10T14:50:41.710+00:00",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of the configuration",
+            "example": "7268d820-a08d-11ed-bbc0-252385d6d389",
+            "format": "uuid",
+            "type": "string"
+          },
+          "longLivedCertCount": {
+            "description": "Number of long lived certificates",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          },
+          "minTlsVersion": {
+            "description": "Minimum required TLS protocol version",
+            "enum": [
+              "TLS12",
+              "TLS13"
+            ],
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "When the configuration was last modified",
+            "example": "2023-12-12T20:00:10.500+00:00",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the configuration",
+            "example": "Some configuration",
+            "type": "string"
+          },
+          "policyIds": {
+            "description": "Array of UUIDs of policies to associate with the configuration",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "serviceAccountIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "shortLivedCertCount": {
+            "description": "Number of short lived certificates",
+            "example": 20,
+            "format": "int64",
+            "type": "integer"
+          },
+          "subTsgId": {
+            "description": "Sub-TSG ID that owns this configuration (null for Primary TSG)",
+            "example": "a007d406bf",
+            "type": "string"
+          },
+          "ultraShortLivedCertCount": {
+            "description": "Number of ultra short lived certificates",
+            "example": 200,
+            "format": "int64",
+            "type": "integer"
+          },
+          "unixSocketAllowedPolicyIds": {
+            "description": "Array of UUIDs of policies that are permitted to be used when using the unix socket",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ConfigurationResponse": {
+        "properties": {
+          "configurations": {
+            "items": {
+              "$ref": "#/components/schemas/ExtendedConfigurationInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ConfigurationUpdateRequest": {
+        "properties": {
+          "advancedSettings": {
+            "$ref": "#/components/schemas/AdvancedSettingsInformation"
+          },
+          "clientAuthentication": {
+            "$ref": "#/components/schemas/ClientAuthenticationRequestOpenApi"
+          },
+          "clientAuthorization": {
+            "$ref": "#/components/schemas/ClientAuthorizationInformation"
+          },
+          "cloudProviders": {
+            "$ref": "#/components/schemas/CloudProvidersInformation"
+          },
+          "minTlsVersion": {
+            "description": "Minimum required TLS protocol version",
+            "enum": [
+              "TLS12",
+              "TLS13"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the configuration",
+            "example": "Some configuration",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "policyIds": {
+            "description": "Array of UUIDs of policies to associate with the configuration",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "serviceAccountIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subCaProviderId": {
+            "description": "UUID of Sub CA provider to associate with the configuration",
+            "example": "2f3c6030-b1e0-11ed-a3ed-e3dbaf56a746",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ConnectorsCreationRequest": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/WebhookProperties"
+          }
+        },
+        "required": [
+          "name",
+          "properties"
+        ],
+        "type": "object"
+      },
+      "ConnectorsInformation": {
+        "properties": {
+          "id": {
+            "description": "Unique identifier of the connector.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Human-readable name of the connector.",
+            "type": "string"
+          },
+          "properties": {
+            "$ref": "#/components/schemas/WebhookProperties"
+          },
+          "status": {
+            "description": "Current status of the connector (for example, enabled or disabled).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "status",
+          "properties"
+        ],
+        "type": "object"
+      },
+      "ConnectorsResponse": {
+        "properties": {
+          "connectors": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorsInformation"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "connectors"
+        ],
+        "type": "object"
+      },
+      "ConnectorsUpdateRequest": {
+        "properties": {
+          "properties": {
+            "$ref": "#/components/schemas/WebhookProperties"
+          }
+        },
+        "required": [
+          "properties"
+        ],
+        "type": "object"
+      },
+      "CreateCMSConfigurationRequest": {
+        "description": "The information representing a Credential Manager Service configuration for creation purpose.",
+        "properties": {
+          "cmsDetails": {
+            "$ref": "#/components/schemas/CreateCMSDetails"
+          },
+          "cmsType": {
+            "$ref": "#/components/schemas/CMSType"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "vSatelliteIds": {
+            "$ref": "#/components/schemas/VSatelliteIds"
+          }
+        },
+        "required": [
+          "cmsType",
+          "vSatelliteIds",
+          "cmsDetails"
+        ],
+        "type": "object"
+      },
+      "CreateCMSConfigurationsRequest": {
+        "description": "The array of Credential Manager Service configurations to create.",
+        "properties": {
+          "cmsConfigurations": {
+            "items": {
+              "$ref": "#/components/schemas/CreateCMSConfigurationRequest"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "cmsConfigurations"
+        ],
+        "type": "object"
+      },
+      "CreateCMSConfigurationsResponse": {
+        "description": "The array of Credential Manager Service configurations created.",
+        "properties": {
+          "cmsConfigurationsCreated": {
+            "items": {
+              "$ref": "#/components/schemas/CMSConfigurationResponse"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cmsConfigurationsCreated",
+          "count"
+        ],
+        "type": "object"
+      },
+      "CreateCMSDetails": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CreateCyberArkDetails"
+          },
+          {
+            "$ref": "#/components/schemas/CreateHashiCorpDetails"
+          }
+        ]
+      },
+      "CreateCredentialDetails": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CreateCyberArkCredDetails"
+          },
+          {
+            "$ref": "#/components/schemas/CreateHashiCorpCredDetails"
+          }
+        ]
+      },
+      "CreateCyberArkCredDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CyberArkDetailsRequiredProp"
+          }
+        ]
+      },
+      "CreateCyberArkDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CyberArkConfigurationRequiredProp"
+          }
+        ]
+      },
+      "CreateHashiCorpCredDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HashiCorpDetailsRequiredProp"
+          }
+        ]
+      },
+      "CreateHashiCorpDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HashiCorpConfigurationRequiredProp"
+          }
+        ]
+      },
+      "CreateServiceAccountRequestBody": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ServiceAccountBaseObject"
+          },
+          {
+            "required": [
+              "name",
+              "scopes"
+            ],
+            "type": "object"
+          }
+        ],
+        "example": {
+          "applications": [
+            "dc96438b-7a80-464b-a09b-9e5ec746c3e3",
+            "5bce5ff4-a69b-4e78-9b7e-6d4029995000"
+          ],
+          "authenticationType": "rsaKey",
+          "credentialLifetime": 30,
+          "name": "Firefly SA",
+          "owner": "2620f8e0-fdbf-11ee-b275-2754a4f7e272",
+          "publicKey": "-----BEGIN PUBLIC KEY-----\\nMCowBQYDK2VwAyEAzRCyRWzXlyhFp3RcUrum1Q6j7YR8jyL0L1fWnh7zgt4=\\n-----END PUBLIC KEY-----",
+          "scopes": [
+            "distributed-issuance"
+          ]
+        }
+      },
+      "CreateServiceAccountResponseBody": {
+        "example": {
+          "id": "933507dd-0286-11ef-bc25-8a00a468403f",
+          "privateKey": "-----BEGIN PRIVATE KEY-----\n⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆⋆\n-----END PRIVATE KEY-----\n",
+          "publicKey": "-----BEGIN PUBLIC KEY-----\\nMCowBQYDK2VwAyEAzRCyRWzXlyhFp3RcUrum1Q6j7YR8jyL0L1fWnh7zgt4=\\n-----END PUBLIC KEY-----"
+        },
+        "properties": {
+          "id": {
+            "description": "The ID for this service account",
+            "format": "UUID",
+            "type": "string",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/google/uuid"
+            }
+          },
+          "ociAccountName": {
+            "description": "The OCI account name generated for a robot in case of the registry scope",
+            "type": "string"
+          },
+          "ociRegistryToken": {
+            "description": "The OCI registry token generated for a robot in case of the registry scope",
+            "type": "string"
+          },
+          "privateKey": {
+            "description": "The generated private key for the service account when not providing a public key on the create payload",
+            "type": "string"
+          },
+          "publicKey": {
+            "description": "The generated public key for the service account when not providing a public key on the create payload",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CreatedBy": {
+        "description": "The ID of the user whom created the credential.",
+        "type": "string"
+      },
+      "CreatedOn": {
+        "description": "The date in ISO 8601 full-date format when the credential was created.",
+        "format": "date",
+        "type": "string"
+      },
+      "CredentialId": {
+        "description": "The ID of the Credential in our System.",
+        "example": "94e86140-d85f-11ed-afa1-0242ac120002",
+        "format": "uuid",
+        "type": "string"
+      },
+      "CredentialName": {
+        "description": "The name of the Credential in our System.",
+        "type": "string"
+      },
+      "CredentialResponse": {
+        "description": "The properties representing a Credential for response purposes.",
+        "properties": {
+          "authType": {
+            "$ref": "#/components/schemas/AuthType"
+          },
+          "cmsConfigId": {
+            "$ref": "#/components/schemas/CMSConfId"
+          },
+          "cmsType": {
+            "$ref": "#/components/schemas/CMSType"
+          },
+          "createdBy": {
+            "$ref": "#/components/schemas/CreatedBy"
+          },
+          "createdOn": {
+            "$ref": "#/components/schemas/CreatedOn"
+          },
+          "credentialDetails": {
+            "$ref": "#/components/schemas/ResponseCredentialDetails"
+          },
+          "id": {
+            "$ref": "#/components/schemas/CredentialId"
+          },
+          "lastModifiedBy": {
+            "$ref": "#/components/schemas/LastModifiedBy"
+          },
+          "lastModifiedOn": {
+            "$ref": "#/components/schemas/LastModifiedOn"
+          },
+          "name": {
+            "$ref": "#/components/schemas/CredentialName"
+          },
+          "references": {
+            "$ref": "#/components/schemas/References"
+          },
+          "teamsIds": {
+            "$ref": "#/components/schemas/TeamsIds"
+          },
+          "tsgId": {
+            "$ref": "#/components/schemas/TSGId"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "cmsConfigId",
+          "authType",
+          "cmsType"
+        ],
+        "type": "object"
+      },
+      "CustomAttributes1": {
+        "description": "A certificate request custom attributes",
+        "example": {
+          "dnsNames": [
+            "www.venafi.com",
+            "venafi.com"
+          ]
+        },
+        "properties": {
+          "dnsNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "overwriteSans": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "CustomAttributes2": {
+        "description": "Certificate request custom attributes",
+        "example": {
+          "dnsNames": [
+            "www.venafi.com",
+            "venafi.com"
+          ]
+        },
+        "properties": {
+          "dnsNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "overwriteSans": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "CustomAttributesInformation": {
+        "description": "Represents custom attributes for certificate requests",
+        "properties": {
+          "dnsNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "overwriteSans": {
+            "description": "Defines if the csr sans should be overwritten by the custom attributes dns sans",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "dnsNames"
+        ],
+        "type": "object"
+      },
+      "CustomClaimsAliasesInformation": {
+        "properties": {
+          "allowAllPolicies": {
+            "maxLength": 128,
+            "type": "string"
+          },
+          "allowedPolicies": {
+            "maxLength": 128,
+            "type": "string"
+          },
+          "configuration": {
+            "maxLength": 128,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CyberArkConfiguration": {
+        "allOf": [
+          {
+            "properties": {
+              "appID": {
+                "$ref": "#/components/schemas/AppId"
+              },
+              "baseUrl": {
+                "$ref": "#/components/schemas/CMSURL"
+              }
+            },
+            "type": "object"
+          },
+          {
+            "$ref": "#/components/schemas/CertificateCredentialData"
+          }
+        ],
+        "description": "The configuration for the CyberArk app. It's required to set the value for the `cmsType` property to `cyberark`."
+      },
+      "CyberArkConfigurationRequiredProp": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CyberArkConfiguration"
+          }
+        ],
+        "description": "The configuration for the CyberArk app. It's required to set the value for the `cmsType` property to `cyberark`.",
+        "required": [
+          "appID",
+          "baseUrl"
+        ]
+      },
+      "CyberArkDetails": {
+        "description": "The CyberArk Credential information.",
+        "properties": {
+          "folder": {
+            "description": "The folder property into the CyberArk Safe.",
+            "type": "string"
+          },
+          "objectName": {
+            "description": "The account's name which represents the credential in the CyberArk instance.",
+            "type": "string"
+          },
+          "safe": {
+            "description": "The CyberArk Safe property.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CyberArkDetailsRequiredProp": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CyberArkDetails"
+          }
+        ],
+        "required": [
+          "objectName",
+          "safe"
+        ]
+      },
+      "DailyPatternInformation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SchedulerPatternInformation2"
+          },
+          {
+            "properties": {
+              "duration": {
+                "description": "Duration in ISO-8601 format",
+                "enum": [
+                  "PT8H",
+                  "PT12H",
+                  "PT24H"
+                ],
+                "example": "PT24H",
+                "type": "string"
+              },
+              "startTime": {
+                "description": "Start time in HH:mm:ss format",
+                "pattern": "^([01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "required": [
+          "duration",
+          "startTime"
+        ],
+        "type": "object"
+      },
+      "DeleteCredentialsResponse": {
+        "description": "The response for the delete credentials action.",
+        "properties": {
+          "count": {
+            "type": "integer"
+          },
+          "idsCredentialsDeleted": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialId"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "idsCredentialsDeleted",
+          "count"
+        ],
+        "type": "object"
+      },
+      "Deployment": {
+        "properties": {
+          "executionTarget": {
+            "default": "vsat",
+            "description": "HELP",
+            "type": "string"
+          },
+          "image": {
+            "description": "URL for where the plugin image resides.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "image",
+          "executionTarget"
+        ],
+        "title": "Deployment",
+        "type": "object",
+        "x-examples": {
+          "Example 1": {
+            "deployment": {
+              "executionTarget": "vsat",
+              "image": "public.ecr.aws/docker/library/nginx:mainline-alpine3.18-slim"
+            }
+          }
+        }
+      },
+      "Details": {
+        "properties": {
+          "credentialsExpiringOn": {
+            "description": "The exact date on which the credentials will expire",
+            "format": "date-time",
+            "type": "string"
+          },
+          "enabled": {
+            "description": "Indicates if the given service account must be enabled or disabled where disable means that the credentials cannot be used for",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "The ID for this service account",
+            "format": "UUID",
+            "type": "string",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/google/uuid"
+            }
+          },
+          "lastUsedOn": {
+            "description": "The last time the account credentials were used to authenticate a machine",
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedBy": {
+            "description": "The UUID of the latest user that modified the account",
+            "format": "UUID",
+            "type": "string",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/google/uuid"
+            }
+          },
+          "updatedOn": {
+            "description": "The last time the account details were updated",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Direction": {
+        "description": "An ordering direction",
+        "enum": [
+          "ASC",
+          "DESC"
+        ],
+        "example": "DESC",
+        "type": "string"
+      },
+      "EdgeInstanceConnectionDetails": {
+        "properties": {
+          "activeMessageCount": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "edgeInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "expiredMessageCount": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "failedMessageCount": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "lastConnectedDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "lastDisconnectedDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "EdgeInstanceHealthDetails": {
+        "properties": {
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "edgeInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "hsmStatus": {
+            "$ref": "#/components/schemas/HSMEdgeStatus"
+          },
+          "installedCharts": {
+            "items": {
+              "$ref": "#/components/schemas/NamespaceChartDetails"
+            },
+            "type": "array"
+          },
+          "nodeStatus": {
+            "items": {
+              "$ref": "#/components/schemas/NodeStatusDetails"
+            },
+            "type": "array"
+          },
+          "systemstatus": {
+            "items": {
+              "$ref": "#/components/schemas/NamespaceStatusDetails"
+            },
+            "type": "array"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "EdgeInstanceInformation": {
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "canRestore": {
+            "type": "boolean"
+          },
+          "clientId": {
+            "type": "string"
+          },
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "deploymentDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "edgeStatus": {
+            "$ref": "#/components/schemas/EdgeStatus"
+          },
+          "edgeType": {
+            "$ref": "#/components/schemas/EdgeType"
+          },
+          "encryptionKeyDeploymentDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "encryptionKeyId": {
+            "type": "string"
+          },
+          "environmentId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "integrationServicesCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "kubernetesVersion": {
+            "type": "string"
+          },
+          "lastSeenOnDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "modificationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "pairingCodeId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "primaryInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "productEntitlements": {
+            "items": {
+              "$ref": "#/components/schemas/ProductEntitlement"
+            },
+            "type": "array"
+          },
+          "reconciliationFailed": {
+            "type": "boolean"
+          },
+          "satelliteVersion": {
+            "type": "string"
+          },
+          "serviceAccountId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "statusDetails": {
+            "$ref": "#/components/schemas/EdgeInstanceStatusDetailsInformation"
+          },
+          "upgradeOrderPriority": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "upgradeStatus": {
+            "$ref": "#/components/schemas/UpgradeStatus"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "workerStatusDetails": {
+            "items": {
+              "$ref": "#/components/schemas/EdgeWorkerStatusDetailsInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "EdgeInstanceRequest": {
+        "properties": {
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "upgradeOrderPriority": {
+            "format": "int32",
+            "maximum": 100,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "EdgeInstanceResponse": {
+        "properties": {
+          "edgeInstances": {
+            "items": {
+              "$ref": "#/components/schemas/EdgeInstanceInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "EdgeInstanceStatusDetailsInformation": {
+        "properties": {
+          "connectionDetails": {
+            "items": {
+              "$ref": "#/components/schemas/EdgeInstanceConnectionDetails"
+            },
+            "type": "array"
+          },
+          "healthDetails": {
+            "items": {
+              "$ref": "#/components/schemas/EdgeInstanceHealthDetails"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "EdgeStatus": {
+        "enum": [
+          "ACTIVE",
+          "LOST_CONNECTION",
+          "REGISTERED",
+          "PAIRED",
+          "LOST_CONNECTION_DURING_INSTALL",
+          "INSTALLED",
+          "INSTALL_FAILED",
+          "UNHEALTHY",
+          "ERROR",
+          "INSTALLING"
+        ],
+        "type": "string"
+      },
+      "EdgeType": {
+        "enum": [
+          "ALL",
+          "HUB",
+          "SATELLITE"
+        ],
+        "type": "string"
+      },
+      "EdgeWorkerDeleteResponse": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "pairingCode": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "EdgeWorkerHealthDetails": {
+        "properties": {
+          "age": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "cpuUsage": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "edgeInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "edgeWorkerId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "host": {
+            "type": "string"
+          },
+          "memoryUsage": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "port": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "services": {
+            "items": {
+              "$ref": "#/components/schemas/WorkerServiceStatusDetails"
+            },
+            "type": "array"
+          },
+          "status": {
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "EdgeWorkerInformation": {
+        "properties": {
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "edgeInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "environmentId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "hiddenPairingCode": {
+            "type": "string"
+          },
+          "host": {
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "lastSeenOnDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "pairingCode": {
+            "type": "string"
+          },
+          "pairingPublicKey": {
+            "type": "string"
+          },
+          "port": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/components/schemas/WorkerStatus"
+          }
+        },
+        "type": "object"
+      },
+      "EdgeWorkerRequest": {
+        "properties": {
+          "edgeInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "host": {
+            "type": "string"
+          },
+          "port": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "EdgeWorkerStatusDetailsInformation": {
+        "properties": {
+          "edgeWorkerId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "healthDetails": {
+            "items": {
+              "$ref": "#/components/schemas/EdgeWorkerHealthDetails"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "EdgeWorkersResponse": {
+        "properties": {
+          "edgeWorkers": {
+            "items": {
+              "$ref": "#/components/schemas/EdgeWorkerInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "EncryptionDetails": {
+        "properties": {
+          "encryptionType": {
+            "enum": [
+              "RSA",
+              "DSA",
+              "EC",
+              "GOST3410",
+              "ECGOST3410",
+              "RESERVED3",
+              "UNKNOWN"
+            ],
+            "type": "string"
+          },
+          "value": {
+            "$ref": "#/components/schemas/AnyValue4"
+          }
+        },
+        "type": "object"
+      },
+      "EncryptionKeyInformation": {
+        "properties": {
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          },
+          "keyAlgorithm": {
+            "$ref": "#/components/schemas/KeyAlgorithm"
+          },
+          "lastBackupDate": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "EncryptionKeysResponse": {
+        "properties": {
+          "encryptionKeys": {
+            "items": {
+              "$ref": "#/components/schemas/EncryptionKeyInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "EntityTag": {
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "weak": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "Error": {
+        "description": "Hold the error details.",
+        "properties": {
+          "args": {
+            "description": "List of arguments used to generate the error message.",
+            "items": {
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "code": {
+            "description": "The error code.",
+            "type": "integer"
+          },
+          "message": {
+            "description": "The error message.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "ErrorInformation1": {
+        "properties": {
+          "args": {
+            "items": {
+              "$ref": "#/components/schemas/AnyValue1"
+            },
+            "type": "array"
+          },
+          "code": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorInformation2": {
+        "properties": {
+          "args": {
+            "items": {
+              "$ref": "#/components/schemas/AnyValue2"
+            },
+            "type": "array"
+          },
+          "code": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorInformation3": {
+        "properties": {
+          "args": {
+            "items": {
+              "$ref": "#/components/schemas/AnyValue3"
+            },
+            "type": "array"
+          },
+          "code": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorInformation4": {
+        "properties": {
+          "args": {
+            "items": {
+              "$ref": "#/components/schemas/AnyValue4"
+            },
+            "type": "array"
+          },
+          "code": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorInformation5": {
+        "properties": {
+          "args": {
+            "items": {
+              "$ref": "#/components/schemas/AnyValue5"
+            },
+            "type": "array"
+          },
+          "code": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorInformation6": {
+        "properties": {
+          "args": {
+            "items": {
+              "$ref": "#/components/schemas/AnyValue6"
+            },
+            "type": "array"
+          },
+          "code": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorInformation7": {
+        "properties": {
+          "args": {
+            "items": {
+              "$ref": "#/components/schemas/AnyValue7"
+            },
+            "type": "array"
+          },
+          "code": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorInformation8": {
+        "properties": {
+          "args": {
+            "items": {
+              "$ref": "#/components/schemas/AnyValue8"
+            },
+            "type": "array"
+          },
+          "code": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorInformation9": {
+        "properties": {
+          "args": {
+            "items": {
+              "$ref": "#/components/schemas/AnyValue9"
+            },
+            "type": "array"
+          },
+          "code": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorResponse1": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorInformation1"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorResponse10": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorInformation9"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorResponse2": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorInformation2"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorResponse3": {
+        "description": "Holds the response body returned for errors.",
+        "properties": {
+          "errors": {
+            "description": "List of encountered errors.",
+            "items": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorResponse4": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorInformation3"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorResponse5": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorInformation4"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorResponse6": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorInformation5"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorResponse7": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorInformation6"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorResponse8": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorInformation7"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorResponse9": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorInformation8"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ExportedActivityLogEntryInformation": {
+        "properties": {
+          "activityDate": {
+            "description": "The date when a log entry was produced",
+            "example": "2023-01-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "activityName": {
+            "description": "An activity name",
+            "example": "Login Succeeded",
+            "type": "string"
+          },
+          "activityType": {
+            "description": "An activity type",
+            "example": "Authentication",
+            "type": "string"
+          },
+          "criticality": {
+            "description": "An activity criticality",
+            "example": 0,
+            "format": "int32",
+            "type": "integer"
+          },
+          "id": {
+            "description": "UUID of a log entry",
+            "example": "2eb29780-9046-11ed-8e50-b994b27d2ece",
+            "format": "uuid",
+            "type": "string"
+          },
+          "message": {
+            "description": "An activity log message",
+            "example": "user logged in",
+            "type": "string"
+          },
+          "payload": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "Expression": {
+        "type": "object"
+      },
+      "ExtendedApplicationOwnership": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "owningTeams": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "owningUsers": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ExtendedCertificateInformation": {
+        "properties": {
+          "applicationIds": {
+            "description": "A collection of application IDs",
+            "example": [
+              "561baf7c-98b7-49af-ab9c-7b3a9fea3028",
+              "4adeba6f-0c94-4595-a5b6-babea458249f"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "archivedDate": {
+            "description": "The date a certificate was archived",
+            "example": "2022-05-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "authorityKeyIdentifierHash": {
+            "description": "An authority key identifier hash",
+            "example": "40572B10F85DDAF18BFF987372178532AB875BCA",
+            "type": "string"
+          },
+          "certificateAuthorityAccountId": {
+            "description": "UUID  of a certificate authority account",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateName": {
+            "description": "A certificate name",
+            "example": "venafi.com",
+            "type": "string"
+          },
+          "certificateRequestId": {
+            "description": "UUID  of a certificate request",
+            "example": "2e8964a0-9046-11ed-8e50-b994b27d2ece",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateStatus": {
+            "description": "Certificate's status",
+            "enum": [
+              "ACTIVE",
+              "RETIRED",
+              "DELETED"
+            ],
+            "example": "ACTIVE",
+            "type": "string"
+          },
+          "companyId": {
+            "description": "UUID  of a company",
+            "example": "85595df0-8e14-11ed-87e3-755db050f29d",
+            "format": "uuid",
+            "type": "string"
+          },
+          "dekHash": {
+            "description": "A certificate dek hash",
+            "example": "RaBDrLmQ69hACXOrPU6542RBT-M-yZOkw4XKsT-r55i=",
+            "type": "string"
+          },
+          "encryptionType": {
+            "description": "A certificate encryption type",
+            "enum": [
+              "RSA",
+              "DSA",
+              "EC",
+              "GOST3410",
+              "ECGOST3410",
+              "RESERVED3",
+              "UNKNOWN"
+            ],
+            "example": "EC",
+            "type": "string"
+          },
+          "extendedKeyUsage": {
+            "description": "A collection of certificate extended key usages",
+            "example": [
+              "1.3.6.1.5.5.7.3.2",
+              "1.3.6.1.5.5.7.3.1"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "fingerprint": {
+            "description": "A certificate fingerprint",
+            "example": "6D4C95512C117B004191F1A096ECAD13242FCD9F",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of a certificate",
+            "example": "2eb29780-9046-11ed-8e50-b994b27d2ece",
+            "format": "uuid",
+            "type": "string"
+          },
+          "inhibitAnyPolicy": {
+            "description": "Inhibit any policy",
+            "example": 150,
+            "format": "int32",
+            "type": "integer"
+          },
+          "inhibitPolicyMapping": {
+            "description": "Inhibit policy mapping",
+            "example": 200,
+            "format": "int32",
+            "type": "integer"
+          },
+          "instances": {
+            "description": "A collection of certificate instances information",
+            "example": [
+              {
+                "certificateId": "7ec12010-9051-11ed-8e50-b994b27d2ece",
+                "certificateInstanceId": "7ec1bc50-9051-11ed-8e50-b994b27d2ece",
+                "certificateSource": "USER_SCAN",
+                "deploymentStatus": "IN_USE",
+                "hostname": "venafi.com",
+                "instanceChainValidationStatus": [
+                  "OK"
+                ],
+                "ipAddress": "23.185.0.2",
+                "lastScanDate": "2023-01-09T19:12:05.314+00:00",
+                "lastValidatedAttempt": "2023-01-09T19:12:05.446+00:00",
+                "modificationDate": "2023-01-09T19:12:14.865+00:00",
+                "port": 443,
+                "serviceIds": [
+                  "1d61e9e0-9046-11ed-bf12-53a1b041cf25"
+                ],
+                "sslProtocols": [
+                  "TLSv1.3",
+                  "TLSv1.2"
+                ],
+                "sslValidationErrorArguments": [],
+                "sslValidationStatus": "OK"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CertificateInstanceInformation"
+            },
+            "type": "array"
+          },
+          "issuerAlternativeNameDns": {
+            "description": "A collection of certificate issuer alternative names DNs",
+            "example": [
+              "venafi.com",
+              "www.venafi.com"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuerAlternativeNameNonDns": {
+            "description": "A collection of certificate issuer alternative name none DNs",
+            "example": [
+              "venafi issuer doman"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuerC": {
+            "description": "A certificate issues Country",
+            "example": "US",
+            "type": "string"
+          },
+          "issuerCN": {
+            "description": "A collection of certificate issuer Common names",
+            "example": [
+              "HydrantID SSL CA G3"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuerCertificateIds": {
+            "description": "A collection of issuer certificate IDs",
+            "example": [
+              "2e8964a0-9046-11ed-8e50-b994b27d2ece",
+              "d5b418a0-297e-11eb-bc4c-8b24e5a66fb6"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuerCertificates": {
+            "description": "A collection of certificate information",
+            "items": {
+              "$ref": "#/components/schemas/CertificateInformation"
+            },
+            "type": "array"
+          },
+          "issuerDN": {
+            "description": "A certificate issue DN",
+            "example": "cn=HydrantID SSL CA G3,o=HydrantID (Avalanche Cloud Corporation),c=US",
+            "type": "string"
+          },
+          "issuerL": {
+            "description": "A certificate issues Locality",
+            "example": "Salt Lake City",
+            "type": "string"
+          },
+          "issuerOU": {
+            "description": "A collection of certificate issuer Organization units",
+            "example": [
+              "Issuer CA"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuerST": {
+            "description": "A certificate issuer State",
+            "example": "Utah",
+            "type": "string"
+          },
+          "keyCurve": {
+            "description": "A certificate key curve",
+            "enum": [
+              "P256",
+              "P384",
+              "P521",
+              "ED25519",
+              "UNKNOWN"
+            ],
+            "example": "P256",
+            "type": "string"
+          },
+          "keyStrength": {
+            "description": "A certificate key strength",
+            "example": 2048,
+            "format": "int32",
+            "type": "integer"
+          },
+          "keyUsage": {
+            "description": "A collection of certificate key usages",
+            "example": [
+              "digitalSignature",
+              "keyEncipherment"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "lastNotification": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "managedCertificateId": {
+            "description": "UUID  of a managed certificate",
+            "example": "2f0e7320-9046-11ed-8ab8-19e0a618d9cd",
+            "format": "uuid",
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "The last date a certificate was modified",
+            "example": "2022-03-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "ocspNoCheck": {
+            "description": "If a certificate no ocsp check",
+            "example": false,
+            "type": "boolean"
+          },
+          "ownership": {
+            "$ref": "#/components/schemas/CertificateOwnership"
+          },
+          "pathLength": {
+            "description": "A certificate path length",
+            "example": 3,
+            "format": "int32",
+            "type": "integer"
+          },
+          "requireExplicitPolicy": {
+            "description": "Required explicit policy is required",
+            "example": 1,
+            "format": "int32",
+            "type": "integer"
+          },
+          "selfSigned": {
+            "description": "If the certificate is self singed",
+            "example": true,
+            "type": "boolean"
+          },
+          "serialNumber": {
+            "description": "A certificate serial number",
+            "example": "0C51A562B02A19A222FFB4730C47A8E2",
+            "type": "string"
+          },
+          "signatureAlgorithm": {
+            "description": "A certificate signature algorithm",
+            "enum": [
+              "MD2_WITH_RSA_ENCRYPTION",
+              "MD5_WITH_RSA_ENCRYPTION",
+              "SHA1_WITH_RSA_ENCRYPTION",
+              "SHA1_WITH_RSA_ENCRYPTION2",
+              "SHA256_WITH_RSA_ENCRYPTION",
+              "SHA384_WITH_RSA_ENCRYPTION",
+              "SHA512_WITH_RSA_ENCRYPTION",
+              "ID_DSA_WITH_SHA1",
+              "dsaWithSHA1",
+              "EC_DSA_WITH_SHA1",
+              "EC_DSA_WITH_SHA224",
+              "EC_DSA_WITH_SHA256",
+              "EC_DSA_WITH_SHA384",
+              "EC_DSA_WITH_SHA512",
+              "UNKNOWN",
+              "SHA1_WITH_RSAandMGF1",
+              "GOST_R3411_94_WITH_GOST_R3410_2001",
+              "GOST_R3411_94_WITH_GOST_R3410_94"
+            ],
+            "example": "SHA256_WITH_RSA_ENCRYPTION",
+            "type": "string"
+          },
+          "signatureHashAlgorithm": {
+            "description": "A certificate signature hash algorithm",
+            "enum": [
+              "MD5",
+              "SHA1",
+              "MD2",
+              "SHA224",
+              "SHA256",
+              "SHA384",
+              "SHA512",
+              "UNKNOWN",
+              "GOSTR3411_94"
+            ],
+            "example": "SHA256",
+            "type": "string"
+          },
+          "statusModificationDate": {
+            "description": "The date a certificate's status was modified",
+            "example": "2022-04-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "statusModificationUserId": {
+            "description": "UUID of the user that modified the certificate installation",
+            "example": "3c9964a0-9046-11ed-8e50-b994b27d2ece",
+            "format": "uuid",
+            "type": "string"
+          },
+          "subjectAlternativeNameDns": {
+            "description": "A collection of certificate subject alternative names DNs",
+            "example": [
+              "venafi.com",
+              "www.venafi.com"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectAlternativeNameNonDns": {
+            "description": "A collection of certificate subject alternative name none DNs",
+            "example": [
+              "venafi domain"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectAlternativeNamesByType": {
+            "$ref": "#/components/schemas/GeneralNamesData2"
+          },
+          "subjectC": {
+            "description": "A certificate subject Country",
+            "example": "US",
+            "type": "string"
+          },
+          "subjectCN": {
+            "description": "A collection of certificate subject CNs",
+            "example": [
+              "venafi.com",
+              "cloud.venafi"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectDN": {
+            "description": "A certificate subject DN",
+            "example": "cn=www.venafi.com,o=Venafi, Inc.,c=US,st=Utah,l=Salt Lake City",
+            "type": "string"
+          },
+          "subjectKeyIdentifierHash": {
+            "description": "A subject key identifier hash",
+            "example": "4E0CE93D3240561F468C33A85F08FCD3B04CC9DC",
+            "type": "string"
+          },
+          "subjectL": {
+            "description": "A certificate subject Locality",
+            "example": "Salt Lake City",
+            "type": "string"
+          },
+          "subjectO": {
+            "description": "A certificate subject Organization",
+            "example": "Venafi, Inc.",
+            "type": "string"
+          },
+          "subjectOU": {
+            "description": "A collection of certificate subject Organization units",
+            "example": [
+              "devops",
+              "test"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectST": {
+            "description": "A certificate subject State",
+            "example": "Utah",
+            "type": "string"
+          },
+          "tags": {
+            "description": "A collection of tags",
+            "example": [
+              "owner:test.user",
+              "90-day"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "totalActiveInstanceCount": {
+            "description": "total active instances of a certificate",
+            "example": 50,
+            "format": "int32",
+            "type": "integer"
+          },
+          "totalInstanceCount": {
+            "description": "total instances of a certificate",
+            "example": 100,
+            "format": "int32",
+            "type": "integer"
+          },
+          "validityEnd": {
+            "description": "The date a certificate validity ends",
+            "example": "2023-01-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "validityStart": {
+            "description": "The date a certificate validity starts",
+            "example": "2022-01-24T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "versionType": {
+            "description": "A certificate version type",
+            "enum": [
+              "OLD",
+              "CURRENT"
+            ],
+            "example": "CURRENT",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ExtendedCertificateInstanceInformation": {
+        "properties": {
+          "applicationIds": {
+            "description": "A collection of application IDs",
+            "example": [
+              "d3cce873-6957-4071-a65e-7676c0ae1123",
+              "322bcd99-286a-47ea-8dcd-8291ec5bff14"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "certificate": {
+            "$ref": "#/components/schemas/CertificateInformation"
+          },
+          "certificateId": {
+            "description": "UUID of a certificate",
+            "example": "2eb29780-9046-11ed-8e50-b994b27d2ece",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateInstanceId": {
+            "description": "UUID of a certificate instance",
+            "example": "f68daf30-4690-45bc-85b3-bb327024735e",
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateSource": {
+            "description": "Certificate source",
+            "enum": [
+              "UNKNOWN",
+              "USER_PROVIDED",
+              "USER_IMPORTED",
+              "USER_SCAN",
+              "TRUSTNET_SCAN",
+              "ON_PREM_CA_IMPORT",
+              "EXTERNAL_CA_IMPORT",
+              "FILE_IMPORT",
+              "EXTERNAL_SCAN",
+              "DOMAIN_SCAN",
+              "SMART_SCAN_INTERNAL",
+              "SMART_SCAN_EXTERNAL",
+              "SMART_VALIDATION_INTERNAL",
+              "SMART_VALIDATION_EXTERNAL",
+              "MACHINE_DISCOVERY",
+              "KUBERNETES_DISCOVERY",
+              "AWS_DISCOVERY",
+              "AZURE_DISCOVERY",
+              "GCP_DISCOVERY"
+            ],
+            "example": "USER_SCAN",
+            "type": "string"
+          },
+          "deploymentStatus": {
+            "description": "The deployment status",
+            "enum": [
+              "UNKNOWN",
+              "IN_USE",
+              "SUPERSEDED"
+            ],
+            "example": "IN_USE",
+            "type": "string"
+          },
+          "hostname": {
+            "description": "A hostname",
+            "example": "venafi.com",
+            "type": "string"
+          },
+          "instanceChainValidationStatus": {
+            "description": "A collection of the instance chain validation status",
+            "example": [
+              "OK"
+            ],
+            "items": {
+              "enum": [
+                "OK",
+                "CHAIN_BUILDING_FAILED",
+                "INCOMPLETE_CHAIN",
+                "CHAIN_EXPIRE_BEFORE_EE",
+                "DISTRUSTED",
+                "UNKNOWN_ERROR",
+                "SELF_SIGNED"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ipAddress": {
+            "description": "An ip address",
+            "example": "14.183.1.32",
+            "type": "string"
+          },
+          "lastScanDate": {
+            "description": "The last scan date",
+            "example": "2023-01-10T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "lastValidatedAttempt": {
+            "description": "The last validation attempt date",
+            "example": "2023-01-11T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "The last modification date",
+            "example": "2023-01-10T09:12:28Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "port": {
+            "description": "A port number",
+            "example": 443,
+            "format": "int32",
+            "type": "integer"
+          },
+          "serviceIds": {
+            "description": "A collection of service IDs",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sslProtocols": {
+            "description": "A collection of ssl protocols",
+            "example": [
+              "TLSv1.1",
+              "TLSv1.2"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sslValidationErrorArguments": {
+            "description": "A collection of ssl validation error arguments",
+            "example": [
+              "B69950CC5F51EDDF55F36AD2BC898767BC43CC2A",
+              "24E5796GA7298E78EDE47D6FAED0790E8F464G54"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sslValidationStatus": {
+            "description": "SSL validation status",
+            "enum": [
+              "HOSTNAME_NOT_RESOLVABLE",
+              "NO_CERTIFICATE_PRESENTED",
+              "INVALID_CERTIFICATE_FOUND",
+              "UNEXPECTED_CERTIFICATE_FOUND",
+              "OLD_VERSION_CERTIFICATE_FOUND",
+              "TARGET_UNREACHABLE",
+              "UNKNOWN_ERROR",
+              "OK"
+            ],
+            "example": "OK",
+            "type": "string"
+          },
+          "sslValidationStatusMessage": {
+            "description": "SSL validation status message",
+            "example": "Certificate installation is using older versions of certificate",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ExtendedCertificateInstanceResponse": {
+        "properties": {
+          "count": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "instances": {
+            "items": {
+              "$ref": "#/components/schemas/ExtendedCertificateInstanceInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ExtendedConfigurationInformation": {
+        "properties": {
+          "advancedSettings": {
+            "$ref": "#/components/schemas/AdvancedSettingsInformation"
+          },
+          "clientAuthentication": {
+            "$ref": "#/components/schemas/ClientAuthenticationInformation"
+          },
+          "clientAuthorization": {
+            "$ref": "#/components/schemas/ClientAuthorizationInformation"
+          },
+          "cloudProviders": {
+            "$ref": "#/components/schemas/CloudProvidersInformation"
+          },
+          "companyId": {
+            "description": "UUID specific to your company",
+            "example": "03eb6e61-9806-11ed-84f2-c747fb71e467",
+            "format": "uuid",
+            "type": "string"
+          },
+          "controllerAllowedPolicyIds": {
+            "description": "Array of UUIDs of policies that the kubernetes controller is permitted to use",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "creationDate": {
+            "description": "When the configuration was initially created",
+            "example": "2022-10-10T14:50:41.710+00:00",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of the configuration",
+            "example": "7268d820-a08d-11ed-bbc0-252385d6d389",
+            "format": "uuid",
+            "type": "string"
+          },
+          "longLivedCertCount": {
+            "description": "Number of long lived certificates",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          },
+          "minTlsVersion": {
+            "description": "Minimum required TLS protocol version",
+            "enum": [
+              "TLS12",
+              "TLS13"
+            ],
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "When the configuration was last modified",
+            "example": "2023-12-12T20:00:10.500+00:00",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the configuration",
+            "example": "Some configuration",
+            "type": "string"
+          },
+          "policies": {
+            "items": {
+              "$ref": "#/components/schemas/PolicyInformation"
+            },
+            "type": "array"
+          },
+          "policyDefinitions": {
+            "items": {
+              "$ref": "#/components/schemas/PolicyInformation"
+            },
+            "type": "array"
+          },
+          "policyIds": {
+            "description": "Array of UUIDs of policies to associate with the configuration",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "serviceAccountIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "shortLivedCertCount": {
+            "description": "Number of short lived certificates",
+            "example": 20,
+            "format": "int64",
+            "type": "integer"
+          },
+          "subCaProvider": {
+            "$ref": "#/components/schemas/SubCaProviderInformation"
+          },
+          "subTsgId": {
+            "description": "Sub-TSG ID that owns this configuration (null for Primary TSG)",
+            "example": "a007d406bf",
+            "type": "string"
+          },
+          "ultraShortLivedCertCount": {
+            "description": "Number of ultra short lived certificates",
+            "example": 200,
+            "format": "int64",
+            "type": "integer"
+          },
+          "unixSocketAllowedPolicyIds": {
+            "description": "Array of UUIDs of policies that are permitted to be used when using the unix socket",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ExtendedPolicyInformation": {
+        "properties": {
+          "companyId": {
+            "description": "UUID specific to your company",
+            "example": "03eb6e61-9806-11ed-84f2-c747fb71e467",
+            "format": "uuid",
+            "type": "string"
+          },
+          "configurations": {
+            "items": {
+              "$ref": "#/components/schemas/ConfigurationInformation"
+            },
+            "type": "array"
+          },
+          "creationDate": {
+            "description": "When the policy was initially created",
+            "example": "2022-10-10T14:50:41.710+00:00",
+            "type": "string"
+          },
+          "extendedKeyUsages": {
+            "description": "Extended key usages",
+            "example": [
+              "CLIENT_AUTH",
+              "SERVER_AUTH"
+            ],
+            "items": {
+              "enum": [
+                "ANY",
+                "SERVER_AUTH",
+                "CLIENT_AUTH",
+                "CODE_SIGNING",
+                "EMAIL_PROTECTION",
+                "IPSEC_ENDSYSTEM",
+                "IPSEC_TUNNEL",
+                "IPSEC_USER",
+                "TIME_STAMPING",
+                "OCSP_SIGNING",
+                "DVCS",
+                "SBGP_CERT_AA_SERVER_AUTH",
+                "SCVP_RESPONDER",
+                "EAP_OVER_PPP",
+                "EAP_OVER_LAN",
+                "SCVP_SERVER",
+                "SCVP_CLIENT",
+                "IPSEC_IKE",
+                "CAPWAP_AC",
+                "CAPWAP_WTP",
+                "IPSEC_IKE_INTERMEDIATE",
+                "SMARTCARD_LOGON"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "UUID of the policy",
+            "example": "8ae92800-b1e0-11ed-859d-b39255f965ee",
+            "format": "uuid",
+            "type": "string"
+          },
+          "keyAlgorithm": {
+            "$ref": "#/components/schemas/KeyAlgorithmInformation"
+          },
+          "keyUsages": {
+            "description": "Key usages",
+            "example": [
+              "keyEncipherment",
+              "digitalSignature"
+            ],
+            "items": {
+              "enum": [
+                "digitalSignature",
+                "nonRepudiation",
+                "keyEncipherment",
+                "dataEncipherment",
+                "keyAgreement",
+                "keyCertSign",
+                "cRLSign",
+                "encipherOnly",
+                "decipherOnly"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modificationDate": {
+            "description": "When the policy was last modified",
+            "example": "2023-12-12T20:00:10.500+00:00",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the policy",
+            "example": "Some policy",
+            "type": "string"
+          },
+          "sans": {
+            "$ref": "#/components/schemas/SansInformation"
+          },
+          "shareWithAll": {
+            "description": "Shared with all sub-TSGs",
+            "example": false,
+            "type": "boolean"
+          },
+          "sharedWithSubTsgIds": {
+            "items": {
+              "description": "Sub-TSG IDs this policy is shared with",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "subject": {
+            "$ref": "#/components/schemas/SubjectAttributesInformation"
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "P30D",
+            "format": "PnYnMnDTnHnMnS",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Facet": {
+        "properties": {
+          "domain": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AnyValue2"
+            },
+            "type": "object"
+          },
+          "facets": {
+            "items": {
+              "$ref": "#/components/schemas/Facet"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Filter1": {
+        "format": "json",
+        "type": "string"
+      },
+      "Filter2": {
+        "properties": {
+          "expression": {
+            "$ref": "#/components/schemas/BaseFilter"
+          },
+          "ordering": {
+            "$ref": "#/components/schemas/BaseOrdering"
+          },
+          "paging": {
+            "$ref": "#/components/schemas/Page2"
+          }
+        },
+        "type": "object"
+      },
+      "FilterOperand": {
+        "properties": {
+          "operand": {
+            "$ref": "#/components/schemas/Condition"
+          },
+          "operator": {
+            "description": "An operator for filtering",
+            "enum": [
+              "NOT"
+            ],
+            "example": "NOT",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "FilterOperands": {
+        "properties": {
+          "operands": {
+            "description": "A list of conditions that will be used for filtering",
+            "example": [
+              {
+                "field": "certificateStatus",
+                "operator": "EQ",
+                "value": "ACTIVE"
+              },
+              {
+                "field": "certificateName",
+                "operator": "EQ",
+                "value": "venafi.com"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/BaseFilter"
+            },
+            "type": "array"
+          },
+          "operator": {
+            "description": "An operator for filtering",
+            "enum": [
+              "AND",
+              "OR"
+            ],
+            "example": "OR",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "GeneralNamesData1": {
+        "description": "A certificate request subject alternative name (SAN) type",
+        "example": {
+          "dNSName": [
+            "www.venafi.com",
+            "venafi.com"
+          ]
+        },
+        "properties": {
+          "dNSName": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "directoryName": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ediPartyName": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "iPAddress": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "otherName": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "registeredID": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "rfc822Name": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "uniformResourceIdentifier": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "x400Address": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "GeneralNamesData2": {
+        "description": "A certificate subject alternative name by type",
+        "example": {
+          "dNSName": [
+            "www.venafi.com",
+            "venafi.com"
+          ]
+        },
+        "properties": {
+          "dNSName": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "directoryName": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ediPartyName": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "iPAddress": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "otherName": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "registeredID": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "rfc822Name": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "uniformResourceIdentifier": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "x400Address": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "GetCMSConfigurationsResponse": {
+        "description": "The array of Credential Manager Service configurations received.",
+        "properties": {
+          "cmsConfigurations": {
+            "items": {
+              "$ref": "#/components/schemas/CMSConfigurationResponse"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "cmsConfigurations",
+          "count"
+        ],
+        "type": "object"
+      },
+      "GetCredentialsResponse": {
+        "description": "Array of credentials received.",
+        "properties": {
+          "count": {
+            "type": "integer"
+          },
+          "credentials": {
+            "items": {
+              "$ref": "#/components/schemas/CredentialResponse"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "credentials",
+          "count"
+        ],
+        "type": "object"
+      },
+      "GetServiceAccountScopesResponseBody": {
+        "example": [
+          {
+            "authenticationType": "rsaKey",
+            "id": "distributed-issuance",
+            "readableName": "Distributed Issuance"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/ScopeDetails"
+        },
+        "type": "array"
+      },
+      "GetServiceAccountsByClientIDResponseBody": {
+        "$ref": "#/components/schemas/ServiceAccountDetails"
+      },
+      "GetServiceAccountsResponseBody": {
+        "example": [
+          {
+            "authenticationType": "rsaKey",
+            "companyId": "145f12e0-fdbf-11ee-b275-2754a4f7e272",
+            "credentialLifetime": 365,
+            "credentialsExpiringOn": "2025-01-01T00:00:00.000000Z",
+            "enabled": true,
+            "id": "933507dd-0286-11ef-bc25-8a00a468403f",
+            "name": "Service Account I",
+            "owner": "2620f8e0-fdbf-11ee-b275-2754a4f7e272",
+            "scopes": [
+              "distributed-issuance"
+            ],
+            "updatedBy": "150760d0-fdbf-11ee-b275-2754a4f7e272",
+            "updatedOn": "2024-01-01T00:00:00.000000Z"
+          },
+          {
+            "authenticationType": "rsaKey",
+            "companyId": "145f12e0-fdbf-11ee-b275-2754a4f7e272",
+            "credentialLifetime": 365,
+            "credentialsExpiringOn": "2025-01-01T00:00:00.000000Z",
+            "enabled": true,
+            "id": "933507dd-0286-11ef-bc25-8a00a468403a",
+            "name": "Service Account II",
+            "owner": "2620f8e0-fdbf-11ee-b275-2754a4f7e272",
+            "scopes": [
+              "distributed-issuance"
+            ],
+            "updatedBy": "150760d0-fdbf-11ee-b275-2754a4f7e272",
+            "updatedOn": "2024-01-01T00:00:00.000000Z"
+          }
+        ],
+        "items": {
+          "$ref": "#/components/schemas/ServiceAccountDetailsNoKey"
+        },
+        "type": "array"
+      },
+      "GoogleCloudProviderInformation": {
+        "properties": {
+          "projectIdentifiers": {
+            "description": "Array of Google project identifiers each of which should be a string with int64 number or 6 to 30 lowercase letters, digits, or hyphens, should start with a letter and not contain trailing hyphens",
+            "example": [
+              "415104041262",
+              "tokyo-rain-123"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "regions": {
+            "description": "Array of Google regions",
+            "example": [
+              "us-west1"
+            ],
+            "items": {
+              "enum": [
+                "asia-east1",
+                "asia-east2",
+                "asia-northeast1",
+                "asia-northeast2",
+                "asia-northeast3",
+                "asia-south1",
+                "asia-south2",
+                "asia-southeast1",
+                "asia-southeast2",
+                "australia-southeast1",
+                "australia-southeast2",
+                "europe-central2",
+                "europe-north1",
+                "europe-southwest1",
+                "europe-west1",
+                "europe-west12",
+                "europe-west2",
+                "europe-west3",
+                "europe-west4",
+                "europe-west6",
+                "europe-west8",
+                "europe-west9",
+                "me-central1",
+                "me-west1",
+                "northamerica-northeast1",
+                "northamerica-northeast2",
+                "southamerica-east1",
+                "southamerica-west1",
+                "us-central1",
+                "us-east1",
+                "us-east4",
+                "us-east5",
+                "us-south1",
+                "us-west1",
+                "us-west2",
+                "us-west3",
+                "us-west4"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "projectIdentifiers",
+          "regions"
+        ],
+        "type": "object"
+      },
+      "HSMEdgeStatus": {
+        "enum": [
+          "HSM_ERROR",
+          "HSM_NOT_CONFIGURED",
+          "HSM_LOST_CONNECTION",
+          "HSM_HEALTHY"
+        ],
+        "type": "string"
+      },
+      "HashiCorpConfiguration": {
+        "allOf": [
+          {
+            "properties": {
+              "authType": {
+                "$ref": "#/components/schemas/CMSAuthenticationType"
+              },
+              "namespace": {
+                "description": "The namespace in HashiCorp Vault to connect to.",
+                "type": "string"
+              },
+              "url": {
+                "$ref": "#/components/schemas/CMSURL"
+              }
+            },
+            "required": [
+              "authType"
+            ],
+            "type": "object"
+          },
+          {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CertificateCredentialData"
+              },
+              {
+                "$ref": "#/components/schemas/UserPasswordAuthenticationData"
+              },
+              {
+                "$ref": "#/components/schemas/TokenAuthenticationData"
+              },
+              {
+                "$ref": "#/components/schemas/AppRoleAuthenticationData"
+              }
+            ]
+          }
+        ],
+        "description": "The configuration for the HashiCorp app. It's required to set the value for the `cmsType` property to `hashicorp`."
+      },
+      "HashiCorpConfigurationRequiredProp": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HashiCorpConfiguration"
+          }
+        ],
+        "description": "The configuration for the HashiCorp app. It's required to set the value for the `cmsType` property to `hashicorp`.",
+        "required": [
+          "url"
+        ]
+      },
+      "HashiCorpDetails": {
+        "description": "The HashiCorp Credential information.",
+        "properties": {
+          "secretKeyName": {
+            "description": "The HashiCorp secret key name property.",
+            "type": "string"
+          },
+          "secretPath": {
+            "description": "The HashiCorp secret path property.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "HashiCorpDetailsRequiredProp": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HashiCorpDetails"
+          }
+        ],
+        "required": [
+          "secretPath",
+          "secretKeyName"
+        ]
+      },
+      "ImportedCertificateInformation": {
+        "properties": {
+          "apiClientInformation": {
+            "$ref": "#/components/schemas/ApiClientInformation"
+          },
+          "base64Certificate": {
+            "description": "Certificate base64 encoded format (PEM without header/footer",
+            "type": "string"
+          },
+          "certificateSource": {
+            "description": "A certificate source",
+            "enum": [
+              "UNKNOWN",
+              "USER_PROVIDED",
+              "USER_IMPORTED",
+              "USER_SCAN",
+              "TRUSTNET_SCAN",
+              "ON_PREM_CA_IMPORT",
+              "EXTERNAL_CA_IMPORT",
+              "FILE_IMPORT",
+              "EXTERNAL_SCAN",
+              "DOMAIN_SCAN",
+              "SMART_SCAN_INTERNAL",
+              "SMART_SCAN_EXTERNAL",
+              "SMART_VALIDATION_INTERNAL",
+              "SMART_VALIDATION_EXTERNAL",
+              "MACHINE_DISCOVERY",
+              "KUBERNETES_DISCOVERY",
+              "AWS_DISCOVERY",
+              "AZURE_DISCOVERY",
+              "GCP_DISCOVERY"
+            ],
+            "example": "USER_PROVIDED",
+            "type": "string"
+          },
+          "certificateUsageMetadata": {
+            "description": "A collection of certificate request metadata",
+            "example": [
+              {
+                "appName": "venafi app1",
+                "automationMetadata": "automation data 008",
+                "nodeName": "venafi node 007"
+              },
+              {
+                "appName": "venafi app2",
+                "automationMetadata": "automation data 0013",
+                "nodeName": "venafi node 005"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/CertificateUsageMetadata"
+            },
+            "type": "array"
+          },
+          "companyId": {
+            "description": "UUID of a company",
+            "example": "2d558b30-da16-11ed-8e4f-8339a1bc8d58",
+            "format": "uuid",
+            "type": "string"
+          },
+          "fingerprint": {
+            "description": "A certificate fingerprint",
+            "example": "2C85B0AD64F55AA70BAC75F69711578DC505C3F9",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of a Certificate",
+            "example": "16cb6940-e2de-11ed-a644-4fab0ea00b60",
+            "format": "uuid",
+            "type": "string"
+          },
+          "issuerCertificateIds": {
+            "description": "A collection of issuer certificates",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "managedCertificateId": {
+            "description": "UUID of a managed certificate",
+            "example": "17488880-e2de-11ed-aed6-79d407efea73",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationServiceCreationRequest": {
+        "properties": {
+          "edgeInstancesIds": {
+            "description": "A collection of Vsatellite instance IDs",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "environmentId": {
+            "description": "UUID of an environment",
+            "example": "2e8cfc70-74ce-11ed-9051-cfa579eae364",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Integration service name",
+            "example": "Internet discovery",
+            "minLength": 1,
+            "type": "string"
+          },
+          "scheduleEnabled": {
+            "description": "If a integration service is scheduled for execution",
+            "example": true,
+            "type": "boolean"
+          },
+          "schedulePattern": {
+            "$ref": "#/components/schemas/SchedulerPatternInformation3"
+          },
+          "serviceType": {
+            "description": "The type of an integration service",
+            "enum": [
+              "BASIC_DISCOVERY",
+              "ENHANCED_DISCOVERY",
+              "EXTERNAL_SCAN",
+              "INTERNET_DISCOVERY",
+              "SMART_DISCOVERY_EXTERNAL",
+              "KEY_GENERATION",
+              "MSCA",
+              "ACME"
+            ],
+            "example": "ENHANCED_DISCOVERY",
+            "type": "string"
+          },
+          "targets": {
+            "$ref": "#/components/schemas/TargetsInformation"
+          },
+          "workTypes": {
+            "description": "A collection of work types",
+            "items": {
+              "enum": [
+                "DISCOVER",
+                "MANAGE"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "environmentId",
+          "name",
+          "serviceType",
+          "workTypes"
+        ],
+        "type": "object"
+      },
+      "IntegrationServiceDetailsResponse": {
+        "properties": {
+          "integrationsServices": {
+            "items": {
+              "$ref": "#/components/schemas/IntegrationServiceInformation"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "description": "The total number of integration services returned",
+            "example": 10,
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationServiceInformation": {
+        "properties": {
+          "companyId": {
+            "description": "UUID of a company",
+            "example": "2b391680-74ce-11ed-bf7a-a3d5ccdf275c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "edgeInstancesIds": {
+            "description": "A collection of Vsatellite instance IDs",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "encryptionKeyId": {
+            "description": "Encryption key UUID",
+            "example": "41bb5280-7193-11ed-a059-a7f274bd0b5b",
+            "format": "uuid",
+            "type": "string"
+          },
+          "environmentId": {
+            "description": "UUID of an environment",
+            "example": "2e8cfc70-74ce-11ed-9051-cfa579eae364",
+            "format": "uuid",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of an integration service",
+            "example": "2e8d71a0-74ce-11ed-9051-cfa579eae364",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Integration service name",
+            "example": "Internet discovery",
+            "type": "string"
+          },
+          "schedulePattern": {
+            "$ref": "#/components/schemas/SchedulerPatternInformation3"
+          },
+          "schedulerEnabled": {
+            "description": "If a integration service is scheduled for execution",
+            "example": true,
+            "type": "boolean"
+          },
+          "serviceType": {
+            "description": "The type of an integration service",
+            "enum": [
+              "BASIC_DISCOVERY",
+              "ENHANCED_DISCOVERY",
+              "EXTERNAL_SCAN",
+              "INTERNET_DISCOVERY",
+              "SMART_DISCOVERY_EXTERNAL",
+              "KEY_GENERATION",
+              "MSCA",
+              "ACME"
+            ],
+            "example": "ENHANCED_DISCOVERY",
+            "type": "string"
+          },
+          "status": {
+            "description": "Integration service status",
+            "enum": [
+              "ACTIVE",
+              "DISABLED",
+              "RUNNING",
+              "WARNING",
+              "DRAFT",
+              "ERROR"
+            ],
+            "example": "DISABLED",
+            "type": "string"
+          },
+          "statusMessage": {
+            "description": "Integration service status message",
+            "example": "Integration service is disable",
+            "type": "string"
+          },
+          "systemGenerated": {
+            "description": "If an integration service was generated automatically",
+            "example": true,
+            "type": "boolean"
+          },
+          "targets": {
+            "$ref": "#/components/schemas/TargetsInformation"
+          },
+          "workTypes": {
+            "description": "A collection of work types",
+            "items": {
+              "enum": [
+                "DISCOVER",
+                "MANAGE"
+              ],
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "type": "object"
+      },
+      "IntegrationServiceUpdateRequest": {
+        "properties": {
+          "edgeInstancesIds": {
+            "description": "A collection of Vsatellite instance IDs",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "name": {
+            "description": "Integration service name",
+            "example": "Internet discovery",
+            "type": "string"
+          },
+          "scheduleEnabled": {
+            "description": "If a integration service is scheduled for execution",
+            "example": true,
+            "type": "boolean"
+          },
+          "schedulePattern": {
+            "$ref": "#/components/schemas/SchedulerPatternInformation3"
+          },
+          "targets": {
+            "$ref": "#/components/schemas/TargetsInformation"
+          },
+          "workTypes": {
+            "description": "A collection of work types",
+            "items": {
+              "enum": [
+                "DISCOVER",
+                "MANAGE"
+              ],
+              "type": "string"
+            },
+            "maxItems": 2147483647,
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "type": "object"
+      },
+      "IntermediateCertificateInformation": {
+        "properties": {
+          "certificate": {
+            "description": "Intermediate certificate bytes in PEM format",
+            "format": "PEM",
+            "type": "string"
+          },
+          "commonName": {
+            "description": "Common name of the Intermediate certificate",
+            "example": "example.com",
+            "type": "string"
+          },
+          "companyId": {
+            "description": "UUID specific to your company",
+            "example": "03eb6e61-9806-11ed-84f2-c747fb71e467",
+            "format": "uuid",
+            "type": "string"
+          },
+          "configuration": {
+            "$ref": "#/components/schemas/ConfigurationInformation"
+          },
+          "creationDate": {
+            "description": "When the intermediate certificate was created",
+            "example": "2022-10-10T14:50:41.710+00:00",
+            "type": "string"
+          },
+          "errorInformation": {
+            "$ref": "#/components/schemas/ErrorInformation9"
+          },
+          "fingerprint": {
+            "description": "Intermediate certificate fingerprint",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of the intermediate certificate",
+            "example": "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "issuerCertificates": {
+            "description": "Intermediate certificate chain bytes in PEM format",
+            "items": {
+              "description": "Intermediate certificate chain bytes in PEM format",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "longLivedCertCount": {
+            "description": "Number of long lived certificates",
+            "example": 1,
+            "format": "int64",
+            "type": "integer"
+          },
+          "modificationDate": {
+            "description": "When the intermediate certificate was last modified",
+            "example": "2023-12-12T20:00:10.500+00:00",
+            "type": "string"
+          },
+          "shortLivedCertCount": {
+            "description": "Number of short lived certificates",
+            "example": 10,
+            "format": "int64",
+            "type": "integer"
+          },
+          "status": {
+            "description": "Status of the Intermediate certificate request",
+            "example": "ISSUED",
+            "type": "string"
+          },
+          "ultraShortLivedCertCount": {
+            "description": "Number of ultra short lived certificates",
+            "example": 100,
+            "format": "int64",
+            "type": "integer"
+          },
+          "validityEnd": {
+            "description": "Intermediate certificate validity end date",
+            "type": "string"
+          },
+          "validityStart": {
+            "description": "Intermediate certificate validity start date",
+            "type": "string"
+          },
+          "workflowId": {
+            "description": "Intermediate certificate workflow id",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "IntermediateCertificateResponse": {
+        "properties": {
+          "intermediateCertificates": {
+            "items": {
+              "$ref": "#/components/schemas/IntermediateCertificateInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "InventoryMonitoringConfig": {
+        "discriminator": {
+          "mapping": {
+            "CERTIFICATE_EXPIRATION": "#/components/schemas/CertificateExpirationInventoryMonitoringConfig"
+          },
+          "propertyName": "inventoryMonitoringConfigurationType"
+        },
+        "properties": {
+          "inventoryMonitoringConfigurationType": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "InventoryMonitoringConfigRequest": {
+        "properties": {
+          "inventoryMonitoringConfiguration": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CertificateExpirationInventoryMonitoringConfig"
+              }
+            ],
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "InventoryMonitoringConfiguration": {
+        "discriminator": {
+          "propertyName": "inventoryMonitoringConfigurationType"
+        },
+        "properties": {
+          "inventoryMonitoringConfigurationType": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "inventoryMonitoringConfigurationType"
+        ],
+        "type": "object"
+      },
+      "InventoryMonitoringConfigurationResponse": {
+        "properties": {
+          "companyId": {
+            "description": "UUID specific to your company",
+            "example": "2b391680-74ce-11ed-bf7a-a3d5ccdf275c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "configuration": {
+            "$ref": "#/components/schemas/InventoryMonitoringConfiguration"
+          },
+          "id": {
+            "description": "UUID of the configuration",
+            "example": "2e8d71a0-74ce-11ed-9051-cfa579eae364",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "InventoryMonitoringSchedulerInformation": {
+        "properties": {
+          "name": {
+            "description": "Name of the configuration",
+            "type": "string"
+          },
+          "status": {
+            "description": "Status of the configuration",
+            "enum": [
+              "PENDING",
+              "RUNNING",
+              "DONE",
+              "FAILED"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "IssuingTemplateDomainsSyncInformation": {
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ErrorInformation4"
+          },
+          "issuingTemplateId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "COMPLETED",
+              "FAILED"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "IssuingTemplateDomainsSyncResponse": {
+        "properties": {
+          "issuingTemplatesInformationList": {
+            "items": {
+              "$ref": "#/components/schemas/IssuingTemplateDomainsSyncInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "IssuingTemplatesDomainsSyncRequest": {
+        "properties": {
+          "action": {
+            "enum": [
+              "REPLACE"
+            ],
+            "type": "string"
+          },
+          "certificateAuthorityAccountId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "issuingTemplatesIds": {
+            "description": "Set of UUIDs of the issuing templates",
+            "example": [
+              "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c"
+            ],
+            "items": {
+              "description": "Set of UUIDs of the issuing templates",
+              "format": "uuid",
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "action",
+          "certificateAuthorityAccountId",
+          "issuingTemplatesIds"
+        ],
+        "type": "object"
+      },
+      "JwtClient": {
+        "properties": {
+          "allowedPolicyIds": {
+            "description": "Array of UUIDs of policies that the client is permitted to use",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuer": {
+            "description": "Issuer of the JWT",
+            "example": "https://kubernetes.default.svc",
+            "type": "string"
+          },
+          "jwksUri": {
+            "description": "URL used to pull the trusted singing keys used for validation",
+            "example": "https://www.example.com:6443/jwks",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the client",
+            "example": "Some client",
+            "type": "string"
+          },
+          "subjects": {
+            "description": "Array of subjects of the JWT",
+            "example": [
+              "system:serviceaccount:venafi:application-team-1"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "JwtClientInformation": {
+        "properties": {
+          "allowedPolicyIds": {
+            "description": "Array of UUIDs of policies that the client is permitted to use",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "format": "uuid",
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "issuer": {
+            "description": "Issuer of the JWT",
+            "example": "https://kubernetes.default.svc",
+            "maxLength": 2048,
+            "type": "string"
+          },
+          "jwksUri": {
+            "description": "URL used to pull the trusted singing keys used for validation",
+            "example": "https://www.example.com:6443/jwks",
+            "maxLength": 2048,
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the client",
+            "example": "Some client",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "subjects": {
+            "description": "Array of subjects of the JWT",
+            "example": [
+              "system:serviceaccount:venafi:application-team-1"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "allowedPolicyIds",
+          "issuer",
+          "name",
+          "subjects"
+        ],
+        "type": "object"
+      },
+      "JwtJwksAuthenticationInformation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ClientAuthenticationInformation"
+          },
+          {
+            "properties": {
+              "urls": {
+                "description": "Array of JWT JWKS urls",
+                "example": [
+                  "https://jwks.example.com"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "required": [
+          "urls"
+        ],
+        "type": "object"
+      },
+      "JwtJwksAuthenticationOpenApi": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ClientAuthenticationOpenApi"
+          },
+          {
+            "properties": {
+              "urls": {
+                "description": "Array of JWT JWKS urls",
+                "example": [
+                  "https://jwks.example.com"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "object"
+      },
+      "JwtOidcAuthenticationInformation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ClientAuthenticationInformation"
+          },
+          {
+            "properties": {
+              "audience": {
+                "description": "OpenId audience",
+                "example": "Client1",
+                "maxLength": 256,
+                "type": "string"
+              },
+              "baseUrl": {
+                "description": "JWT OpenId base URL",
+                "example": "https://openid.example.com",
+                "maxLength": 2048,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "required": [
+          "audience",
+          "baseUrl"
+        ],
+        "type": "object"
+      },
+      "JwtOidcAuthenticationOpenApi": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ClientAuthenticationOpenApi"
+          },
+          {
+            "properties": {
+              "audience": {
+                "description": "OpenId audience",
+                "example": "Alpha testers",
+                "type": "string"
+              },
+              "baseUrl": {
+                "description": "JWT OpenId base URL",
+                "example": "https://oidc.example.com/",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "object"
+      },
+      "JwtStandardClaimsAuthenticationInformation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ClientAuthenticationInformation"
+          },
+          {
+            "properties": {
+              "audience": {
+                "description": "Recipients that the JWT is intended for",
+                "example": "Client1",
+                "maxLength": 256,
+                "type": "string"
+              },
+              "clients": {
+                "description": "List with clients, identified by processing JWTs that include standard/registered claims",
+                "items": {
+                  "$ref": "#/components/schemas/JwtClientInformation"
+                },
+                "minItems": 1,
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "required": [
+          "audience",
+          "clients"
+        ],
+        "type": "object"
+      },
+      "JwtStandardClaimsAuthenticationOpenApi": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ClientAuthenticationOpenApi"
+          },
+          {
+            "properties": {
+              "audience": {
+                "description": "Recipients that the JWT is intended for",
+                "example": "Client1",
+                "type": "string"
+              },
+              "clients": {
+                "description": "List with clients, identified by processing JWTs that include standard/registered claims",
+                "items": {
+                  "$ref": "#/components/schemas/JwtClient"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "type": "object"
+      },
+      "KeyAlgorithm": {
+        "enum": [
+          "RSA",
+          "ED25519",
+          "VSAT_HPKE"
+        ],
+        "type": "string"
+      },
+      "KeyAlgorithmInformation": {
+        "description": "Key algorithm",
+        "properties": {
+          "allowedValues": {
+            "description": "Key algorithm allowed values",
+            "items": {
+              "enum": [
+                "RSA_2048",
+                "RSA_3072",
+                "RSA_4096",
+                "EC_P256",
+                "EC_P384",
+                "EC_P521",
+                "EC_ED25519"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "defaultValue": {
+            "description": "Key algorithm default value",
+            "enum": [
+              "RSA_2048",
+              "RSA_3072",
+              "RSA_4096",
+              "EC_P256",
+              "EC_P384",
+              "EC_P521",
+              "EC_ED25519"
+            ],
+            "example": "RSA_4096",
+            "type": "string"
+          }
+        },
+        "required": [
+          "allowedValues",
+          "defaultValue"
+        ],
+        "type": "object"
+      },
+      "KeyTypeInformation": {
+        "discriminator": {
+          "propertyName": "keyType"
+        },
+        "properties": {
+          "keyType": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "KeyTypeParameters1": {
+        "properties": {
+          "keyCurves": {
+            "items": {
+              "enum": [
+                "P256",
+                "P384",
+                "P521",
+                "ED25519",
+                "UNKNOWN"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "keyLengths": {
+            "items": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "type": "array"
+          },
+          "keyType": {
+            "enum": [
+              "RSA",
+              "EC"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "keyType"
+        ],
+        "type": "object"
+      },
+      "KeyTypeParameters2": {
+        "properties": {
+          "keyCurve": {
+            "enum": [
+              "P256",
+              "P384",
+              "P521",
+              "ED25519",
+              "UNKNOWN"
+            ],
+            "type": "string"
+          },
+          "keyLength": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "keyType": {
+            "enum": [
+              "RSA",
+              "EC"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "keyCurve",
+          "keyLength",
+          "keyType"
+        ],
+        "type": "object"
+      },
+      "LastModifiedBy": {
+        "description": "The ID of the user whom modified the credential.",
+        "type": "string"
+      },
+      "LastModifiedOn": {
+        "description": "The date in ISO 8601 full-date format when the credential was modified.",
+        "format": "date",
+        "type": "string"
+      },
+      "Link": {
+        "properties": {
+          "params": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "rel": {
+            "type": "string"
+          },
+          "rels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "uri": {
+            "format": "uri",
+            "type": "string"
+          },
+          "uriBuilder": {
+            "$ref": "#/components/schemas/UriBuilder"
+          }
+        },
+        "type": "object"
+      },
+      "LocalizationResource": {
+        "description": "Translation map for the UI being rendered. This map is used with the manifest schema. The keys represent the values provided for the \"x-localizationKey\" property in the domain entity definition, and each key's value is used to represent field labels, enum values, or error messages.",
+        "nullable": true,
+        "properties": {
+          "en": {
+            "type": "object"
+          }
+        },
+        "title": "LocalizationResources",
+        "type": "object",
+        "x-examples": {
+          "Example 1": {
+            "en": {
+              "address": {
+                "label": "Server Hostname"
+              },
+              "binding": {
+                "label": "Server Store Details"
+              },
+              "certificateName": {
+                "description": "How the certificate should appear on the server.",
+                "label": "Certificate Name"
+              },
+              "chainName": {
+                "label": "Chain Bundle Name"
+              },
+              "discovery": {
+                "expiredCertificatesLabel": "Exclude expired certificates",
+                "inactiveProfilesLabel": "Exclude certificates that are not in use by either a virtual server or a monitor.",
+                "partitionDescription": "A comma separated list of partition names.",
+                "partitionLabel": "Partition(s)"
+              },
+              "discoveryType": {
+                "all": "Both Monitors and Virtual Servers",
+                "label": "Resource Types to Discover",
+                "monitor": "Monitors",
+                "virtualServer": "Virtual Servers"
+              },
+              "keystore": {
+                "label": "Certificate Information"
+              },
+              "parentProfile": {
+                "description": "No value is interpreted as \"clientssl\" or \"serverssl\" depending on the Profile Type selected.",
+                "label": "Parent Profile"
+              },
+              "partition": {
+                "description": "No value is interpreted as the \"Common\" partition.",
+                "label": "Partition"
+              },
+              "password": {
+                "hidePassword": "Hide Password",
+                "label": "Password",
+                "showPassword": "Show Password"
+              },
+              "port": {
+                "description": "No value is interpreted as 443.",
+                "label": "Port"
+              },
+              "serverName": {
+                "description": "An alternative DNS name used for Server Name Indication.",
+                "label": "SNI"
+              },
+              "sslProfile": {
+                "label": "SSL Profile"
+              },
+              "sslProfileType": {
+                "client": "Client SSL Profile",
+                "label": "Profile Type",
+                "server": "Server SSL Profile"
+              },
+              "username": {
+                "label": "Username"
+              }
+            }
+          }
+        }
+      },
+      "MachineBatchProvisioningResultInformation": {
+        "properties": {
+          "endDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "errorMessage": {
+            "type": "string"
+          },
+          "machineIdentitiesCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "machineIdentitiesFailedCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "machineIdentitiesSucceedCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "startDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "MANUAL",
+              "SCHEDULED"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MachineCreationRequest": {
+        "properties": {
+          "connectionDetails": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "dekId": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "edgeInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "machineTypeId": {
+            "deprecated": true,
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "owningTeamId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "pluginId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "DRAFT",
+              "VERIFIED",
+              "UNVERIFIED",
+              "DELETING"
+            ],
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "connectionDetails",
+          "dekId",
+          "edgeInstanceId",
+          "name",
+          "pluginId"
+        ],
+        "type": "object"
+      },
+      "MachineDiscoveryResultInformation": {
+        "properties": {
+          "certificatesCountCurrent": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "certificatesCountTotal": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "discoveryStatus": {
+            "enum": [
+              "NEVER INITIATED",
+              "INITIATED",
+              "RUNNING",
+              "COMPLETED",
+              "ABORTED",
+              "ABORTING",
+              "FAILED"
+            ],
+            "type": "string"
+          },
+          "endDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "errorCount": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "machineIdentitiesCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "machineIdentitiesDeletedCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "machineIdentitiesMissingCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "startDate": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MachineDocumentInformation": {
+        "properties": {
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "creationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "integrationId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "machineIdentitiesCount": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "machineName": {
+            "type": "string"
+          },
+          "machineType": {
+            "deprecated": true,
+            "type": "string"
+          },
+          "machineTypeId": {
+            "deprecated": true,
+            "format": "uuid",
+            "type": "string"
+          },
+          "modificationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "ownership": {
+            "$ref": "#/components/schemas/MachineOwnership"
+          },
+          "owningTeam": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "pluginId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "pluginName": {
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "DRAFT",
+              "VERIFIED",
+              "UNVERIFIED",
+              "DELETING"
+            ],
+            "type": "string"
+          },
+          "tsgId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MachineDocumentResponse": {
+        "properties": {
+          "machines": {
+            "items": {
+              "$ref": "#/components/schemas/MachineDocumentInformation"
+            },
+            "type": "array"
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "MachineIdentityCreationRequest": {
+        "properties": {
+          "binding": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "certificateId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "keystore": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "machineId": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "certificateId",
+          "machineId"
+        ],
+        "type": "object"
+      },
+      "MachineIdentityDocumentInformation": {
+        "properties": {
+          "applicationIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "binding": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "certificateFingerprint": {
+            "type": "string"
+          },
+          "certificateId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "certificateName": {
+            "type": "string"
+          },
+          "certificateValidityEnd": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "creationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "keystore": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "lastSeenOn": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "machineId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "machineName": {
+            "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "modificationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "NEW",
+              "PENDING",
+              "INSTALLED",
+              "DISCOVERED",
+              "VALIDATED",
+              "MISSING",
+              "FAILED"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MachineIdentityDocumentResponse": {
+        "properties": {
+          "machineIdentities": {
+            "items": {
+              "$ref": "#/components/schemas/MachineIdentityDocumentInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MachineIdentityInformation": {
+        "properties": {
+          "binding": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "certificateId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "creationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "keystore": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "lastSeenOn": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "machineId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "modificationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "NEW",
+              "PENDING",
+              "INSTALLED",
+              "DISCOVERED",
+              "VALIDATED",
+              "MISSING",
+              "FAILED"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MachineIdentityResponse": {
+        "properties": {
+          "machineIdentities": {
+            "items": {
+              "$ref": "#/components/schemas/MachineIdentityInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MachineIdentitySearchRequest": {
+        "properties": {
+          "expression": {
+            "$ref": "#/components/schemas/Expression"
+          },
+          "ordering": {
+            "$ref": "#/components/schemas/Ordering"
+          },
+          "paging": {
+            "$ref": "#/components/schemas/Paging"
+          }
+        },
+        "type": "object"
+      },
+      "MachineIdentityUpdateRequest": {
+        "properties": {
+          "binding": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "certificateId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "keystore": {
+            "$ref": "#/components/schemas/AnyValue5"
+          }
+        },
+        "type": "object"
+      },
+      "MachineIdentityWorkflowInformation": {
+        "properties": {
+          "workflowId": {
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MachineIdentityWorkflowRequest": {
+        "properties": {
+          "workflowInput": {
+            "$ref": "#/components/schemas/ProvisionCertificateWorkflowInputInformation"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "workflowName"
+        ],
+        "type": "object"
+      },
+      "MachineInformation": {
+        "properties": {
+          "batchProvisioningResult": {
+            "$ref": "#/components/schemas/MachineBatchProvisioningResultInformation"
+          },
+          "batchProvisioningSchedulerEnabled": {
+            "type": "boolean"
+          },
+          "batchProvisioningSchedulerPattern": {
+            "$ref": "#/components/schemas/SchedulerPatternInformation1"
+          },
+          "batchProvisioningStatus": {
+            "enum": [
+              "NEVER_INITIATED",
+              "INITIATED",
+              "RUNNING",
+              "COMPLETED",
+              "ABORTED",
+              "ABORTING",
+              "FAILED"
+            ],
+            "type": "string"
+          },
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "creationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "discoveryJson": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "discoverySchedulerEnabled": {
+            "type": "boolean"
+          },
+          "discoverySchedulerPattern": {
+            "$ref": "#/components/schemas/SchedulerPatternInformation1"
+          },
+          "discoveryStatus": {
+            "enum": [
+              "NEVER INITIATED",
+              "INITIATED",
+              "RUNNING",
+              "COMPLETED",
+              "ABORTED",
+              "ABORTING",
+              "FAILED"
+            ],
+            "type": "string"
+          },
+          "edgeInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "integrationId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "machineType": {
+            "deprecated": true,
+            "type": "string"
+          },
+          "modificationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owningTeamId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "pluginId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "DRAFT",
+              "VERIFIED",
+              "UNVERIFIED",
+              "DELETING"
+            ],
+            "type": "string"
+          },
+          "tsgId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MachineOwnership": {
+        "properties": {
+          "owningTeams": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "type": "object"
+      },
+      "MachineUpdateRequest": {
+        "properties": {
+          "batchProvisioningSchedulerEnabled": {
+            "type": "boolean"
+          },
+          "batchProvisioningSchedulerPattern": {
+            "$ref": "#/components/schemas/SchedulerPatternInformation1"
+          },
+          "connectionDetails": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "discoveryJson": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "discoverySchedulerEnabled": {
+            "type": "boolean"
+          },
+          "discoverySchedulerPattern": {
+            "$ref": "#/components/schemas/SchedulerPatternInformation1"
+          },
+          "edgeInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owningTeamId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "DRAFT",
+              "VERIFIED",
+              "UNVERIFIED",
+              "DELETING"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MachineWorkflowRequest": {
+        "properties": {
+          "workflowInput": {
+            "$ref": "#/components/schemas/AnyValue5"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "MachinesResponse": {
+        "properties": {
+          "machines": {
+            "items": {
+              "$ref": "#/components/schemas/MachineInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "MachinesSearchRequest": {
+        "properties": {
+          "expression": {
+            "$ref": "#/components/schemas/Expression"
+          },
+          "ordering": {
+            "$ref": "#/components/schemas/Ordering"
+          },
+          "paging": {
+            "$ref": "#/components/schemas/Paging"
+          }
+        },
+        "type": "object"
+      },
+      "Manifest": {
+        "properties": {
+          "deployment": {
+            "$ref": "#/components/schemas/Deployment"
+          },
+          "description": {
+            "description": "Description text for the plugin.",
+            "type": "string"
+          },
+          "domainSchema": {
+            "type": "object"
+          },
+          "hooks": {
+            "properties": {
+              "mapping": {
+                "type": "object"
+              },
+              "requestConverters": {
+                "items": {},
+                "nullable": true,
+                "type": "array"
+              }
+            },
+            "required": [
+              "mapping"
+            ],
+            "type": "object"
+          },
+          "localizationResources": {
+            "$ref": "#/components/schemas/LocalizationResource"
+          },
+          "name": {
+            "description": "Name of the plugin.",
+            "type": "string"
+          },
+          "pluginType": {
+            "$ref": "#/components/schemas/PluginType"
+          },
+          "workTypes": {
+            "description": "Defines the type of workflows supported for the plugin.",
+            "items": {
+              "$ref": "#/components/schemas/WorkType"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "name",
+          "workTypes",
+          "deployment",
+          "domainSchema",
+          "hooks"
+        ],
+        "title": "Manifest",
+        "type": "object",
+        "x-examples": {
+          "Example 1": {
+            "deployment": {
+              "executionTarget": "vsat",
+              "image": "public.ecr.aws/docker/library/nginx:mainline-alpine3.18-slim"
+            },
+            "description": "Description text.",
+            "domainSchema": {
+              "binding": {
+                "properties": {
+                  "parentProfile": {
+                    "description": "parentProfile.description",
+                    "type": "string",
+                    "x-labelLocalizationKey": "parentProfile.label",
+                    "x-rank": 1
+                  },
+                  "serverName": {
+                    "description": "serverName.description",
+                    "format": "hostname",
+                    "type": "string",
+                    "x-labelLocalizationKey": "serverName.label",
+                    "x-rank": 3,
+                    "x-rule": {
+                      "condition": {
+                        "type": "#/properties/sslProfileType"
+                      },
+                      "effect": "SHOW"
+                    }
+                  },
+                  "sslProfile": {
+                    "type": "string",
+                    "x-labelLocalizationKey": "sslProfile.label",
+                    "x-rank": 2
+                  },
+                  "sslProfileType": {
+                    "oneOf": [
+                      {
+                        "const": "client",
+                        "x-labelLocalizationKey": "sslProfileType.client"
+                      },
+                      {
+                        "const": "server",
+                        "x-labelLocalizationKey": "sslProfileType.server"
+                      }
+                    ],
+                    "x-labelLocalizationKey": "sslProfileType.label",
+                    "x-rank": 0
+                  }
+                },
+                "required": [
+                  "sslProfile",
+                  "sslProfileType"
+                ],
+                "type": "object",
+                "x-labelLocalizationKey": "binding.label",
+                "x-primaryKey": [
+                  "#/sslProfileType",
+                  "#/sslProfile"
+                ]
+              },
+              "certificateBundle": {
+                "properties": {
+                  "certificate": {
+                    "contentEncoding": "base64",
+                    "type": "string"
+                  },
+                  "certificateChain": {
+                    "contentEncoding": "base64",
+                    "type": "string"
+                  },
+                  "privateKey": {
+                    "contentEncoding": "base64",
+                    "type": "string",
+                    "x-encrypted-base64": true
+                  }
+                },
+                "required": [
+                  "certificate",
+                  "privateKey",
+                  "certificateChain"
+                ],
+                "type": "object"
+              },
+              "connection": {
+                "properties": {
+                  "hostnameOrAddress": {
+                    "type": "string",
+                    "x-labelLocalizationKey": "address.label",
+                    "x-rank": 0
+                  },
+                  "password": {
+                    "type": "string",
+                    "x-controlOptions": {
+                      "hidePasswordLabel": "password.hidePassword",
+                      "password": true,
+                      "showPasswordLabel": "password.showPassword"
+                    },
+                    "x-encrypted": true,
+                    "x-labelLocalizationKey": "password.label",
+                    "x-rank": 3
+                  },
+                  "port": {
+                    "description": "port.description",
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer",
+                    "x-labelLocalizationKey": "port.label",
+                    "x-rank": 1
+                  },
+                  "username": {
+                    "type": "string",
+                    "x-encrypted": true,
+                    "x-labelLocalizationKey": "username.label",
+                    "x-rank": 2
+                  }
+                },
+                "required": [
+                  "hostnameOrAddress",
+                  "username",
+                  "password"
+                ],
+                "type": "object"
+              },
+              "discovery": {
+                "properties": {
+                  "discoveryType": {
+                    "oneOf": [
+                      {
+                        "const": "all",
+                        "x-labelLocalizationKey": "discoveryType.all"
+                      },
+                      {
+                        "const": "monitor",
+                        "x-labelLocalizationKey": "discoveryType.monitor"
+                      },
+                      {
+                        "const": "virtualServer",
+                        "x-labelLocalizationKey": "discoveryType.virtualServer"
+                      }
+                    ],
+                    "x-labelLocalizationKey": "discoveryType.label",
+                    "x-rank": 0
+                  },
+                  "excludeExpiredCertificates": {
+                    "type": "boolean",
+                    "x-labelLocalizationKey": "discovery.expiredCertificatesLabel",
+                    "x-rank": 2
+                  },
+                  "excludeInactiveProfiles": {
+                    "type": "boolean",
+                    "x-labelLocalizationKey": "discovery.inactiveProfilesLabel",
+                    "x-rank": 3
+                  },
+                  "partition": {
+                    "default": "Common",
+                    "description": "discovery.partitionDescription",
+                    "maxLength": 64,
+                    "type": "string",
+                    "x-labelLocalizationKey": "discovery.partitionLabel",
+                    "x-rank": 1
+                  }
+                },
+                "type": "object"
+              },
+              "discoveryControl": {
+                "properties": {
+                  "maxResults": {
+                    "type": "int"
+                  }
+                },
+                "required": [
+                  "maxResults"
+                ],
+                "type": "object"
+              },
+              "discoveryPage": {
+                "properties": {
+                  "discoveryType": {
+                    "type": "string"
+                  },
+                  "paginator": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              },
+              "keystore": {
+                "properties": {
+                  "certificateName": {
+                    "description": "certificateName.description",
+                    "type": "string",
+                    "x-labelLocalizationKey": "certificateName.label",
+                    "x-rank": 0
+                  },
+                  "chainName": {
+                    "type": "string",
+                    "x-labelLocalizationKey": "chainName.label",
+                    "x-rank": 1
+                  },
+                  "partition": {
+                    "description": "partition.description",
+                    "maxLength": 64,
+                    "type": "string",
+                    "x-labelLocalizationKey": "partition.label",
+                    "x-rank": 2,
+                    "x-targetConfigurationRef": "/partitions"
+                  }
+                },
+                "required": [
+                  "certificateName",
+                  "chainName"
+                ],
+                "type": "object",
+                "x-labelLocalizationKey": "keystore.label",
+                "x-primaryKey": [
+                  "#/certificateName",
+                  "#/partition"
+                ]
+              }
+            },
+            "hooks": {
+              "mapping": {
+                "configureInstallationEndpoint": "/v1/configureinstallationendpoint",
+                "discoverCertificates": "/v1/discovercertificates",
+                "installCertificateBundle": "/v1/installcertificatebundle",
+                "testConnection": "/v1/testconnection"
+              },
+              "requestConverters": [
+                "arguments-decrypter"
+              ]
+            },
+            "localizationResources": {
+              "en": {
+                "address": {
+                  "label": "Server Hostname"
+                },
+                "binding": {
+                  "label": "Server Store Details"
+                },
+                "certificateName": {
+                  "description": "How the certificate should appear on the server.",
+                  "label": "Certificate Name"
+                },
+                "chainName": {
+                  "label": "Chain Bundle Name"
+                },
+                "discovery": {
+                  "expiredCertificatesLabel": "Exclude expired certificates.",
+                  "inactiveProfilesLabel": "Exclude certificates that are not in use by either a virtual server or a monitor.",
+                  "partitionDescription": "A comma separated list of partition names.",
+                  "partitionLabel": "Partition(s)"
+                },
+                "discoveryType": {
+                  "all": "Both Monitors and Virtual Servers",
+                  "label": "Resource Types to Discover",
+                  "monitor": "Monitors",
+                  "virtualServer": "Virtual Servers"
+                },
+                "keystore": {
+                  "label": "Certificate Information"
+                },
+                "parentProfile": {
+                  "description": "No value is interpreted as \"clientssl\" or \"serverssl\" depending on the Profile Type selected.",
+                  "label": "Parent Profile"
+                },
+                "partition": {
+                  "description": "No value is interpreted as the \"Common\" partition.",
+                  "label": "Partition"
+                },
+                "password": {
+                  "hidePassword": "Hide Password",
+                  "label": "Password",
+                  "showPassword": "Show Password"
+                },
+                "port": {
+                  "description": "No value is interpreted as 443.",
+                  "label": "Port"
+                },
+                "serverName": {
+                  "description": "An alternative DNS name used for Server Name Indication.",
+                  "label": "SNI"
+                },
+                "sslProfile": {
+                  "label": "SSL Profile"
+                },
+                "sslProfileType": {
+                  "client": "Client SSL Profile",
+                  "label": "Profile Type",
+                  "server": "Server SSL Profile"
+                },
+                "username": {
+                  "label": "Username"
+                }
+              }
+            },
+            "name": "Sample Manifest"
+          }
+        }
+      },
+      "MediaType": {
+        "properties": {
+          "parameters": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "subtype": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "wildcardSubtype": {
+            "type": "boolean"
+          },
+          "wildcardType": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "Name": {
+        "description": "The Name of CMS configuration",
+        "type": "string"
+      },
+      "NamespaceChartDetails": {
+        "properties": {
+          "charts": {
+            "items": {
+              "$ref": "#/components/schemas/ChartDetails"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NamespaceStatusDetails": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "pods": {
+            "items": {
+              "$ref": "#/components/schemas/PodStatusDetails"
+            },
+            "type": "array"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NaryOperator": {
+        "description": "An operator for filtering",
+        "enum": [
+          "AND",
+          "OR"
+        ],
+        "example": "OR",
+        "type": "string"
+      },
+      "NewCookie": {
+        "properties": {
+          "comment": {
+            "type": "string"
+          },
+          "domain": {
+            "type": "string"
+          },
+          "expiry": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "httpOnly": {
+            "type": "boolean"
+          },
+          "maxAge": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "sameSite": {
+            "enum": [
+              "NONE",
+              "LAX",
+              "STRICT"
+            ],
+            "type": "string"
+          },
+          "secure": {
+            "type": "boolean"
+          },
+          "value": {
+            "type": "string"
+          },
+          "version": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "NodeCondition": {
+        "properties": {
+          "Status": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "Type": {
+            "type": "string",
+            "writeOnly": true
+          },
+          "status": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NodeInfo": {
+        "properties": {
+          "kubelet_version": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "NodeStatusDetails": {
+        "properties": {
+          "conditions": {
+            "items": {
+              "$ref": "#/components/schemas/NodeCondition"
+            },
+            "type": "array"
+          },
+          "info": {
+            "$ref": "#/components/schemas/NodeInfo"
+          }
+        },
+        "type": "object"
+      },
+      "Order": {
+        "properties": {
+          "direction": {
+            "description": "An ordering direction",
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
+            "example": "DESC",
+            "type": "string"
+          },
+          "field": {
+            "description": "A field, that will be used for ordering",
+            "example": "modificationDate",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "OrderObject": {
+        "properties": {
+          "direction": {
+            "enum": [
+              "ASC",
+              "DESC"
+            ],
+            "type": "string"
+          },
+          "field": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Ordering": {
+        "properties": {
+          "orders": {
+            "items": {
+              "$ref": "#/components/schemas/OrderObject"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Page1": {
+        "description": "Specify pagination on the search request",
+        "properties": {
+          "pageNumber": {
+            "description": "page number",
+            "example": 0,
+            "format": "int32",
+            "type": "integer"
+          },
+          "pageSize": {
+            "description": "page size",
+            "example": 10,
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "Page2": {
+        "description": "Specify pagination on the search request",
+        "properties": {
+          "pageNumber": {
+            "description": "page number",
+            "example": 0,
+            "format": "int32",
+            "type": "integer"
+          },
+          "pageSize": {
+            "description": "page size",
+            "example": 10,
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "Paging": {
+        "properties": {
+          "pageNumber": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "pageSize": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "PairingCodeInformation": {
+        "properties": {
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "environmentId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "expirationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "pairingCode": {
+            "type": "string"
+          },
+          "productEntitlements": {
+            "items": {
+              "$ref": "#/components/schemas/ProductEntitlement"
+            },
+            "type": "array"
+          },
+          "reuseCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "PairingCodeRequest": {
+        "properties": {
+          "environmentId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "primaryInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "reuseCount": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "PatchServiceAccountByClientIDRequestBody": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ServiceAccountPatchBaseObject"
+          },
+          {
+            "properties": {
+              "enabled": {
+                "description": "Indicates if the given service account must be enabled or disabled where disable means that the credentials cannot be used for authentication",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "example": {
+          "credentialLifetime": 365,
+          "enabled": true,
+          "name": "New name",
+          "owner": "2620f8e0-fdbf-11ee-b275-2754a4f7e272",
+          "publicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAor3JRni8bObnKbmWzRubiNyKMoCXLVrswqiMm2h8zl8=\n-----END PUBLIC KEY-----\n",
+          "scopes": [
+            "distributed-issuance"
+          ]
+        }
+      },
+      "Persona": {
+        "enum": [
+          "Application Owners",
+          "All PKI Admins",
+          "All Admins"
+        ],
+        "type": "string"
+      },
+      "Plugin": {
+        "properties": {
+          "creationTime": {
+            "description": "Represents the date when the plugin was created.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "disabled": {
+            "description": "Indicates whether the tenant has disabled the plugin from its list of plugins.",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Represents the plugin ID.",
+            "type": "string"
+          },
+          "lastModifiedOn": {
+            "description": "Date the plugin was last modified.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "maintainer": {
+            "description": "Refers to the organization, individual, email, location, or website responsible for maintaining the plugin.",
+            "nullable": true,
+            "type": "string"
+          },
+          "manifest": {
+            "$ref": "#/components/schemas/Manifest"
+          },
+          "name": {
+            "description": "Represents the name of the plugin. This must be unique.",
+            "type": "string"
+          },
+          "pluginType": {
+            "$ref": "#/components/schemas/PluginType"
+          },
+          "revision": {
+            "description": "Represents the number of times the plugins has been updated.",
+            "type": "integer"
+          },
+          "workTypes": {
+            "description": "Represents the type of workflow the plugin supports.",
+            "items": {
+              "$ref": "#/components/schemas/WorkType"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "revision",
+          "pluginType",
+          "workTypes",
+          "manifest",
+          "lastModifiedOn",
+          "creationTime"
+        ],
+        "title": "Plugin",
+        "type": "object"
+      },
+      "PluginResponse": {
+        "properties": {
+          "plugins": {
+            "items": {
+              "$ref": "#/components/schemas/Plugin"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "plugins"
+        ],
+        "title": "PluginResponse",
+        "type": "object"
+      },
+      "PluginType": {
+        "description": "Used for differentiation between different types of plugins.",
+        "enum": [
+          "MACHINE",
+          "CA",
+          "TPP",
+          "CREDENTIAL_MANAGER"
+        ],
+        "title": "PluginType",
+        "type": "string"
+      },
+      "PodStatusDetails": {
+        "properties": {
+          "age": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "cpuUsage": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "image": {
+            "type": "string"
+          },
+          "memoryUsage": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "restartCount": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "PolicyCreateRequest": {
+        "properties": {
+          "extendedKeyUsages": {
+            "description": "Extended key usages",
+            "example": [
+              "CLIENT_AUTH",
+              "SERVER_AUTH"
+            ],
+            "items": {
+              "enum": [
+                "ANY",
+                "SERVER_AUTH",
+                "CLIENT_AUTH",
+                "CODE_SIGNING",
+                "EMAIL_PROTECTION",
+                "IPSEC_ENDSYSTEM",
+                "IPSEC_TUNNEL",
+                "IPSEC_USER",
+                "TIME_STAMPING",
+                "OCSP_SIGNING",
+                "DVCS",
+                "SBGP_CERT_AA_SERVER_AUTH",
+                "SCVP_RESPONDER",
+                "EAP_OVER_PPP",
+                "EAP_OVER_LAN",
+                "SCVP_SERVER",
+                "SCVP_CLIENT",
+                "IPSEC_IKE",
+                "CAPWAP_AC",
+                "CAPWAP_WTP",
+                "IPSEC_IKE_INTERMEDIATE",
+                "SMARTCARD_LOGON"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "keyAlgorithm": {
+            "$ref": "#/components/schemas/KeyAlgorithmInformation"
+          },
+          "keyUsages": {
+            "description": "Key usages",
+            "example": [
+              "keyEncipherment",
+              "digitalSignature"
+            ],
+            "items": {
+              "enum": [
+                "digitalSignature",
+                "nonRepudiation",
+                "keyEncipherment",
+                "dataEncipherment",
+                "keyAgreement",
+                "keyCertSign",
+                "cRLSign",
+                "encipherOnly",
+                "decipherOnly"
+              ],
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "name": {
+            "description": "Name of the policy",
+            "example": "Some policy",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "sans": {
+            "$ref": "#/components/schemas/SansInformation"
+          },
+          "shareWithAll": {
+            "description": "Share with all sub-TSGs",
+            "example": false,
+            "type": "boolean"
+          },
+          "sharedWithSubTsgIds": {
+            "items": {
+              "description": "Specific sub-TSG IDs to share with",
+              "example": "[\"1378242802\",\"1896239460\"]",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/SubjectAttributesInformation"
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "P30D",
+            "format": "PnYnMnDTnHnMnS",
+            "type": "string"
+          }
+        },
+        "required": [
+          "extendedKeyUsages",
+          "keyAlgorithm",
+          "keyUsages",
+          "name",
+          "sans",
+          "subject",
+          "validityPeriod"
+        ],
+        "type": "object"
+      },
+      "PolicyDeleteResponse": {
+        "properties": {
+          "id": {
+            "description": "UUID of the policy",
+            "example": "8ae92800-b1e0-11ed-859d-b39255f965ee",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the policy",
+            "example": "Some policy",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "PolicyInformation": {
+        "properties": {
+          "companyId": {
+            "description": "UUID specific to your company",
+            "example": "03eb6e61-9806-11ed-84f2-c747fb71e467",
+            "format": "uuid",
+            "type": "string"
+          },
+          "creationDate": {
+            "description": "When the policy was initially created",
+            "example": "2022-10-10T14:50:41.710+00:00",
+            "type": "string"
+          },
+          "extendedKeyUsages": {
+            "description": "Extended key usages",
+            "example": [
+              "CLIENT_AUTH",
+              "SERVER_AUTH"
+            ],
+            "items": {
+              "enum": [
+                "ANY",
+                "SERVER_AUTH",
+                "CLIENT_AUTH",
+                "CODE_SIGNING",
+                "EMAIL_PROTECTION",
+                "IPSEC_ENDSYSTEM",
+                "IPSEC_TUNNEL",
+                "IPSEC_USER",
+                "TIME_STAMPING",
+                "OCSP_SIGNING",
+                "DVCS",
+                "SBGP_CERT_AA_SERVER_AUTH",
+                "SCVP_RESPONDER",
+                "EAP_OVER_PPP",
+                "EAP_OVER_LAN",
+                "SCVP_SERVER",
+                "SCVP_CLIENT",
+                "IPSEC_IKE",
+                "CAPWAP_AC",
+                "CAPWAP_WTP",
+                "IPSEC_IKE_INTERMEDIATE",
+                "SMARTCARD_LOGON"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "UUID of the policy",
+            "example": "8ae92800-b1e0-11ed-859d-b39255f965ee",
+            "format": "uuid",
+            "type": "string"
+          },
+          "keyAlgorithm": {
+            "$ref": "#/components/schemas/KeyAlgorithmInformation"
+          },
+          "keyUsages": {
+            "description": "Key usages",
+            "example": [
+              "keyEncipherment",
+              "digitalSignature"
+            ],
+            "items": {
+              "enum": [
+                "digitalSignature",
+                "nonRepudiation",
+                "keyEncipherment",
+                "dataEncipherment",
+                "keyAgreement",
+                "keyCertSign",
+                "cRLSign",
+                "encipherOnly",
+                "decipherOnly"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "modificationDate": {
+            "description": "When the policy was last modified",
+            "example": "2023-12-12T20:00:10.500+00:00",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the policy",
+            "example": "Some policy",
+            "type": "string"
+          },
+          "sans": {
+            "$ref": "#/components/schemas/SansInformation"
+          },
+          "shareWithAll": {
+            "description": "Shared with all sub-TSGs",
+            "example": false,
+            "type": "boolean"
+          },
+          "sharedWithSubTsgIds": {
+            "items": {
+              "description": "Sub-TSG IDs this policy is shared with",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "subject": {
+            "$ref": "#/components/schemas/SubjectAttributesInformation"
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "P30D",
+            "format": "PnYnMnDTnHnMnS",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "PolicyResponse": {
+        "properties": {
+          "policies": {
+            "items": {
+              "$ref": "#/components/schemas/ExtendedPolicyInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "PolicyUpdateRequest": {
+        "properties": {
+          "extendedKeyUsages": {
+            "description": "Extended key usages",
+            "example": [
+              "CLIENT_AUTH",
+              "SERVER_AUTH"
+            ],
+            "items": {
+              "enum": [
+                "ANY",
+                "SERVER_AUTH",
+                "CLIENT_AUTH",
+                "CODE_SIGNING",
+                "EMAIL_PROTECTION",
+                "IPSEC_ENDSYSTEM",
+                "IPSEC_TUNNEL",
+                "IPSEC_USER",
+                "TIME_STAMPING",
+                "OCSP_SIGNING",
+                "DVCS",
+                "SBGP_CERT_AA_SERVER_AUTH",
+                "SCVP_RESPONDER",
+                "EAP_OVER_PPP",
+                "EAP_OVER_LAN",
+                "SCVP_SERVER",
+                "SCVP_CLIENT",
+                "IPSEC_IKE",
+                "CAPWAP_AC",
+                "CAPWAP_WTP",
+                "IPSEC_IKE_INTERMEDIATE",
+                "SMARTCARD_LOGON"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "keyAlgorithm": {
+            "$ref": "#/components/schemas/KeyAlgorithmInformation"
+          },
+          "keyUsages": {
+            "description": "Key usages",
+            "example": [
+              "keyEncipherment",
+              "digitalSignature"
+            ],
+            "items": {
+              "enum": [
+                "digitalSignature",
+                "nonRepudiation",
+                "keyEncipherment",
+                "dataEncipherment",
+                "keyAgreement",
+                "keyCertSign",
+                "cRLSign",
+                "encipherOnly",
+                "decipherOnly"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "name": {
+            "description": "Name of the policy",
+            "example": "Some policy",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "sans": {
+            "$ref": "#/components/schemas/SansInformation"
+          },
+          "shareWithAll": {
+            "description": "Share with all sub-TSGs",
+            "type": "boolean"
+          },
+          "sharedWithSubTsgIds": {
+            "items": {
+              "description": "Specific sub-TSG IDs to share with",
+              "example": "[\"1378242802\",\"1896239460\"]",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/SubjectAttributesInformation"
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "P30D",
+            "format": "PnYnMnDTnHnMnS",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ProductEntitlement": {
+        "enum": [
+          "ANY",
+          "MIRA",
+          "DEVOPS",
+          "OUTAGE_DETECTION",
+          "CODESIGN"
+        ],
+        "type": "string"
+      },
+      "PropertyInformation": {
+        "properties": {
+          "allowedValues": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "defaultValues": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "maxOccurrences": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "minOccurrences": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "IGNORED",
+              "FORBIDDEN",
+              "OPTIONAL",
+              "REQUIRED",
+              "LOCKED"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ProvisionCertificateWorkflowInputInformation": {
+        "properties": {
+          "wsClientId": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "wsClientId"
+        ],
+        "type": "object"
+      },
+      "PublicPluginCreationRequest": {
+        "properties": {
+          "maintainer": {
+            "description": "Refers to the organization, individual, email, location, or website responsible for maintaining the plugin.",
+            "nullable": true,
+            "type": "string"
+          },
+          "manifest": {
+            "$ref": "#/components/schemas/Manifest"
+          },
+          "pluginType": {
+            "$ref": "#/components/schemas/PluginType"
+          }
+        },
+        "required": [
+          "manifest",
+          "pluginType"
+        ],
+        "title": "PublicPluginCreationRequest",
+        "type": "object",
+        "x-stoplight": {
+          "id": "sto5fs3n5bxmf"
+        }
+      },
+      "PublicPluginUpdateRequest": {
+        "properties": {
+          "image": {
+            "nullable": true,
+            "type": "string"
+          },
+          "maintainer": {
+            "nullable": true,
+            "type": "string"
+          },
+          "manifest": {
+            "$ref": "#/components/schemas/Manifest"
+          }
+        },
+        "title": "PublicPluginUpdateRequest",
+        "type": "object",
+        "x-stoplight": {
+          "id": "8ypau6to0udah"
+        }
+      },
+      "PutServiceAccountByClientIDCredentialsRequestBody": {
+        "example": {
+          "extendCredentialLifetime": true
+        },
+        "properties": {
+          "extendCredentialLifetime": {
+            "description": "Extend the credential lifetime",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "extendCredentialLifetime"
+        ],
+        "type": "object"
+      },
+      "PutServiceAccountByClientIDCredentialsResponseBody": {
+        "properties": {
+          "credentialExpiresIn": {
+            "description": "Expiration in hours for service account credentials",
+            "format": "float",
+            "type": "number",
+            "x-go-type": "float64"
+          }
+        },
+        "type": "object"
+      },
+      "PutServiceAccountByClientIDOCITokenResponseBody": {
+        "properties": {
+          "ociRegistryToken": {
+            "description": "The OCI registry token generated for a robot in case of the registry scope",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "Recipient": {
+        "properties": {
+          "id": {
+            "description": "The ID of a user or team who should be included as a recipient.",
+            "format": "UUID",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of the recipient.",
+            "enum": [
+              "User",
+              "Team"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ],
+        "type": "object"
+      },
+      "RecommendedSettingsInformation": {
+        "properties": {
+          "key": {
+            "$ref": "#/components/schemas/RecommendedSettingsKeyTypeInformation"
+          },
+          "keyGeneratedBy": {
+            "type": "string"
+          },
+          "sanRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectCNRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectCValue": {
+            "type": "string"
+          },
+          "subjectLValue": {
+            "type": "string"
+          },
+          "subjectOUValue": {
+            "type": "string"
+          },
+          "subjectOValue": {
+            "type": "string"
+          },
+          "subjectSTValue": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "RecommendedSettingsKeyTypeInformation": {
+        "properties": {
+          "curve": {
+            "enum": [
+              "P256",
+              "P384",
+              "P521",
+              "ED25519",
+              "UNKNOWN"
+            ],
+            "type": "string"
+          },
+          "length": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "RSA",
+              "EC"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "RecommendedSettingsKeyTypeParameter": {
+        "properties": {
+          "curve": {
+            "enum": [
+              "P256",
+              "P384",
+              "P521",
+              "ED25519",
+              "UNKNOWN"
+            ],
+            "type": "string"
+          },
+          "length": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "RSA",
+              "EC"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "RecommendedSettingsRequest": {
+        "properties": {
+          "key": {
+            "$ref": "#/components/schemas/RecommendedSettingsKeyTypeParameter"
+          },
+          "keyGeneratedBy": {
+            "type": "string"
+          },
+          "sanRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectCNRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "subjectCValue": {
+            "pattern": "^(([A-Z]{2})|(\\.\\*))$",
+            "type": "string"
+          },
+          "subjectLValue": {
+            "pattern": "[^\\*]*",
+            "type": "string"
+          },
+          "subjectOUValue": {
+            "pattern": "[^\\*]*",
+            "type": "string"
+          },
+          "subjectOValue": {
+            "pattern": "[^\\*]*",
+            "type": "string"
+          },
+          "subjectSTValue": {
+            "pattern": "[^\\*]*",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "RecoveryCodeInformation": {
+        "properties": {
+          "companyId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "dataPlaneDomain": {
+            "type": "string"
+          },
+          "expirationDate": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "hiddenRecoveryCode": {
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "productEntitlements": {
+            "items": {
+              "$ref": "#/components/schemas/ProductEntitlement"
+            },
+            "type": "array"
+          },
+          "recoveryCode": {
+            "type": "string"
+          },
+          "tsgId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "RecoveryCodeRequest": {
+        "properties": {
+          "edgeInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "edgeInstanceId"
+        ],
+        "type": "object"
+      },
+      "Reference": {
+        "description": "The machine referenced.",
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ReferenceType"
+          }
+        },
+        "required": [
+          "id",
+          "type"
+        ],
+        "type": "object"
+      },
+      "ReferenceType": {
+        "description": "The type of the reference:\n  * `machine`\n",
+        "enum": [
+          "machine"
+        ],
+        "type": "string"
+      },
+      "References": {
+        "description": "The machines referenced.",
+        "items": {
+          "$ref": "#/components/schemas/Reference"
+        },
+        "type": "array",
+        "uniqueItems": true
+      },
+      "Response": {
+        "properties": {
+          "allowedMethods": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "closed": {
+            "type": "boolean"
+          },
+          "cookies": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/NewCookie"
+            },
+            "type": "object"
+          },
+          "date": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "entity": {
+            "$ref": "#/components/schemas/AnyValue2"
+          },
+          "entityTag": {
+            "$ref": "#/components/schemas/EntityTag"
+          },
+          "headers": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/AnyValue2"
+              },
+              "type": "array"
+            },
+            "properties": {
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "language": {
+            "properties": {
+              "country": {
+                "type": "string"
+              },
+              "displayCountry": {
+                "type": "string"
+              },
+              "displayLanguage": {
+                "type": "string"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "displayScript": {
+                "type": "string"
+              },
+              "displayVariant": {
+                "type": "string"
+              },
+              "extensionKeys": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "uniqueItems": true
+              },
+              "iso3Country": {
+                "type": "string"
+              },
+              "iso3Language": {
+                "type": "string"
+              },
+              "language": {
+                "type": "string"
+              },
+              "script": {
+                "type": "string"
+              },
+              "unicodeLocaleAttributes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "uniqueItems": true
+              },
+              "unicodeLocaleKeys": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "uniqueItems": true
+              },
+              "variant": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "lastModified": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "length": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "links": {
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "location": {
+            "format": "uri",
+            "type": "string"
+          },
+          "mediaType": {
+            "$ref": "#/components/schemas/MediaType"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/AnyValue2"
+              },
+              "type": "array"
+            },
+            "properties": {
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "status": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "statusInfo": {
+            "$ref": "#/components/schemas/StatusType"
+          },
+          "stringHeaders": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "properties": {
+              "empty": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "ResponseCMSDetails": {
+        "description": "An string containing the JSON content representing the details of the specific privileged access management.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ResponseCyberArkDetails"
+          },
+          {
+            "$ref": "#/components/schemas/ResponseHashiCorpDetails"
+          }
+        ]
+      },
+      "ResponseCredentialDetails": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ResponseCyberArkCredDetails"
+          },
+          {
+            "$ref": "#/components/schemas/ResponseHashiCorpCredDetails"
+          }
+        ]
+      },
+      "ResponseCyberArkCredDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CyberArkDetailsRequiredProp"
+          }
+        ]
+      },
+      "ResponseCyberArkDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CyberArkConfiguration"
+          }
+        ]
+      },
+      "ResponseHashiCorpCredDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HashiCorpDetailsRequiredProp"
+          }
+        ]
+      },
+      "ResponseHashiCorpDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HashiCorpConfiguration"
+          }
+        ]
+      },
+      "Role": {
+        "enum": [
+          "SYSTEM_ADMIN",
+          "OUTAGE_DETECTION_PLATFORM_ADMIN",
+          "OUTAGE_DETECTION_PKI_ADMIN",
+          "OUTAGE_DETECTION_RESOURCE_OWNER",
+          "OUTAGE_DETECTION_GUEST"
+        ],
+        "type": "string"
+      },
+      "SansInformation": {
+        "description": "Subject alternative names",
+        "properties": {
+          "dnsNames": {
+            "$ref": "#/components/schemas/PropertyInformation"
+          },
+          "ipAddresses": {
+            "$ref": "#/components/schemas/PropertyInformation"
+          },
+          "rfc822Names": {
+            "$ref": "#/components/schemas/PropertyInformation"
+          },
+          "uniformResourceIdentifiers": {
+            "$ref": "#/components/schemas/PropertyInformation"
+          }
+        },
+        "type": "object"
+      },
+      "SchedulerPatternInformation1": {
+        "discriminator": {
+          "propertyName": "recurrenceType"
+        },
+        "properties": {
+          "recurrenceType": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "recurrenceType"
+        ],
+        "type": "object"
+      },
+      "SchedulerPatternInformation2": {
+        "discriminator": {
+          "mapping": {
+            "DAY": "#/components/schemas/DailyPatternInformation",
+            "WEEK": "#/components/schemas/WeeklyPatternInformation"
+          },
+          "propertyName": "recurrenceType"
+        },
+        "properties": {
+          "recurrenceType": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "recurrenceType"
+        ],
+        "type": "object"
+      },
+      "SchedulerPatternInformation3": {
+        "discriminator": {
+          "propertyName": "recurrenceType"
+        },
+        "properties": {
+          "recurrenceType": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "recurrenceType"
+        ],
+        "type": "object"
+      },
+      "Scope": {
+        "description": "The service account authorization scopes",
+        "example": "distributed-issuance",
+        "type": "string"
+      },
+      "ScopeDetails": {
+        "description": "The service account authorization scopes detailed",
+        "example": {
+          "authenticationType": "rsaKey",
+          "id": "distributed-issuance",
+          "readableName": "Distributed Issuance"
+        },
+        "properties": {
+          "authenticationType": {
+            "description": "Type of authentication used in the scope",
+            "type": "string"
+          },
+          "id": {
+            "description": "ID for the given scope",
+            "type": "string"
+          },
+          "readableName": {
+            "description": "User friendly name for the scope",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "readableName"
+        ],
+        "type": "object"
+      },
+      "ServiceAccountBaseObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ServiceAccountBaseObjectNoKey"
+          },
+          {
+            "properties": {
+              "publicKey": {
+                "description": "The client generated public key",
+                "maxLength": 2000,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "ServiceAccountBaseObjectNoKey": {
+        "properties": {
+          "applications": {
+            "description": "The list of applications for which the account is authorized",
+            "example": [
+              "dc96438b-7a80-464b-a09b-9e5ec746c3e3",
+              "5bce5ff4-a69b-4e78-9b7e-6d4029995000"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Application"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "audience": {
+            "description": "The intended audience or recipients of the entity",
+            "example": "Audience",
+            "maxLength": 250,
+            "minLength": 1,
+            "type": "string"
+          },
+          "authenticationType": {
+            "description": "Type of authentication used in the scope. Currently supporting two types rsaKey and ociToken",
+            "example": "rsaKey",
+            "type": "string"
+          },
+          "companyId": {
+            "description": "The UUID of the company/tenant",
+            "format": "UUID",
+            "type": "string",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/google/uuid"
+            }
+          },
+          "credentialLifetime": {
+            "description": "The number of days for which the credentials will be valid before expiring and requiring renewal",
+            "example": 365,
+            "maximum": 365,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "issuerURL": {
+            "description": "The URL of the entity issuer, providing the source or origin",
+            "example": "https://accounts.google.com/",
+            "maxLength": 250,
+            "minLength": 1,
+            "type": "string"
+          },
+          "jwksURI": {
+            "description": "The URI pointing to the JSON Web Key Set (JWKS) for the entity, facilitating secure authentication",
+            "example": "https://www.googleapis.com/oauth2/v3/certs",
+            "maxLength": 250,
+            "minLength": 1,
+            "type": "string"
+          },
+          "name": {
+            "description": "User friendly name for the given account",
+            "maxLength": 250,
+            "minLength": 1,
+            "type": "string"
+          },
+          "owner": {
+            "description": "The UUID of the owning team",
+            "format": "UUID",
+            "type": "string",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/google/uuid"
+            }
+          },
+          "scopes": {
+            "description": "The list of scopes for which the account is authorized",
+            "example": [
+              "distributed-issuance"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Scope"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "subject": {
+            "description": "The subject of the entity, representing the main topic or title.",
+            "example": "Subject",
+            "maxLength": 250,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ServiceAccountBasePatchObjectNoKey": {
+        "properties": {
+          "applications": {
+            "description": "The list of applications for which the account is authorized",
+            "example": [
+              "dc96438b-7a80-464b-a09b-9e5ec746c3e3",
+              "5bce5ff4-a69b-4e78-9b7e-6d4029995000"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Application"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "audience": {
+            "description": "The intended audience or recipients of the entity",
+            "example": "Audience",
+            "maxLength": 250,
+            "minLength": 1,
+            "type": "string"
+          },
+          "credentialLifetime": {
+            "description": "The number of days for which the credentials will be valid before expiring and requiring renewal",
+            "maximum": 365,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "issuerURL": {
+            "description": "The URL of the entity issuer, providing the source or origin",
+            "example": "https://accounts.google.com/",
+            "maxLength": 250,
+            "minLength": 1,
+            "type": "string"
+          },
+          "jwksURI": {
+            "description": "The URI pointing to the JSON Web Key Set (JWKS) for the entity, facilitating secure authentication",
+            "example": "https://www.googleapis.com/oauth2/v3/certs",
+            "maxLength": 250,
+            "minLength": 1,
+            "type": "string"
+          },
+          "name": {
+            "description": "User friendly name for the given account",
+            "maxLength": 250,
+            "minLength": 1,
+            "type": "string"
+          },
+          "owner": {
+            "description": "The UUID of the owning team",
+            "format": "UUID",
+            "type": "string",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/google/uuid"
+            }
+          },
+          "scopes": {
+            "description": "The list of scopes for which the account is authorized",
+            "items": {
+              "$ref": "#/components/schemas/Scope"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "subject": {
+            "description": "The subject of the entity, representing the main topic or title.",
+            "example": "Subject",
+            "maxLength": 250,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ServiceAccountDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ServiceAccountBaseObject"
+          },
+          {
+            "$ref": "#/components/schemas/Details"
+          }
+        ]
+      },
+      "ServiceAccountDetailsNoKey": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ServiceAccountBaseObjectNoKey"
+          },
+          {
+            "$ref": "#/components/schemas/Details"
+          }
+        ],
+        "example": {
+          "authenticationType": "rsaKey",
+          "companyId": "145f12e0-fdbf-11ee-b275-2754a4f7e272",
+          "credentialLifetime": 365,
+          "credentialsExpiringOn": "2025-01-01T00:00:00.000000Z",
+          "enabled": true,
+          "id": "933507dd-0286-11ef-bc25-8a00a468403f",
+          "name": "Service Account I",
+          "owner": "2620f8e0-fdbf-11ee-b275-2754a4f7e272",
+          "scopes": [
+            "distributed-issuance"
+          ],
+          "updatedBy": "150760d0-fdbf-11ee-b275-2754a4f7e272",
+          "updatedOn": "2024-01-01T00:00:00.000000Z"
+        }
+      },
+      "ServiceAccountPatchBaseObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ServiceAccountBasePatchObjectNoKey"
+          },
+          {
+            "properties": {
+              "publicKey": {
+                "description": "The client generated public key",
+                "maxLength": 2000,
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "StatusResponse": {
+        "description": "Details about the current in-progress certificate auto-renewal process, and the most recently completed process.",
+        "properties": {
+          "current": {
+            "$ref": "#/components/schemas/StatusResponseItem"
+          },
+          "previous": {
+            "$ref": "#/components/schemas/StatusResponseItem"
+          }
+        },
+        "required": [
+          "current"
+        ],
+        "type": "object"
+      },
+      "StatusResponseItem": {
+        "description": "Details about the upcoming certificate auto-renewal run.",
+        "example": {
+          "applications": 13,
+          "certificates": {
+            "eligible": 47,
+            "renewal": {
+              "failed": 1,
+              "successful": 9,
+              "triggered": 3
+            }
+          },
+          "state": "running",
+          "timestamp": "2023-08-25T20:59:36.688019837Z"
+        },
+        "properties": {
+          "applications": {
+            "description": "The number of applications that have auto-renewal enabled.",
+            "example": 13,
+            "format": "int64",
+            "type": "integer"
+          },
+          "certificates": {
+            "description": "A set of statistics related to the certificates that were included in the auto-renewal process.",
+            "example": {
+              "eligible": 47,
+              "renewal": {
+                "failed": 1,
+                "successful": 9,
+                "triggered": 3
+              }
+            },
+            "properties": {
+              "eligible": {
+                "description": "The number of certificates that belong to an application that has auto-renewal enabled.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "renewal": {
+                "properties": {
+                  "failed": {
+                    "description": "The number of certificates for which renewal failed",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "successful": {
+                    "description": "The number of certificates for which renewal completed successfully",
+                    "format": "int64",
+                    "type": "integer"
+                  },
+                  "triggered": {
+                    "description": "The number of certificates for which the renewal has been started",
+                    "format": "int64",
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "triggered",
+                  "successful",
+                  "failed"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "eligible",
+              "renewal"
+            ],
+            "type": "object"
+          },
+          "state": {
+            "description": "A string representing the status of a specific run of the auto-renewal process.",
+            "enum": [
+              "pending",
+              "triggered",
+              "running",
+              "complete",
+              "awaiting results",
+              "no enabled apps",
+              "no automated keypair service active",
+              "failure"
+            ],
+            "example": "running",
+            "type": "string"
+          },
+          "timestamp": {
+            "description": "The date and time when certificate auto-renewal is estimated to begin.",
+            "example": "2023-08-25T20:59:36.688019837Z",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "timestamp",
+          "state",
+          "applications",
+          "certificates"
+        ],
+        "type": "object"
+      },
+      "StatusType": {
+        "properties": {
+          "family": {
+            "enum": [
+              "INFORMATIONAL",
+              "SUCCESSFUL",
+              "REDIRECTION",
+              "CLIENT_ERROR",
+              "SERVER_ERROR",
+              "OTHER"
+            ],
+            "type": "string"
+          },
+          "reasonPhrase": {
+            "type": "string"
+          },
+          "statusCode": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "SubCaProviderCreateRequest": {
+        "properties": {
+          "caAccountId": {
+            "description": "UUID of the CA account used by this Sub CA provider",
+            "example": "4ece3180-b1e0-11ed-862d-ad36b18e787a",
+            "format": "uuid",
+            "type": "string"
+          },
+          "caProductOptionId": {
+            "description": "UUID of the CA product option used by this Sub CA provider",
+            "example": "6b3d8d20-b1e0-11ed-9c2f-953e35982bbd",
+            "format": "uuid",
+            "type": "string"
+          },
+          "caType": {
+            "description": "Type of CA this Sub CA provider works with",
+            "enum": [
+              "MOCKCA",
+              "DIGICERT",
+              "GLOBALSIGN",
+              "BUILTIN",
+              "ENTRUST",
+              "MICROSOFT",
+              "ACME",
+              "ZTPKI",
+              "GLOBALSIGNMSSL",
+              "TPP"
+            ],
+            "example": "BUILTIN",
+            "type": "string"
+          },
+          "commonName": {
+            "description": "Common name",
+            "example": "example.com",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "country": {
+            "description": "Country",
+            "example": "US",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "keyAlgorithm": {
+            "description": "Key algorithm type",
+            "enum": [
+              "RSA_2048",
+              "RSA_3072",
+              "RSA_4096",
+              "EC_P256",
+              "EC_P384",
+              "EC_P521",
+              "EC_ED25519"
+            ],
+            "example": "EC_P256",
+            "type": "string"
+          },
+          "locality": {
+            "description": "Locality",
+            "example": "San Antonio",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the Sub CA provider",
+            "example": "Some Sub CA provider",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "organization": {
+            "description": "Organization",
+            "example": "Some organization",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "organizationalUnit": {
+            "description": "Organizational unit",
+            "example": "Some organizational unit",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "pkcs11": {
+            "$ref": "#/components/schemas/SubCaProviderPkcs11ConfigurationInformation"
+          },
+          "shareWithAll": {
+            "description": "Share with all sub-TSGs",
+            "example": false,
+            "type": "boolean"
+          },
+          "sharedWithSubTsgIds": {
+            "items": {
+              "description": "Specific sub-TSG IDs to share with",
+              "example": "[\"1378242802\",\"1896239460\"]",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "stateOrProvince": {
+            "description": "State or province",
+            "example": "Texas",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "P30D",
+            "format": "PnYnMnDTnHnMnS",
+            "type": "string"
+          }
+        },
+        "required": [
+          "caAccountId",
+          "caProductOptionId",
+          "caType",
+          "commonName",
+          "keyAlgorithm",
+          "name",
+          "validityPeriod"
+        ],
+        "type": "object"
+      },
+      "SubCaProviderDeleteResponse": {
+        "properties": {
+          "id": {
+            "description": "UUID of the Sub CA provider",
+            "example": "2f3c6030-b1e0-11ed-a3ed-e3dbaf56a746",
+            "format": "uuid",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the Sub CA provider",
+            "example": "Some Sub CA",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SubCaProviderInformation": {
+        "properties": {
+          "caAccountId": {
+            "description": "UUID of the CA account used by this Sub CA provider",
+            "example": "4ece3180-b1e0-11ed-862d-ad36b18e787a",
+            "format": "uuid",
+            "type": "string"
+          },
+          "caProductOptionId": {
+            "description": "UUID of the CA product option used by this Sub CA provider",
+            "example": "6b3d8d20-b1e0-11ed-9c2f-953e35982bbd",
+            "format": "uuid",
+            "type": "string"
+          },
+          "caType": {
+            "description": "Type of CA this Sub CA provider works with",
+            "enum": [
+              "MOCKCA",
+              "DIGICERT",
+              "GLOBALSIGN",
+              "BUILTIN",
+              "ENTRUST",
+              "MICROSOFT",
+              "ACME",
+              "ZTPKI",
+              "GLOBALSIGNMSSL",
+              "TPP"
+            ],
+            "example": "BUILTIN",
+            "type": "string"
+          },
+          "commonName": {
+            "description": "Common name",
+            "example": "example.com",
+            "type": "string"
+          },
+          "companyId": {
+            "description": "UUID specific to your company",
+            "example": "03eb6e61-9806-11ed-84f2-c747fb71e467",
+            "format": "uuid",
+            "type": "string"
+          },
+          "country": {
+            "description": "Country",
+            "example": "US",
+            "type": "string"
+          },
+          "creationDate": {
+            "description": "When the Sub CA provider was initially created",
+            "example": "2022-10-10T14:50:41.710+00:00",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of the Sub CA provider",
+            "example": "2f3c6030-b1e0-11ed-a3ed-e3dbaf56a746",
+            "format": "uuid",
+            "type": "string"
+          },
+          "keyAlgorithm": {
+            "description": "Key algorithm type",
+            "enum": [
+              "RSA_2048",
+              "RSA_3072",
+              "RSA_4096",
+              "EC_P256",
+              "EC_P384",
+              "EC_P521",
+              "EC_ED25519"
+            ],
+            "example": "EC_P256",
+            "type": "string"
+          },
+          "locality": {
+            "description": "Locality",
+            "example": "San Antonio",
+            "type": "string"
+          },
+          "modificationDate": {
+            "description": "When the Sub CA provider was last modified",
+            "example": "2023-12-12T20:00:10.500+00:00",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the Sub CA provider",
+            "example": "Some Sub CA provider",
+            "type": "string"
+          },
+          "organization": {
+            "description": "Organization",
+            "example": "Some organization",
+            "type": "string"
+          },
+          "organizationalUnit": {
+            "description": "Organizational unit",
+            "example": "Some organizational unit",
+            "type": "string"
+          },
+          "pkcs11": {
+            "$ref": "#/components/schemas/SubCaProviderPkcs11ConfigurationInformation"
+          },
+          "shareWithAll": {
+            "description": "Shared with all sub-TSGs",
+            "example": false,
+            "type": "boolean"
+          },
+          "sharedWithSubTsgIds": {
+            "items": {
+              "description": "Sub-TSG IDs this SubCA provider is shared with",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "stateOrProvince": {
+            "description": "State or province",
+            "example": "Texas",
+            "type": "string"
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "P30D",
+            "format": "PnYnMnDTnHnMnS",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SubCaProviderPkcs11ConfigurationInformation": {
+        "properties": {
+          "allowedClientLibraries": {
+            "description": "A collection of strings each of which represents SHA256 hash of an allowed HSM client library",
+            "example": [
+              "c34d199f2e30bb679cd9b8533b99975465aefe8b023be1b37972f1ab43ab7b2d"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "partitionLabel": {
+            "description": "HSM Partition Label",
+            "example": "workload-identity-manager-hsm-partition",
+            "type": "string"
+          },
+          "partitionSerialNumber": {
+            "description": "HSM Partition Serial Number",
+            "example": "1444210958933",
+            "pattern": "^[A-Fa-fx0-9]{0,18}$",
+            "type": "string"
+          },
+          "pin": {
+            "description": "HSM PIN",
+            "example": "1234",
+            "type": "string",
+            "writeOnly": true
+          },
+          "signingEnabled": {
+            "description": "Indicates whether HSM signing is enabled or not",
+            "example": true,
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "SubCaProviderResponse": {
+        "properties": {
+          "subCaProviders": {
+            "items": {
+              "$ref": "#/components/schemas/SubCaProviderInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "SubCaProviderUpdateRequest": {
+        "properties": {
+          "caProductOptionId": {
+            "description": "UUID of the CA product option used by this Sub CA provider",
+            "example": "6b3d8d20-b1e0-11ed-9c2f-953e35982bbd",
+            "format": "uuid",
+            "type": "string"
+          },
+          "commonName": {
+            "description": "Common name",
+            "example": "example.com",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "country": {
+            "description": "Country",
+            "example": "US",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "keyAlgorithm": {
+            "description": "Key algorithm type",
+            "enum": [
+              "RSA_2048",
+              "RSA_3072",
+              "RSA_4096",
+              "EC_P256",
+              "EC_P384",
+              "EC_P521",
+              "EC_ED25519"
+            ],
+            "example": "EC_P256",
+            "type": "string"
+          },
+          "locality": {
+            "description": "Locality",
+            "example": "San Antonio",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the Sub CA provider",
+            "example": "Some Sub CA",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "organization": {
+            "description": "Organization",
+            "example": "Some organization",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "organizationalUnit": {
+            "description": "Organizational unit",
+            "example": "Some organizational unit",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "pkcs11": {
+            "$ref": "#/components/schemas/SubCaProviderPkcs11ConfigurationInformation"
+          },
+          "shareWithAll": {
+            "description": "Share with all sub-TSGs",
+            "type": "boolean"
+          },
+          "sharedWithSubTsgIds": {
+            "items": {
+              "description": "Specific sub-TSG IDs to share with",
+              "example": "[\"1378242802\",\"1896239460\"]",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "stateOrProvince": {
+            "description": "State or province",
+            "example": "Texas",
+            "maxLength": 64,
+            "type": "string"
+          },
+          "validityPeriod": {
+            "description": "ISO8601 Period Format",
+            "example": "PnYnMnDTnHnMnS",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "SubjectAlternativeNamesByType": {
+        "properties": {
+          "dnsNames": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "ipAddresses": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "rfc822Names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "uniformResourceIdentifiers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "SubjectAttributesInformation": {
+        "description": "Subject attributes",
+        "properties": {
+          "commonName": {
+            "$ref": "#/components/schemas/PropertyInformation"
+          },
+          "country": {
+            "$ref": "#/components/schemas/PropertyInformation"
+          },
+          "locality": {
+            "$ref": "#/components/schemas/PropertyInformation"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/PropertyInformation"
+          },
+          "organizationalUnit": {
+            "$ref": "#/components/schemas/PropertyInformation"
+          },
+          "stateOrProvince": {
+            "$ref": "#/components/schemas/PropertyInformation"
+          }
+        },
+        "type": "object"
+      },
+      "TSGId": {
+        "description": "The TSG identifier the credential belongs to.",
+        "type": "string"
+      },
+      "TagAssignmentErrorInformation": {
+        "description": "Error information for tags not assigned",
+        "example": {
+          "errorInformation": {
+            "message": "not assigned",
+            "statusCode": 1111
+          }
+        },
+        "properties": {
+          "args": {
+            "items": {
+              "$ref": "#/components/schemas/AnyValue7"
+            },
+            "type": "array"
+          },
+          "message": {
+            "type": "string"
+          },
+          "statusCode": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "TagInformation": {
+        "properties": {
+          "companyId": {
+            "description": "UUID specific to your company",
+            "example": "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "id": {
+            "description": "UUID of the tag",
+            "example": "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "isReserved": {
+            "description": "Used by Venafi to reserve system tags",
+            "example": false,
+            "type": "boolean"
+          },
+          "key": {
+            "description": "Same as tag name, though all lowercase",
+            "example": "application",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the tag",
+            "example": "Application",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TagRequest": {
+        "description": "Array of tag and tag-value objects",
+        "properties": {
+          "name": {
+            "description": "Name of the tag",
+            "example": "Application",
+            "minLength": 1,
+            "type": "string"
+          },
+          "values": {
+            "description": "Array of values associated with the tag",
+            "example": [
+              "TLS Protect",
+              "Jetstack"
+            ],
+            "items": {
+              "description": "Array of values associated with the tag",
+              "example": "[\"TLS Protect\",\"Jetstack\"]",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "TagResponse": {
+        "properties": {
+          "count": {
+            "description": "Number of tags returned",
+            "example": 7,
+            "format": "int32",
+            "type": "integer"
+          },
+          "tags": {
+            "items": {
+              "$ref": "#/components/schemas/TagInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TagValueInformation": {
+        "properties": {
+          "companyId": {
+            "description": "UUID specific to your company",
+            "example": "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "id": {
+            "description": "The ID of the value",
+            "example": "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "tagId": {
+            "description": "The ID of the tag the value applies to",
+            "example": "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "value": {
+            "description": "Name of the value",
+            "example": "TLS Protect",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TagValuesRequest": {
+        "properties": {
+          "values": {
+            "description": "Array of value names to associate with the tag",
+            "items": {
+              "description": "Array of value names to associate with the tag",
+              "example": "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c",
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "values"
+        ],
+        "type": "object"
+      },
+      "TagValuesResponse": {
+        "properties": {
+          "count": {
+            "description": "Number of values returned",
+            "example": 7,
+            "format": "int32",
+            "type": "integer"
+          },
+          "values": {
+            "items": {
+              "$ref": "#/components/schemas/TagValueInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TagsAndValuesInformation": {
+        "properties": {
+          "tag": {
+            "$ref": "#/components/schemas/TagInformation"
+          },
+          "values": {
+            "items": {
+              "$ref": "#/components/schemas/TagValueInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TagsAndValuesResponse": {
+        "properties": {
+          "tagsAndValues": {
+            "items": {
+              "$ref": "#/components/schemas/TagsAndValuesInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TagsAssignRequest": {
+        "properties": {
+          "action": {
+            "description": "Action to perform",
+            "enum": [
+              "REPLACE",
+              "ADD",
+              "DELETE",
+              "DELETE_ALL"
+            ],
+            "example": "REPLACE",
+            "type": "string"
+          },
+          "entityIds": {
+            "description": "Array of UUIDs of the objects",
+            "example": [
+              "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c"
+            ],
+            "items": {
+              "description": "Array of UUIDs of the objects",
+              "format": "uuid",
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "entityType": {
+            "description": "Object type that the tag applies to",
+            "enum": [
+              "CERTIFICATE",
+              "CERTIFICATE_INSTANCE",
+              "APPLICATION"
+            ],
+            "example": "CERTIFICATE",
+            "type": "string"
+          },
+          "targetedTags": {
+            "description": "Array of tags to apply",
+            "example": [
+              "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c"
+            ],
+            "items": {
+              "description": "Array of tags to apply",
+              "example": "[\"265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c\"]",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "entityIds"
+        ],
+        "type": "object"
+      },
+      "TagsAssignResponse": {
+        "properties": {
+          "tagsAssignInformation": {
+            "items": {
+              "$ref": "#/components/schemas/TagsAssignResponseInformation"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "TagsAssignResponseInformation": {
+        "properties": {
+          "companyId": {
+            "description": "UUID specific to your company",
+            "example": "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "creationDate": {
+            "description": "The date when the assignment is created",
+            "example": "2023-01-30T16:28:53.166Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "entityId": {
+            "description": "UUID of the object",
+            "example": "265f6d30-a0bb-11ed-aee0-89fe7e5f5d0c",
+            "format": "uuid",
+            "type": "string"
+          },
+          "entityType": {
+            "description": "Object type that the tag applies to",
+            "example": "CERTIFICATE",
+            "type": "string"
+          },
+          "errorInformation": {
+            "$ref": "#/components/schemas/TagAssignmentErrorInformation"
+          },
+          "modificationDate": {
+            "description": "The date when the assignment is last modified",
+            "example": "2023-01-30T16:28:53.166Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "status": {
+            "description": "Status of the assigned entity",
+            "example": "ASSIGNED",
+            "type": "string"
+          },
+          "tags": {
+            "description": "The tags that are assigned",
+            "example": [
+              "Application:TLS"
+            ],
+            "items": {
+              "description": "The tags that are assigned",
+              "example": "[\"Application:TLS\"]",
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "type": "object"
+      },
+      "TagsAssignmentAggregatesRequest": {
+        "properties": {
+          "entityType": {
+            "description": "Object type that the tag applies to. If null, get all object types",
+            "enum": [
+              "CERTIFICATE",
+              "CERTIFICATE_INSTANCE",
+              "APPLICATION"
+            ],
+            "example": "CERTIFICATE",
+            "type": "string"
+          },
+          "tags": {
+            "description": "Array of tags",
+            "example": [
+              "TAG",
+              "Tag:Value"
+            ],
+            "items": {
+              "description": "Array of tags",
+              "example": "[\"TAG\",\"Tag:Value\"]",
+              "type": "string"
+            },
+            "maxItems": 100,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "tags"
+        ],
+        "type": "object"
+      },
+      "TagsAssignmentAggregatesResponse": {
+        "properties": {
+          "aggregates": {
+            "additionalProperties": {
+              "description": "Represents a mapping of tag name to list of aggregates information",
+              "items": {
+                "$ref": "#/components/schemas/TagsAssignmentAggregatesResponseInformation"
+              },
+              "type": "array"
+            },
+            "description": "Represents a mapping of tag name to list of aggregates information",
+            "example": {
+              "TagNew": [
+                {
+                  "count": 2,
+                  "entityType": "CERTIFICATE"
+                },
+                {
+                  "count": 5,
+                  "entityType": "APPLICATION"
+                }
+              ],
+              "tag:value": [
+                {
+                  "count": 6,
+                  "entityType": "CERTIFICATE"
+                },
+                {
+                  "count": 1,
+                  "entityType": "APPLICATION"
+                }
+              ]
+            },
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "TagsAssignmentAggregatesResponseInformation": {
+        "description": "Represents a mapping of tag name to list of aggregates information",
+        "example": {
+          "TagNew": [
+            {
+              "count": 2,
+              "entityType": "CERTIFICATE"
+            },
+            {
+              "count": 5,
+              "entityType": "APPLICATION"
+            }
+          ],
+          "tag:value": [
+            {
+              "count": 6,
+              "entityType": "CERTIFICATE"
+            },
+            {
+              "count": 1,
+              "entityType": "APPLICATION"
+            }
+          ]
+        },
+        "properties": {
+          "count": {
+            "description": "Number of entities per type",
+            "example": 2,
+            "format": "int32",
+            "type": "integer"
+          },
+          "entityType": {
+            "description": "Object type that the tag applies to",
+            "example": "CERTIFICATE",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TagsBulkRequest": {
+        "properties": {
+          "tags": {
+            "description": "Array of tag and tag-value objects",
+            "items": {
+              "$ref": "#/components/schemas/TagRequest"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "Target": {
+        "properties": {
+          "connection": {
+            "description": "JSON object that configures the webhook connection for this target.\nSupported fields:\n- `url` (string, required): HTTPS endpoint URL for the webhook.\n- `headers` (object, optional): Key/value pairs of HTTP headers. Only the `Authorization` header is honored by the webhook service; all other headers are ignored.\n- `secret` (string, optional): Shared secret used to generate an HMAC signature sent in the `VaaS-Signature` header.\nWebhook deliveries always use `Content-Type: application/json`. Custom `Content-Type` values are not supported.\nExample:\n ```json\n{\n\"url\": \"https://example.com/webhook\",\n\"headers\": {\n\"Authorization\": \"Splunk 12345678-ABCD\"\n},\n\"secret\": \"my-shared-secret\"\n }\n",
+            "format": "json",
+            "type": "string"
+          },
+          "type": {
+            "description": "The delivery mechanism for this connector. For webhook-based notifications, use:\n- `generic` for a standard HTTPS webhook endpoint\n- `slack` for a Slack webhook target\n- `teams` for a Microsoft Teams webhook target\n",
+            "enum": [
+              "generic",
+              "slack",
+              "teams"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "connection",
+          "type"
+        ],
+        "type": "object"
+      },
+      "TargetsInformation": {
+        "discriminator": {
+          "propertyName": "serviceType"
+        },
+        "properties": {
+          "serviceType": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "serviceType"
+        ],
+        "type": "object"
+      },
+      "TeamId": {
+        "description": "The ID of a team.",
+        "example": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "format": "uuid",
+        "type": "string"
+      },
+      "TeamsIds": {
+        "description": "The ID's of teams.",
+        "items": {
+          "$ref": "#/components/schemas/TeamId"
+        },
+        "type": "array",
+        "uniqueItems": true
+      },
+      "TenantExpirationNotificationConfiguration": {
+        "properties": {
+          "additionalRecipients": {
+            "description": "A list of users and/or teams who should be added as recipients.",
+            "example": [
+              {
+                "id": "22153ae0-4352-11ee-b95c-3531a284802b",
+                "type": "User"
+              },
+              {
+                "id": "22153ae0-4352-11ee-b95c-12345abcd123",
+                "type": "Team"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Recipient"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "channels": {
+            "description": "A list of channels that should be used to deliver the notification.",
+            "example": [
+              "email"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Channel"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "enabled": {
+            "description": "If true, then the system will send notification for certificates which are nearing expiration.",
+            "example": true,
+            "type": "boolean"
+          },
+          "fallbackToPKIAdmin": {
+            "description": "If true, then all users with the PKI admin role will be added as recipients if the persona list does not include any recipients for a specific certificate.",
+            "example": true,
+            "type": "boolean"
+          },
+          "includeCertificateDetails": {
+            "description": "If true, then the notification may include potentially sensitive details about the certificate that is nearing expiration.",
+            "example": true,
+            "type": "boolean"
+          },
+          "personas": {
+            "description": "A list of personas who should be recipients of the notification. If \"Application Owners\" is included then the owners of the Application object to which the certificate is assigned will be added as recipients. If \"All PKI Admins\" or \"All Admins\" are present then all users in the system with that role will be added as recipients.",
+            "example": [
+              "Application Owners",
+              "All PKI Admins"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Persona"
+            },
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "type": "object"
+      },
+      "TenantExpirationReportsConfiguration": {
+        "properties": {
+          "additionalRecipients": {
+            "description": "A list of users and/or teams who should be added as recipients.",
+            "example": [
+              {
+                "id": "22153ae0-4352-11ee-b95c-3531a284802b",
+                "type": "User"
+              },
+              {
+                "id": "22153ae0-4352-11ee-b95c-12345abcd123",
+                "type": "Team"
+              }
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Recipient"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "channels": {
+            "description": "A list of channels that should be used to deliver the notification.",
+            "example": [
+              "email"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Channel"
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          },
+          "enabled": {
+            "description": "If true, then the system will send reports providing details of certificates which are nearing expiration.",
+            "example": true,
+            "type": "boolean"
+          },
+          "expiringWithinDays": {
+            "description": "Any certificates which will expire within the number of days specified here will be included in the report.",
+            "example": 30,
+            "type": "integer"
+          },
+          "ignoreAfterDays": {
+            "description": "Any certificates which have expired for more than the specified days will be excluded in the report.",
+            "example": 30,
+            "type": "integer"
+          },
+          "roles": {
+            "description": "All users with the specified VaaS roles will be added as a report recipient.",
+            "example": [
+              "SYSTEM_ADMIN"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Role"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
+          "schedule": {
+            "description": "A cron string representing the desired schedule for delivering reports. Note that currently reports may not be sent more than once per day. The `hour` and `minute` fields of the cron schedule will be ignored.",
+            "example": "0 0 * * Mon",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TenantRenewalConfiguration": {
+        "properties": {
+          "defaultIssuingTemplateId": {
+            "format": "UUID",
+            "type": "string"
+          },
+          "id": {
+            "description": "The object ID",
+            "example": "12a05220-4352-11ee-ac28-c1379e5decf9",
+            "format": "UUID",
+            "type": "string"
+          },
+          "renewalActions": {
+            "description": "A set of options that can be used to specify the actions that should be taken when the auto-renewal process runs.",
+            "example": {
+              "provision": false,
+              "renew": true
+            },
+            "properties": {
+              "provision": {
+                "description": "If true, the system with attempt to provision any certificates associated with this application after a successful auto-renewal.",
+                "type": "boolean"
+              },
+              "renew": {
+                "description": "If true, the system will attempt to renew any certificates associated with this application that are expected to expire within the configured number of days.",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "renew",
+              "provision"
+            ],
+            "type": "object"
+          },
+          "renewalWindow": {
+            "description": "A set of options to control the time window in which auto-renewal of certificates should be attempted.",
+            "example": {
+              "days": 30
+            },
+            "properties": {
+              "days": {
+                "description": "Any certificates associated with this object that are expected to expire within the specified number of days will be acted on.",
+                "format": "int64",
+                "minimum": 1,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "days"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "renewalWindow"
+        ],
+        "type": "object"
+      },
+      "TestCMSConfigurationRequest": {
+        "description": "The information representing a Credential Manager Service configuration for test purposes.",
+        "properties": {
+          "cmsDetails": {
+            "$ref": "#/components/schemas/TestCMSDetails"
+          },
+          "cmsType": {
+            "$ref": "#/components/schemas/CMSType"
+          },
+          "id": {
+            "$ref": "#/components/schemas/CMSConfId"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "vSatelliteIds": {
+            "$ref": "#/components/schemas/VSatelliteIds"
+          },
+          "wsClientId": {
+            "description": "An ID where you can subscribe to receive the response of the workflow.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "wsClientId"
+        ],
+        "type": "object"
+      },
+      "TestCMSConfigurationResponse": {
+        "description": "The result of testing the Credential Manager Service configuration.",
+        "properties": {
+          "workflowId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "workflowId",
+          "workflowName"
+        ],
+        "type": "object"
+      },
+      "TestCMSDetails": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/TestCyberArkDetails"
+          },
+          {
+            "$ref": "#/components/schemas/TestHashiCorpDetails"
+          }
+        ]
+      },
+      "TestCredentialDetails": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/TestCyberArkCredDetails"
+          },
+          {
+            "$ref": "#/components/schemas/TestHashiCorpCredDetails"
+          }
+        ]
+      },
+      "TestCredentialRequest": {
+        "description": "The properties representing a credential to test.",
+        "properties": {
+          "authType": {
+            "$ref": "#/components/schemas/AuthType"
+          },
+          "cmsType": {
+            "$ref": "#/components/schemas/CMSType"
+          },
+          "credentialDetails": {
+            "$ref": "#/components/schemas/TestCredentialDetails"
+          },
+          "id": {
+            "$ref": "#/components/schemas/CredentialId"
+          },
+          "wsClientId": {
+            "description": "An ID where you can subscribe to receive the response of the workflow.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "wsClientId"
+        ],
+        "type": "object"
+      },
+      "TestCredentialResponse": {
+        "description": "The result of testing access to the credential.",
+        "properties": {
+          "workflowId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "workflowName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "workflowId",
+          "workflowName"
+        ],
+        "type": "object"
+      },
+      "TestCyberArkCredDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CyberArkDetails"
+          }
+        ]
+      },
+      "TestCyberArkDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CyberArkConfigurationRequiredProp"
+          }
+        ]
+      },
+      "TestHashiCorpCredDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HashiCorpDetails"
+          }
+        ]
+      },
+      "TestHashiCorpDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HashiCorpConfigurationRequiredProp"
+          }
+        ]
+      },
+      "TokenAuthenticationData": {
+        "properties": {
+          "token": {
+            "description": "The token used for authentication with the underlying credentials provider.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "TrackingDataInformation": {
+        "discriminator": {
+          "propertyName": "certificateAuthority"
+        },
+        "properties": {
+          "certificateAuthority": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "certificateAuthority"
+        ],
+        "type": "object"
+      },
+      "UnaryOperator": {
+        "description": "An operator for filtering",
+        "enum": [
+          "NOT"
+        ],
+        "example": "NOT",
+        "type": "string"
+      },
+      "UpdateCMSConfigurationRequest": {
+        "description": "The information representing a Credential Manager Service configuration for update.",
+        "properties": {
+          "cmsDetails": {
+            "$ref": "#/components/schemas/UpdateCMSDetails"
+          },
+          "id": {
+            "$ref": "#/components/schemas/CMSConfId"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "vSatelliteIds": {
+            "$ref": "#/components/schemas/VSatelliteIds"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "UpdateCMSDetails": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/UpdateCyberArkDetails"
+          },
+          {
+            "$ref": "#/components/schemas/UpdateHashiCorpDetails"
+          }
+        ]
+      },
+      "UpdateCredentialDetails": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/UpdateCyberArkCredDetails"
+          },
+          {
+            "$ref": "#/components/schemas/UpdateHashiCorpCredDetails"
+          }
+        ]
+      },
+      "UpdateCredentialRequest": {
+        "description": "The properties representing a credential to update.",
+        "properties": {
+          "cmsConfigId": {
+            "$ref": "#/components/schemas/CMSConfId"
+          },
+          "credentialDetails": {
+            "$ref": "#/components/schemas/UpdateCredentialDetails"
+          },
+          "id": {
+            "$ref": "#/components/schemas/CredentialId"
+          },
+          "name": {
+            "$ref": "#/components/schemas/CredentialName"
+          },
+          "teamsIds": {
+            "$ref": "#/components/schemas/TeamsIds"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "UpdateCyberArkCredDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CyberArkDetails"
+          }
+        ]
+      },
+      "UpdateCyberArkDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CyberArkConfiguration"
+          }
+        ]
+      },
+      "UpdateHashiCorpCredDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HashiCorpDetails"
+          }
+        ]
+      },
+      "UpdateHashiCorpDetails": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/HashiCorpConfiguration"
+          }
+        ]
+      },
+      "UpdatesConfigRequest": {
+        "properties": {
+          "updateConfigSchedulerPattern": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DailyPatternInformation"
+              },
+              {
+                "$ref": "#/components/schemas/WeeklyPatternInformation"
+              }
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "updateConfigSchedulerPattern"
+        ],
+        "type": "object"
+      },
+      "UpdatesConfigResponse": {
+        "properties": {
+          "updateConfigSchedulerPattern": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/DailyPatternInformation"
+              },
+              {
+                "$ref": "#/components/schemas/WeeklyPatternInformation"
+              }
+            ],
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "UpgradeStatus": {
+        "enum": [
+          "LATEST",
+          "UPGRADE_PENDING",
+          "UPGRADING",
+          "FAILED"
+        ],
+        "type": "string"
+      },
+      "UriBuilder": {
+        "type": "object"
+      },
+      "UserPasswordAuthenticationData": {
+        "properties": {
+          "password": {
+            "description": "The user's password of the underlying credentials provider.",
+            "format": "password",
+            "type": "string"
+          },
+          "userName": {
+            "description": "The user's name of the underlying credentials provider.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "VSatelliteId": {
+        "description": "The VSatellite ID",
+        "format": "uuid",
+        "type": "string"
+      },
+      "VSatelliteIds": {
+        "description": "An array of the VSatellite Ids which are connected to the CMS provider.",
+        "items": {
+          "$ref": "#/components/schemas/VSatelliteId"
+        },
+        "minItems": 1,
+        "type": "array",
+        "uniqueItems": true
+      },
+      "WebhookProperties": {
+        "description": "Connector properties for webhook-based notifications.\nWebhook notifications are delivered as HTTP POST requests with a JSON body structured as:\n```json\n{\n  \"events\": [\n    {\n      \"eventName\": \"string\",\n      \"eventType\": \"string\",\n      \"message\": \"string\",\n      \"criticality\": 0,\n      \"createdAt\": \"2025-01-15T12:45:00Z\"\n    }\n  ]\n}\n```\nOnly one event is included per request. The webhook service sets `Content-Type: application/json`, `VaaS-Timestamp`, and, when a `secret` is configured in the connection, `VaaS-Signature`.\n",
+        "properties": {
+          "filter": {
+            "$ref": "#/components/schemas/Filter1"
+          },
+          "target": {
+            "$ref": "#/components/schemas/Target"
+          }
+        },
+        "required": [
+          "filter",
+          "target"
+        ],
+        "type": "object"
+      },
+      "WeeklyPatternInformation": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SchedulerPatternInformation2"
+          },
+          {
+            "properties": {
+              "daysOfWeek": {
+                "description": "Days of the week",
+                "enum": [
+                  "MONDAY",
+                  "TUESDAY",
+                  "WEDNESDAY",
+                  "THURSDAY",
+                  "FRIDAY",
+                  "SATURDAY",
+                  "SUNDAY"
+                ],
+                "items": {
+                  "description": "Days of the week",
+                  "enum": [
+                    "MONDAY",
+                    "TUESDAY",
+                    "WEDNESDAY",
+                    "THURSDAY",
+                    "FRIDAY",
+                    "SATURDAY",
+                    "SUNDAY"
+                  ],
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "duration": {
+                "description": "Duration in ISO-8601 format",
+                "enum": [
+                  "PT8H",
+                  "PT12H",
+                  "PT24H"
+                ],
+                "example": "PT24H",
+                "type": "string"
+              },
+              "startTime": {
+                "description": "Start time in HH:mm:ss format",
+                "pattern": "^([01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ],
+        "required": [
+          "daysOfWeek",
+          "duration",
+          "startTime"
+        ],
+        "type": "object"
+      },
+      "WorkType": {
+        "description": "Defines the type of supported workflow for the plugin.",
+        "enum": [
+          "DISCOVERY",
+          "CREDENTIAL",
+          "PROVISIONING",
+          "ISSUANCE",
+          "CERTIFICATE_IMPORT"
+        ],
+        "title": "WorkType",
+        "type": "string"
+      },
+      "WorkerServiceStatusDetails": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "WorkerStatus": {
+        "enum": [
+          "DRAFT",
+          "PAIRED",
+          "ACTIVE",
+          "FAILED",
+          "INACTIVE"
+        ],
+        "type": "string"
+      }
+    },
+    "securitySchemes": {
+      "scmOAuth": {
+        "type": "oauth2",
+        "description": "Strata Cloud Manager APIs authenticate client requests using the OAuth 2.0 Client Credentials flow. Please use the `client_id`, `client_secret` values associated with an IAM service account along with a scope value of `tsg_id:XXXXXXXXXX`, where `XXXXXXXXXX` is the Tenant Service Group (TSG) ID. The resulting JWT access token should be attached to all API calls as a `Bearer` token in the `Authorization` header (ex. `Authorization: Bearer tokenstring`).",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "https://auth.apps.paloaltonetworks.com/oauth2/access_token",
+            "scopes": {}
+          }
+        }
+      },
+      "scmToken": {
+        "type": "http",
+        "description": "Strata Cloud Manager APIs authenticate client requests using the OAuth 2.0 Client Credentials flow. Please use the `client_id`, `client_secret` values associated with an IAM service account along with a scope value of `tsg_id:XXXXXXXXXX`, where `XXXXXXXXXX` is the Tenant Service Group (TSG) ID. The resulting JWT access token should be attached to all API calls as a `Bearer` token in the `Authorization` header (ex. `Authorization: Bearer tokenstring`).",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  },
+  "security": [
+    {
+      "scmToken": []
+    }
+  ]
+}

--- a/openapi-specs/scm/config/ngts/tlsprotect-cloud.json
+++ b/openapi-specs/scm/config/ngts/tlsprotect-cloud.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "TLS Protect Cloud API for Strata Cloud Manager",
-    "description": "Use the TLS Protect Cloud APIs to manage certificates, certificate requests, applications, machine identities, users, teams, event logs, and more. This Open API spec file was created on May 11, 2026. © 2026 Palo Alto Networks, Inc. Palo Alto Networks is a registered trademark of Palo Alto Networks. A list of our trademarks can be found at https://www.paloaltonetworks.com/company/trademarks.html. All other marks mentioned herein may be trademarks of their respective companies.",
+    "description": "Use the TLS Protect Cloud APIs to manage certificates, certificate requests, applications, machine identities, users, teams, event logs, and more. This Open API spec file was created on June 04, 2026. © 2026 Palo Alto Networks, Inc. Palo Alto Networks is a registered trademark of Palo Alto Networks. A list of our trademarks can be found at https://www.paloaltonetworks.com/company/trademarks.html. All other marks mentioned herein may be trademarks of their respective companies.",
     "version": "1.0.0",
     "license": {
       "name": "MIT",
@@ -113,8 +113,8 @@
       "description": "APIs for Plugins."
     },
     {
-      "name": "Service Accounts",
-      "description": "APIs for Service Accounts."
+      "name": "Built-In Accounts",
+      "description": "APIs for Built-In Accounts."
     }
   ],
   "paths": {
@@ -179,12 +179,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -194,12 +194,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -218,7 +218,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CertificateImportRequest2"
+                "$ref": "#/components/schemas/CertificateImportRequest1"
               }
             }
           }
@@ -228,7 +228,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CertificateImportResponse2"
+                  "$ref": "#/components/schemas/CertificateImportResponse1"
                 }
               }
             },
@@ -238,7 +238,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -248,7 +248,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -309,7 +309,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -319,7 +319,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -329,7 +329,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -420,17 +420,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "application/octet-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -440,17 +440,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "application/octet-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -460,17 +460,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "application/octet-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -511,7 +511,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -521,7 +521,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -562,7 +562,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -572,7 +572,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -613,7 +613,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -623,7 +623,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -658,7 +658,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -668,7 +668,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -707,7 +707,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Filter2"
+                "$ref": "#/components/schemas/Filter"
               }
             }
           }
@@ -732,12 +732,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -747,12 +747,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -841,12 +841,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -856,12 +856,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -905,7 +905,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -915,7 +915,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -925,7 +925,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -967,7 +967,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -977,7 +977,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -998,7 +998,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Filter2"
+                "$ref": "#/components/schemas/Filter"
               }
             }
           }
@@ -1023,12 +1023,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1038,12 +1038,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1095,7 +1095,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1105,7 +1105,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1146,7 +1146,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1191,7 +1191,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1201,7 +1201,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1211,7 +1211,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1256,7 +1256,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1266,7 +1266,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1276,7 +1276,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1330,7 +1330,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1340,7 +1340,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1350,7 +1350,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse1"
                 }
               }
             },
@@ -1371,7 +1371,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CertificateImportRequest1"
+                "$ref": "#/components/schemas/CertificateImportRequest2"
               }
             }
           }
@@ -1381,7 +1381,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CertificateImportResponse1"
+                  "$ref": "#/components/schemas/CertificateImportResponse2"
                 }
               }
             },
@@ -1391,7 +1391,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse5"
                 }
               }
             },
@@ -1401,7 +1401,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse5"
                 }
               }
             },
@@ -1445,7 +1445,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse5"
                 }
               }
             },
@@ -1455,7 +1455,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse5"
                 }
               }
             },
@@ -1465,7 +1465,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse5"
                 }
               }
             },
@@ -1497,7 +1497,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1507,7 +1507,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1546,7 +1546,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1556,7 +1556,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1601,7 +1601,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1611,7 +1611,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1621,7 +1621,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1675,7 +1675,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1685,7 +1685,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1695,7 +1695,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1736,7 +1736,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1746,7 +1746,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1767,7 +1767,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Filter2"
+                "$ref": "#/components/schemas/Filter"
               }
             }
           }
@@ -1787,7 +1787,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1797,7 +1797,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -1840,7 +1840,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -1850,7 +1850,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -1889,7 +1889,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -1899,7 +1899,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -1909,7 +1909,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -1919,7 +1919,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -1964,7 +1964,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -1974,7 +1974,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -1984,7 +1984,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -2046,7 +2046,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -2056,7 +2056,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -2066,7 +2066,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -2102,7 +2102,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -2112,7 +2112,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -2122,7 +2122,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -2671,7 +2671,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2681,7 +2681,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2720,7 +2720,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2765,7 +2765,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2775,7 +2775,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2785,7 +2785,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2821,7 +2821,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2831,7 +2831,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2841,7 +2841,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2893,7 +2893,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2903,7 +2903,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2913,7 +2913,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2967,7 +2967,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2977,7 +2977,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -2987,7 +2987,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3028,7 +3028,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3038,7 +3038,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3093,7 +3093,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3103,7 +3103,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3142,7 +3142,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3187,7 +3187,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3197,7 +3197,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3207,7 +3207,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3243,7 +3243,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3253,7 +3253,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3263,7 +3263,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3315,7 +3315,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3325,7 +3325,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3335,7 +3335,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3389,7 +3389,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3441,7 +3441,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3451,7 +3451,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3489,7 +3489,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3499,7 +3499,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3509,7 +3509,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3519,7 +3519,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3564,7 +3564,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3574,7 +3574,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3584,7 +3584,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3629,7 +3629,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3639,7 +3639,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3649,7 +3649,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3690,7 +3690,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse1"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -3700,7 +3700,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse1"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -3749,12 +3749,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse1"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse1"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -3764,12 +3764,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse1"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse1"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -3804,7 +3804,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse1"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -3814,7 +3814,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse1"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -3852,7 +3852,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -3862,7 +3862,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -3872,7 +3872,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -3946,7 +3946,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -3956,7 +3956,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -3966,7 +3966,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4051,7 +4051,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4061,7 +4061,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4071,7 +4071,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4123,7 +4123,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4133,7 +4133,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4143,7 +4143,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4184,7 +4184,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4225,7 +4225,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4296,7 +4296,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4306,7 +4306,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4359,7 +4359,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4369,7 +4369,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4414,7 +4414,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4424,7 +4424,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4434,7 +4434,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -4534,7 +4534,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -4544,7 +4544,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -4554,7 +4554,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -4610,7 +4610,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -4620,7 +4620,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -4677,7 +4677,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -4687,7 +4687,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse2"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5645,7 +5645,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5655,7 +5655,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5685,7 +5685,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5695,7 +5695,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5738,7 +5738,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5748,7 +5748,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5758,7 +5758,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5810,7 +5810,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5820,7 +5820,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5830,7 +5830,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5871,7 +5871,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5881,7 +5881,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5891,7 +5891,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5934,7 +5934,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5944,7 +5944,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5974,7 +5974,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -5984,7 +5984,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6027,7 +6027,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6037,7 +6037,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6047,7 +6047,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6099,7 +6099,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6109,7 +6109,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6119,7 +6119,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6160,7 +6160,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6170,7 +6170,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6180,7 +6180,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6221,7 +6221,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6231,7 +6231,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6261,7 +6261,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6271,7 +6271,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6314,7 +6314,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6324,7 +6324,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6334,7 +6334,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6384,7 +6384,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6394,7 +6394,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6404,7 +6404,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6445,7 +6445,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6455,7 +6455,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6465,7 +6465,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6497,7 +6497,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6507,7 +6507,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse10"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -6574,7 +6574,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6584,7 +6584,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6594,7 +6594,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6651,7 +6651,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6661,7 +6661,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6704,7 +6704,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6714,7 +6714,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6744,7 +6744,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6754,7 +6754,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6799,7 +6799,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6809,7 +6809,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6819,7 +6819,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6871,7 +6871,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6881,7 +6881,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6891,7 +6891,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6933,7 +6933,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6943,7 +6943,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6953,7 +6953,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -6997,7 +6997,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7007,7 +7007,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7017,7 +7017,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7060,7 +7060,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7070,7 +7070,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7100,7 +7100,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7110,7 +7110,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7155,7 +7155,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7165,7 +7165,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7175,7 +7175,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7227,7 +7227,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7237,7 +7237,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7247,7 +7247,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7289,7 +7289,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7299,7 +7299,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7309,7 +7309,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse2"
                 }
               }
             },
@@ -7610,7 +7610,7 @@
         },
         "summary": "Retrieves all the Service Accounts the",
         "tags": [
-          "Service Accounts"
+          "Built-In Accounts"
         ]
       },
       "post": {
@@ -7650,7 +7650,7 @@
         },
         "summary": "Creates a Service Account",
         "tags": [
-          "Service Accounts"
+          "Built-In Accounts"
         ]
       }
     },
@@ -7698,7 +7698,7 @@
         },
         "summary": "Gets a Service Account",
         "tags": [
-          "Service Accounts"
+          "Built-In Accounts"
         ]
       },
       "patch": {
@@ -7748,7 +7748,7 @@
         },
         "summary": "Updates a Service Account",
         "tags": [
-          "Service Accounts"
+          "Built-In Accounts"
         ]
       },
       "delete": {
@@ -7787,7 +7787,7 @@
         },
         "summary": "Deletes a Service Account",
         "tags": [
-          "Service Accounts"
+          "Built-In Accounts"
         ]
       }
     },
@@ -7818,7 +7818,7 @@
         },
         "summary": "Retrieves all the Service Accounts Scopes",
         "tags": [
-          "Service Accounts"
+          "Built-In Accounts"
         ]
       }
     },
@@ -7866,7 +7866,7 @@
         },
         "summary": "Regenerate the OCI registry token for",
         "tags": [
-          "Service Accounts"
+          "Built-In Accounts"
         ]
       }
     },
@@ -7925,7 +7925,7 @@
         },
         "summary": "Updates a Service Account credentials",
         "tags": [
-          "Service Accounts"
+          "Built-In Accounts"
         ]
       }
     }
@@ -8188,7 +8188,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse3"
+              "$ref": "#/components/schemas/ErrorResponse10"
             }
           }
         },
@@ -8198,7 +8198,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse3"
+              "$ref": "#/components/schemas/ErrorResponse10"
             }
           }
         },
@@ -8208,7 +8208,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse3"
+              "$ref": "#/components/schemas/ErrorResponse10"
             }
           }
         },
@@ -8218,7 +8218,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse3"
+              "$ref": "#/components/schemas/ErrorResponse10"
             }
           }
         },
@@ -8228,7 +8228,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse3"
+              "$ref": "#/components/schemas/ErrorResponse10"
             }
           }
         },
@@ -8348,7 +8348,7 @@
             "$ref": "#/components/schemas/BaseActivityLogOrdering"
           },
           "paging": {
-            "$ref": "#/components/schemas/Page1"
+            "$ref": "#/components/schemas/Page2"
           }
         },
         "type": "object"
@@ -8993,6 +8993,13 @@
           "companyId": {
             "$ref": "#/components/schemas/CompanyId"
           },
+          "consumerTsgIds": {
+            "description": "List of sub-TSG IDs the configuration is explicitly shared with. Mutually exclusive with shareWithAll=true.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "createdBy": {
             "$ref": "#/components/schemas/CreatedBy"
           },
@@ -9010,6 +9017,10 @@
           },
           "name": {
             "$ref": "#/components/schemas/Name"
+          },
+          "shareWithAll": {
+            "description": "When true, the configuration is shared with all sub-TSGs.",
+            "type": "boolean"
           },
           "vSatelliteIds": {
             "$ref": "#/components/schemas/VSatelliteIds"
@@ -9327,6 +9338,25 @@
       },
       "CertificateImportRequest1": {
         "properties": {
+          "certificates": {
+            "description": "Base64 encoding certificate content.",
+            "items": {
+              "$ref": "#/components/schemas/CertificateImportInfo"
+            },
+            "type": "array"
+          },
+          "overrideBlocklist": {
+            "description": "Imports the certificate even if it's present in the Certificates blocklist.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "certificates"
+        ],
+        "type": "object"
+      },
+      "CertificateImportRequest2": {
+        "properties": {
           "edgeInstanceId": {
             "description": "Id for edge instance",
             "format": "uuid",
@@ -9354,40 +9384,7 @@
         ],
         "type": "object"
       },
-      "CertificateImportRequest2": {
-        "properties": {
-          "certificates": {
-            "description": "Base64 encoding certificate content.",
-            "items": {
-              "$ref": "#/components/schemas/CertificateImportInfo"
-            },
-            "type": "array"
-          },
-          "overrideBlocklist": {
-            "description": "Imports the certificate even if it's present in the Certificates blocklist.",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "certificates"
-        ],
-        "type": "object"
-      },
       "CertificateImportResponse1": {
-        "properties": {
-          "creationDate": {
-            "description": "Import creation date of certificates and private keys",
-            "format": "date-time",
-            "type": "string"
-          },
-          "id": {
-            "description": "Import id used to check the status of the bulk operation",
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "CertificateImportResponse2": {
         "properties": {
           "certificateInformations": {
             "description": "A collection of information about certificates that were newly imported.",
@@ -9404,6 +9401,20 @@
             },
             "description": "Certificate import statistics",
             "type": "object"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateImportResponse2": {
+        "properties": {
+          "creationDate": {
+            "description": "Import creation date of certificates and private keys",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Import id used to check the status of the bulk operation",
+            "type": "string"
           }
         },
         "type": "object"
@@ -10951,7 +10962,7 @@
             "$ref": "#/components/schemas/CustomAttributes2"
           },
           "errorInformation": {
-            "$ref": "#/components/schemas/ErrorInformation2"
+            "$ref": "#/components/schemas/ErrorInformation4"
           },
           "finalApproverId": {
             "description": "UUID of the final approver if configured",
@@ -11168,7 +11179,7 @@
             "$ref": "#/components/schemas/EncryptionDetails"
           },
           "errorInformation": {
-            "$ref": "#/components/schemas/ErrorInformation4"
+            "$ref": "#/components/schemas/ErrorInformation2"
           },
           "id": {
             "description": "UUID of a certificate request",
@@ -11368,7 +11379,7 @@
             "$ref": "#/components/schemas/CustomAttributesInformation"
           },
           "errorInformation": {
-            "$ref": "#/components/schemas/ErrorInformation2"
+            "$ref": "#/components/schemas/ErrorInformation4"
           },
           "finalApproverId": {
             "description": "UUID of the final approver if configured",
@@ -12528,73 +12539,6 @@
         },
         "type": "object"
       },
-      "ConnectorsCreationRequest": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "properties": {
-            "$ref": "#/components/schemas/WebhookProperties"
-          }
-        },
-        "required": [
-          "name",
-          "properties"
-        ],
-        "type": "object"
-      },
-      "ConnectorsInformation": {
-        "properties": {
-          "id": {
-            "description": "Unique identifier of the connector.",
-            "format": "uuid",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human-readable name of the connector.",
-            "type": "string"
-          },
-          "properties": {
-            "$ref": "#/components/schemas/WebhookProperties"
-          },
-          "status": {
-            "description": "Current status of the connector (for example, enabled or disabled).",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "status",
-          "properties"
-        ],
-        "type": "object"
-      },
-      "ConnectorsResponse": {
-        "properties": {
-          "connectors": {
-            "items": {
-              "$ref": "#/components/schemas/ConnectorsInformation"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "connectors"
-        ],
-        "type": "object"
-      },
-      "ConnectorsUpdateRequest": {
-        "properties": {
-          "properties": {
-            "$ref": "#/components/schemas/WebhookProperties"
-          }
-        },
-        "required": [
-          "properties"
-        ],
-        "type": "object"
-      },
       "CreateCMSConfigurationRequest": {
         "description": "The information representing a Credential Manager Service configuration for creation purpose.",
         "properties": {
@@ -12604,8 +12548,19 @@
           "cmsType": {
             "$ref": "#/components/schemas/CMSType"
           },
+          "consumerTsgIds": {
+            "description": "List of sub-TSG IDs the configuration is explicitly shared with. Mutually exclusive with shareWithAll=true.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "name": {
             "$ref": "#/components/schemas/Name"
+          },
+          "shareWithAll": {
+            "description": "When true, the configuration is shared with all sub-TSGs.",
+            "type": "boolean"
           },
           "vSatelliteIds": {
             "$ref": "#/components/schemas/VSatelliteIds"
@@ -12980,7 +12935,7 @@
       "DailyPatternInformation": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/SchedulerPatternInformation2"
+            "$ref": "#/components/schemas/SchedulerPatternInformation3"
           },
           {
             "properties": {
@@ -13521,7 +13476,7 @@
             "type": "string"
           },
           "value": {
-            "$ref": "#/components/schemas/AnyValue4"
+            "$ref": "#/components/schemas/AnyValue2"
           }
         },
         "type": "object"
@@ -13769,10 +13724,12 @@
         "type": "object"
       },
       "ErrorResponse10": {
+        "description": "Holds the response body returned for errors.",
         "properties": {
           "errors": {
+            "description": "List of encountered errors.",
             "items": {
-              "$ref": "#/components/schemas/ErrorInformation9"
+              "$ref": "#/components/schemas/Error"
             },
             "type": "array"
           }
@@ -13791,19 +13748,6 @@
         "type": "object"
       },
       "ErrorResponse3": {
-        "description": "Holds the response body returned for errors.",
-        "properties": {
-          "errors": {
-            "description": "List of encountered errors.",
-            "items": {
-              "$ref": "#/components/schemas/Error"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "ErrorResponse4": {
         "properties": {
           "errors": {
             "items": {
@@ -13814,7 +13758,7 @@
         },
         "type": "object"
       },
-      "ErrorResponse5": {
+      "ErrorResponse4": {
         "properties": {
           "errors": {
             "items": {
@@ -13825,7 +13769,7 @@
         },
         "type": "object"
       },
-      "ErrorResponse6": {
+      "ErrorResponse5": {
         "properties": {
           "errors": {
             "items": {
@@ -13836,7 +13780,7 @@
         },
         "type": "object"
       },
-      "ErrorResponse7": {
+      "ErrorResponse6": {
         "properties": {
           "errors": {
             "items": {
@@ -13847,7 +13791,7 @@
         },
         "type": "object"
       },
-      "ErrorResponse8": {
+      "ErrorResponse7": {
         "properties": {
           "errors": {
             "items": {
@@ -13858,11 +13802,22 @@
         },
         "type": "object"
       },
-      "ErrorResponse9": {
+      "ErrorResponse8": {
         "properties": {
           "errors": {
             "items": {
               "$ref": "#/components/schemas/ErrorInformation8"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ErrorResponse9": {
+        "properties": {
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/ErrorInformation9"
             },
             "type": "array"
           }
@@ -13914,6 +13869,35 @@
         "type": "object"
       },
       "Expression": {
+        "type": "object"
+      },
+      "ExpressionNode": {
+        "properties": {
+          "compound": {
+            "type": "boolean"
+          },
+          "field": {
+            "type": "string"
+          },
+          "operands": {
+            "items": {
+              "$ref": "#/components/schemas/ExpressionNode"
+            },
+            "type": "array"
+          },
+          "operator": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "values": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
         "type": "object"
       },
       "ExtendedApplicationOwnership": {
@@ -14864,7 +14848,7 @@
         "properties": {
           "domain": {
             "additionalProperties": {
-              "$ref": "#/components/schemas/AnyValue2"
+              "$ref": "#/components/schemas/AnyValue4"
             },
             "type": "object"
           },
@@ -14880,11 +14864,7 @@
         },
         "type": "object"
       },
-      "Filter1": {
-        "format": "json",
-        "type": "string"
-      },
-      "Filter2": {
+      "Filter": {
         "properties": {
           "expression": {
             "$ref": "#/components/schemas/BaseFilter"
@@ -14893,7 +14873,7 @@
             "$ref": "#/components/schemas/BaseOrdering"
           },
           "paging": {
-            "$ref": "#/components/schemas/Page2"
+            "$ref": "#/components/schemas/Page1"
           }
         },
         "type": "object"
@@ -15443,7 +15423,7 @@
             "type": "boolean"
           },
           "schedulePattern": {
-            "$ref": "#/components/schemas/SchedulerPatternInformation3"
+            "$ref": "#/components/schemas/SchedulerPatternInformation1"
           },
           "serviceType": {
             "description": "The type of an integration service",
@@ -15543,7 +15523,7 @@
             "type": "string"
           },
           "schedulePattern": {
-            "$ref": "#/components/schemas/SchedulerPatternInformation3"
+            "$ref": "#/components/schemas/SchedulerPatternInformation1"
           },
           "schedulerEnabled": {
             "description": "If a integration service is scheduled for execution",
@@ -15628,7 +15608,7 @@
             "type": "boolean"
           },
           "schedulePattern": {
-            "$ref": "#/components/schemas/SchedulerPatternInformation3"
+            "$ref": "#/components/schemas/SchedulerPatternInformation1"
           },
           "targets": {
             "$ref": "#/components/schemas/TargetsInformation"
@@ -15677,7 +15657,7 @@
             "type": "string"
           },
           "errorInformation": {
-            "$ref": "#/components/schemas/ErrorInformation9"
+            "$ref": "#/components/schemas/ErrorInformation7"
           },
           "fingerprint": {
             "description": "Intermediate certificate fingerprint",
@@ -15717,6 +15697,10 @@
           "status": {
             "description": "Status of the Intermediate certificate request",
             "example": "ISSUED",
+            "type": "string"
+          },
+          "subTsgId": {
+            "description": "Sub-TSG ID this intermediate certificate belongs to; null for non-NGTS tenants",
             "type": "string"
           },
           "ultraShortLivedCertCount": {
@@ -15834,7 +15818,7 @@
       "IssuingTemplateDomainsSyncInformation": {
         "properties": {
           "error": {
-            "$ref": "#/components/schemas/ErrorInformation4"
+            "$ref": "#/components/schemas/ErrorInformation2"
           },
           "issuingTemplateId": {
             "format": "uuid",
@@ -16431,10 +16415,9 @@
       "MachineCreationRequest": {
         "properties": {
           "connectionDetails": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "dekId": {
-            "minLength": 1,
             "type": "string"
           },
           "edgeInstanceId": {
@@ -16476,8 +16459,6 @@
         },
         "required": [
           "connectionDetails",
-          "dekId",
-          "edgeInstanceId",
           "name",
           "pluginId"
         ],
@@ -16621,14 +16602,14 @@
       "MachineIdentityCreationRequest": {
         "properties": {
           "binding": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "certificateId": {
             "format": "uuid",
             "type": "string"
           },
           "keystore": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "machineId": {
             "format": "uuid",
@@ -16651,7 +16632,7 @@
             "type": "array"
           },
           "binding": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "certificateFingerprint": {
             "type": "string"
@@ -16680,7 +16661,7 @@
             "type": "string"
           },
           "keystore": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "lastSeenOn": {
             "format": "date-time",
@@ -16694,7 +16675,7 @@
             "type": "string"
           },
           "metadata": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "modificationDate": {
             "format": "date-time",
@@ -16729,7 +16710,7 @@
       "MachineIdentityInformation": {
         "properties": {
           "binding": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "certificateId": {
             "format": "uuid",
@@ -16748,7 +16729,7 @@
             "type": "string"
           },
           "keystore": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "lastSeenOn": {
             "format": "date-time",
@@ -16759,7 +16740,7 @@
             "type": "string"
           },
           "metadata": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "modificationDate": {
             "format": "date-time",
@@ -16808,14 +16789,14 @@
       "MachineIdentityUpdateRequest": {
         "properties": {
           "binding": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "certificateId": {
             "format": "uuid",
             "type": "string"
           },
           "keystore": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           }
         },
         "type": "object"
@@ -16854,7 +16835,7 @@
             "type": "boolean"
           },
           "batchProvisioningSchedulerPattern": {
-            "$ref": "#/components/schemas/SchedulerPatternInformation1"
+            "$ref": "#/components/schemas/SchedulerPatternInformation2"
           },
           "batchProvisioningStatus": {
             "enum": [
@@ -16877,13 +16858,13 @@
             "type": "string"
           },
           "discoveryJson": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "discoverySchedulerEnabled": {
             "type": "boolean"
           },
           "discoverySchedulerPattern": {
-            "$ref": "#/components/schemas/SchedulerPatternInformation1"
+            "$ref": "#/components/schemas/SchedulerPatternInformation2"
           },
           "discoveryStatus": {
             "enum": [
@@ -16962,19 +16943,19 @@
             "type": "boolean"
           },
           "batchProvisioningSchedulerPattern": {
-            "$ref": "#/components/schemas/SchedulerPatternInformation1"
+            "$ref": "#/components/schemas/SchedulerPatternInformation2"
           },
           "connectionDetails": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "discoveryJson": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "discoverySchedulerEnabled": {
             "type": "boolean"
           },
           "discoverySchedulerPattern": {
-            "$ref": "#/components/schemas/SchedulerPatternInformation1"
+            "$ref": "#/components/schemas/SchedulerPatternInformation2"
           },
           "edgeInstanceId": {
             "format": "uuid",
@@ -17002,7 +16983,7 @@
       "MachineWorkflowRequest": {
         "properties": {
           "workflowInput": {
-            "$ref": "#/components/schemas/AnyValue5"
+            "$ref": "#/components/schemas/AnyValue3"
           },
           "workflowName": {
             "type": "string"
@@ -18581,7 +18562,7 @@
             "type": "string"
           },
           "entity": {
-            "$ref": "#/components/schemas/AnyValue2"
+            "$ref": "#/components/schemas/AnyValue4"
           },
           "entityTag": {
             "$ref": "#/components/schemas/EntityTag"
@@ -18589,7 +18570,7 @@
           "headers": {
             "additionalProperties": {
               "items": {
-                "$ref": "#/components/schemas/AnyValue2"
+                "$ref": "#/components/schemas/AnyValue4"
               },
               "type": "array"
             },
@@ -18684,7 +18665,7 @@
           "metadata": {
             "additionalProperties": {
               "items": {
-                "$ref": "#/components/schemas/AnyValue2"
+                "$ref": "#/components/schemas/AnyValue4"
               },
               "type": "array"
             },
@@ -18812,10 +18793,6 @@
       },
       "SchedulerPatternInformation2": {
         "discriminator": {
-          "mapping": {
-            "DAY": "#/components/schemas/DailyPatternInformation",
-            "WEEK": "#/components/schemas/WeeklyPatternInformation"
-          },
           "propertyName": "recurrenceType"
         },
         "properties": {
@@ -18830,6 +18807,10 @@
       },
       "SchedulerPatternInformation3": {
         "discriminator": {
+          "mapping": {
+            "DAY": "#/components/schemas/DailyPatternInformation",
+            "WEEK": "#/components/schemas/WeeklyPatternInformation"
+          },
           "propertyName": "recurrenceType"
         },
         "properties": {
@@ -19716,7 +19697,7 @@
         "properties": {
           "args": {
             "items": {
-              "$ref": "#/components/schemas/AnyValue7"
+              "$ref": "#/components/schemas/AnyValue8"
             },
             "type": "array"
           },
@@ -20139,29 +20120,6 @@
         },
         "type": "object"
       },
-      "Target": {
-        "properties": {
-          "connection": {
-            "description": "JSON object that configures the webhook connection for this target.\nSupported fields:\n- `url` (string, required): HTTPS endpoint URL for the webhook.\n- `headers` (object, optional): Key/value pairs of HTTP headers. Only the `Authorization` header is honored by the webhook service; all other headers are ignored.\n- `secret` (string, optional): Shared secret used to generate an HMAC signature sent in the `VaaS-Signature` header.\nWebhook deliveries always use `Content-Type: application/json`. Custom `Content-Type` values are not supported.\nExample:\n ```json\n{\n\"url\": \"https://example.com/webhook\",\n\"headers\": {\n\"Authorization\": \"Splunk 12345678-ABCD\"\n},\n\"secret\": \"my-shared-secret\"\n }\n",
-            "format": "json",
-            "type": "string"
-          },
-          "type": {
-            "description": "The delivery mechanism for this connector. For webhook-based notifications, use:\n- `generic` for a standard HTTPS webhook endpoint\n- `slack` for a Slack webhook target\n- `teams` for a Microsoft Teams webhook target\n",
-            "enum": [
-              "generic",
-              "slack",
-              "teams"
-            ],
-            "type": "string"
-          }
-        },
-        "required": [
-          "connection",
-          "type"
-        ],
-        "type": "object"
-      },
       "TargetsInformation": {
         "discriminator": {
           "propertyName": "serviceType"
@@ -20549,11 +20507,22 @@
           "cmsDetails": {
             "$ref": "#/components/schemas/UpdateCMSDetails"
           },
+          "consumerTsgIds": {
+            "description": "List of sub-TSG IDs the configuration is explicitly shared with. Mutually exclusive with shareWithAll=true.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "id": {
             "$ref": "#/components/schemas/CMSConfId"
           },
           "name": {
             "$ref": "#/components/schemas/Name"
+          },
+          "shareWithAll": {
+            "description": "When true, the configuration is shared with all sub-TSGs.",
+            "type": "boolean"
           },
           "vSatelliteIds": {
             "$ref": "#/components/schemas/VSatelliteIds"
@@ -20711,26 +20680,10 @@
         "type": "array",
         "uniqueItems": true
       },
-      "WebhookProperties": {
-        "description": "Connector properties for webhook-based notifications.\nWebhook notifications are delivered as HTTP POST requests with a JSON body structured as:\n```json\n{\n  \"events\": [\n    {\n      \"eventName\": \"string\",\n      \"eventType\": \"string\",\n      \"message\": \"string\",\n      \"criticality\": 0,\n      \"createdAt\": \"2025-01-15T12:45:00Z\"\n    }\n  ]\n}\n```\nOnly one event is included per request. The webhook service sets `Content-Type: application/json`, `VaaS-Timestamp`, and, when a `secret` is configured in the connection, `VaaS-Signature`.\n",
-        "properties": {
-          "filter": {
-            "$ref": "#/components/schemas/Filter1"
-          },
-          "target": {
-            "$ref": "#/components/schemas/Target"
-          }
-        },
-        "required": [
-          "filter",
-          "target"
-        ],
-        "type": "object"
-      },
       "WeeklyPatternInformation": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/SchedulerPatternInformation2"
+            "$ref": "#/components/schemas/SchedulerPatternInformation3"
           },
           {
             "properties": {

--- a/products/scm/api/config/ngts/ngts-api.md
+++ b/products/scm/api/config/ngts/ngts-api.md
@@ -1,0 +1,61 @@
+---
+id: ngts-api
+title: NGTS API
+sidebar_label: NGTS API
+keywords:
+  - Strata Cloud Manager
+  - NGTS
+  - Certificates
+  - Reference
+  - API
+---
+
+Welcome to the NGTS API reference section. This reference is your key to a comprehensive understanding of the NGTS APIs. Here you can start working with NGTS APIs as quickly as possible. Developers can try out our APIs right from our docs and see what's working (or not) with real-time logs. So let's jump right in!
+
+The NGTS APIs are designed for administrators to perform critical tasks, such as discovering and monitoring TLS keys and certificates and managing your TLS machine identities. This section provides detailed information about these APIs, including operations, types, inputs and outputs, and error codes.
+
+:::note
+Using the navigation on the left, you'll find details for each endpoint and type of object used in the API.
+:::
+
+## NGTS REST APIs
+
+The NGTS REST API provides programmatic access to functionality that is available via the NGTS web user interface (UI). Any task that can be performed using the UI can also be accomplished using the REST API. This feature allows you to automate operations that are present in the UI for greater consistency and scale.
+
+The REST API follows best practices in API design. For example, it uses JSON for encapsulating objects returned by the API, proper HTTP request verbs and status codes, and comprehensive error messages in failed requests to aid developers in diagnosing issues.
+
+## Common use cases
+
+- Auditing your organization's NGTS account to understand what certificates are in inventory.
+- Requesting certificates from NGTS for use by applications, such as HTTPS-enabled web servers. (Certificate request API)
+- Searching NGTS to understand what certificates have been issued by your organization.
+- Extracting data for custom reports based on certificate data and summary information to help track key and certificate management policy compliance.
+
+## Authentication
+
+The NGTS APIs use OAuth 2.0 Client Credentials flow for authentication. To get started:
+
+1. Create a [Tenant Service Group (TSG)](/scm/docs/tenant-service-groups) and a [service account](/scm/docs/service-accounts) with the appropriate roles.
+2. Use the service account's **Client ID** and **Client Secret** to [request an access token](/scm/docs/access-tokens).
+3. Include the token as a `Bearer` token in the `Authorization` header of every API call.
+
+The API endpoint pages let you authorize and run API calls directly from the docs.
+
+## Base URL
+
+All API requests use the following base URL. HTTPS is required for all requests.
+
+```
+https://api.strata.paloaltonetworks.com
+```
+
+## JSON
+
+Request and response bodies are encoded as JSON.
+
+- Top-level resources have an "object" property. This property can be used to determine the type of resource (e.g., "database," "user," etc.)
+- Property names are in camelCase (not snake_case or kebab-case).
+
+## Code samples
+
+Samples requests and responses are shown for each endpoint. Requests are shown using cURL, Go, Java, JavaScript, Python, and more. These samples make it easy to copy, paste, and modify as you build your integration.

--- a/products/scm/api/config/ngts/ngts-api.md
+++ b/products/scm/api/config/ngts/ngts-api.md
@@ -24,11 +24,15 @@ The NGTS REST API provides programmatic access to functionality that is availabl
 
 The REST API follows best practices in API design. For example, it uses JSON for encapsulating objects returned by the API, proper HTTP request verbs and status codes, and comprehensive error messages in failed requests to aid developers in diagnosing issues.
 
+:::info
+
 ## NGTS-specific behavior
 
 The `application(s)` and `team(s)` resources do not apply to Next-Gen Trust Security (NGTS). These fields remain in the schemas in this section for backward compatibility with Venafi Control Plane SaaS, but in NGTS they are ignored on request and are not populated in responses. You can safely omit them from NGTS requests.
 
 The NGTS API uses `/serviceaccount` endpoints to manage what the NGTS UI calls **Built-in Accounts**. The feature was renamed in the UI to avoid confusion with Strata Cloud Manager Service Accounts, but the API endpoint paths and field names were not changed. When you see `serviceaccount` in the API, it refers to NGTS Built-in Accounts, not Strata Cloud Manager Service Accounts.
+
+:::
 
 ## Common use cases
 

--- a/products/scm/api/config/ngts/ngts-api.md
+++ b/products/scm/api/config/ngts/ngts-api.md
@@ -24,6 +24,12 @@ The NGTS REST API provides programmatic access to functionality that is availabl
 
 The REST API follows best practices in API design. For example, it uses JSON for encapsulating objects returned by the API, proper HTTP request verbs and status codes, and comprehensive error messages in failed requests to aid developers in diagnosing issues.
 
+## NGTS-specific behavior
+
+The `application(s)` and `team(s)` resources do not apply to Next-Gen Trust Security (NGTS). These fields remain in the schemas in this section for backward compatibility with Venafi Control Plane SaaS, but in NGTS they are ignored on request and are not populated in responses. You can safely omit them from NGTS requests.
+
+The NGTS API uses `/serviceaccount` endpoints to manage what the NGTS UI calls **Built-in Accounts**. The feature was renamed in the UI to avoid confusion with Strata Cloud Manager Service Accounts, but the API endpoint paths and field names were not changed. When you see `serviceaccount` in the API, it refers to NGTS Built-in Accounts, not Strata Cloud Manager Service Accounts.
+
 ## Common use cases
 
 - Auditing your organization's NGTS account to understand what certificates are in inventory.

--- a/products/scm/sidebars.ts
+++ b/products/scm/sidebars.ts
@@ -285,6 +285,18 @@ module.exports = {
     },
     {
       type: "category",
+      label: "NGTS Configuration",
+      collapsed: true,
+      items: [
+        {
+          type: "doc",
+          id: "scm/api/config/ngts/ngts-api",
+        },
+        require("./api/config/ngts/sidebar"),
+      ],
+    },
+    {
+      type: "category",
       label: "Incidents API",
       collapsed: true,
       items: [

--- a/src/pages/strata-cloud-manager/index.js
+++ b/src/pages/strata-cloud-manager/index.js
@@ -197,6 +197,13 @@ export default function SCMLandingPage() {
             icon: "api-doc",
           },
         ],
+        "NGTS Configuration": [
+          {
+            to: "scm/api/config/ngts/ngts-api",
+            label: "NGTS API",
+            icon: "api-doc",
+          },
+        ],
         Posture: [
           {
             to: "scm/api/config/posture-management/introduction-posture",

--- a/static/img/homepage-banner/2.svg
+++ b/static/img/homepage-banner/2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="400" viewBox="0 0 1200 400">
+  <rect width="1200" height="400" fill="#FA582D" opacity="0.1"/>
+</svg>


### PR DESCRIPTION
Adds the Venafi NGTS TLS Protect Cloud API reference to the Strata Cloud Manager section of pan.dev, and excludes operations that are not in scope for the Strata publication.

## Added

**NGTS TLS Protect Cloud API** — 97 paths across 25 categories:

Certificates, Certificate Installations, Certificate Discovery, Certificate Import, Private Key Import, Certificate Request, Certificate Policy, Credential Management, Machine Identities, Machine Types, Machines, Event Logs, VSatellite, Certificate Inventory Monitoring, Certificate Auto-renewal Monitoring, Certificate Expiration Reports, Tags, Workload Identity Manager Configurations, Workload Identity Manager Sub CA Providers, Workload Identity Manager Policies, Workload Identity Manager Intermediate Certificates, Certificate Approvals, Certificate Revocation Approvals, Plugins, Built-In Accounts

Files:
- `openapi-specs/scm/config/ngts/tlsprotect-cloud.json` — spec (from ua-repo CI)
- `products/scm/api/config/ngts/ngts-api.md` — overview landing page
- `docusaurus.config.ts` — NGTS plugin entry

## Excluded from the full spec (not published to pan.dev)

**Application category** (VC-51819, ua-repo MR-355 — merged 2026-04-28):
- `applications_getAll`, `applications_getById`, `applications_create`, `applications_update`, `applications_delete`
- `applications_invitations_create`, `applications_getScanafiConfigById`
- `applications_assignToCertificates`, `applications_getByName`
- `certificateissuingtemplates_getByAlias`

**Certificate Renewal Configuration** (VC-51819, ua-repo MR-355):
- `get-v1-application-renewal-configuration`
- `put-v1-application-renewal-configuration`

**Users, UserAccounts, and Teams** (VC-51672, ua-repo MR-357 — merged 2026-05-08):
- `/v1/users`, `/v1/users/{id}` and 4 sub-paths (6 paths)
- `/v1/useraccounts` (1 path)
- `/v1/teams`, `/v1/teams/{id}`, `/v1/teams/{id}/members`, `/v1/teams/{id}/owners` (4 paths)

**Webhooks** (VC-51671, ua-repo MR-358 — merged 2026-05-15):
- `connectors_getAll`, `connectors_create`, `connectors_update`, `connectors_delete`
- Paths: `/v1/connectors`, `/v1/connectors/{id}`

**Full spec scope: 111 paths → 97 paths published (-14)**

## Why

NGTS is scoping the Strata pan.dev publication to certificate and machine identity management operations only. Application management, user/team management, and webhook connectors are excluded from this publication. Source of truth: ua-repo `siteconf-pandev.yaml`.

## Validation

- Spec pulled from ua-repo CI pipeline 2577181082 / job 14699443096 (commit cf822261, post MR-361 merge to master)
- 97 paths confirmed in output spec
- Spectral linted locally against `techpubs/docs/api-specs` `spectral/netsec-ruleset.yaml` — **0 errors** (pre-existing warnings unchanged)

## Changelog

| Commit | Change | Source |
|--------|--------|--------|
| `076c3c3d` | Initial publication — 97 paths, Application/users/teams/webhooks excluded | ua-repo MRs 355, 357, 358 |
| `ae340d66` | Updated ngts-api.md landing page copy | VC-51675 |
| `40aee096` | Renamed "Service Accounts" category to "Built-In Accounts" | VC-54460, ua-repo MR-361 |

## Relation to existing #1167

This branch was forked from `add-ngts-api-docs` and contains all of #1167's commits plus the VC-51819, VC-51672, and VC-51671 spec changes. Once this merges, #1167 can be closed (or rebased) to avoid conflicts.