### PR TITLE
RLP-15854 Deprecate Asset Inventory v3 and Compliance Posture v2 trend endpoints (RLP-158545)

### DIFF
--- a/openapi-specs/cspm/AssetInventory.json
+++ b/openapi-specs/cspm/AssetInventory.json
@@ -1560,6 +1560,7 @@
     },
     "/v3/inventory/trend": {
       "get": {
+        "deprecated": true,
         "description": "Returns asset inventory pass/fail trends.",
         "operationId": "asset-inventory-trend-v3",
         "parameters": [
@@ -1704,6 +1705,7 @@
         ]
       },
       "post": {
+        "deprecated": true,
         "description": "Returns asset inventory pass/fail trends.  \r\n\r\nYou can get a list of the valid names and values for the filters body parameter \nthrough [List Inventory Filters V2](/prisma-cloud/api/cspm/get-asset-inventory-v-2-dashboard-filter-options).\n",
         "operationId": "post-method-asset-inventory-trend-v3",
         "requestBody": {

--- a/openapi-specs/cspm/CompliancePosture.json
+++ b/openapi-specs/cspm/CompliancePosture.json
@@ -2277,6 +2277,7 @@
     },
     "/v2/compliance/posture/trend": {
       "get": {
+        "deprecated": true,
         "description": "Returns a compliance posture summary that describes the passed/failed statistics trend.",
         "operationId": "get-compliance-posture-trend-v2",
         "parameters": [
@@ -2364,6 +2365,7 @@
         ]
       },
       "post": {
+        "deprecated": true,
         "description": "Returns a compliance posture summary that describes the passed/failed statistics trend.  \r\n\r\nThe **`fields`** body parameter allows you to request specific fields. These fields are separate \nfrom the filters you specify. The following are valid **fields** items.\n\n* cloud.account\n* account.group\n* cloud.region\n* cloud.type\n* policy.complianceStandard\n* policy.complianceRequirement\n* policy.complianceSection\n\nThe **`filters`** body parameter enables you to narrow your request for alerts. \nSee [Get Compliance Overview Filters and Options](/prisma-cloud/api/cspm/get-compliance-posture-filters-and-options) \nfor the API request to list all valid filters.",
         "operationId": "post-compliance-posture-trend-v2",
         "requestBody": {
@@ -2406,6 +2408,7 @@
     },
     "/v2/compliance/posture/trend/{complianceId}": {
       "get": {
+        "deprecated": true,
         "description": "Returns a compliance posture summary that describes the passed/failed statistics trend for the specified compliance standard ID.  \r\n\r\nThe **fields** request body parameter allows you to request specific fields. These fields are separate \nfrom the filters you specify. The following are valid **fields** items.\n\n* cloud.account\n* account.group\n* cloud.region\n* cloud.type\n* policy.complianceStandard\n* policy.complianceRequirement\n* policy.complianceSection\n\nThe **filters** request body parameter enables you to narrow your request for alerts. \nSee [Get Compliance Overview Filters and Options](/prisma-cloud/api/cspm/get-compliance-posture-filters-and-options) \nfor for an API request to list all the valid filters.\n",
         "operationId": "get-compliance-posture-trend-for-standard-v2",
         "parameters": [
@@ -2494,6 +2497,7 @@
         ]
       },
       "post": {
+        "deprecated": true,
         "description": "Returns a compliance posture summary that describes the passed/failed statistics trend for the specified compliance standard ID.",
         "operationId": "post-compliance-posture-trend-for-standard-v2",
         "parameters": [
@@ -2548,6 +2552,7 @@
     },
     "/v2/compliance/posture/trend/{complianceId}/{requirementId}": {
       "get": {
+        "deprecated": true,
         "description": "Returns the compliance posture summary that describes the passed/failed statistics trend for the given compliance standard ID and compliance requirement ID.",
         "operationId": "get-compliance-posture-trend-for-requirement-v2",
         "parameters": [
@@ -2637,6 +2642,7 @@
         ]
       },
       "post": {
+        "deprecated": true,
         "description": "Returns the compliance posture summary that describes the passed/failed statistics trend for the given compliance standard ID and compliance requirement ID.  \r\n\r\nThe **fields** body parameter allows you to request specific fields. These fields are separate \nfrom the filters you specify. The following are valid **fields** items.\n\n* cloud.account\n* account.group\n* cloud.region\n* cloud.type\n* policy.complianceStandard\n* policy.complianceRequirement\n* policy.complianceSection\n\nThe **filters** body parameter enables you to narrow your request for alerts. \nSee [Get Compliance Overview Filters and Options](/prisma-cloud/api/cspm/get-compliance-posture-filters-and-options)\nfor the API request to list all valid filters.                               \n",
         "operationId": "post-compliance-posture-trend-for-requirement-v2",
         "parameters": [


### PR DESCRIPTION
## Description

Marks 8 CSPM trend endpoints as deprecated

Jira: [RLP-158545](https://jira-dc.paloaltonetworks.com/browse/RLP-158545)

### Endpoints deprecated

**[`openapi-specs/cspm/AssetInventory.json`](openapi-specs/cspm/AssetInventory.json)**
- `GET  /v3/inventory/trend` — [`asset-inventory-trend-v3`](openapi-specs/cspm/AssetInventory.json:1565)
- `POST /v3/inventory/trend` — [`post-method-asset-inventory-trend-v3`](openapi-specs/cspm/AssetInventory.json:1710)

**[`openapi-specs/cspm/CompliancePosture.json`](openapi-specs/cspm/CompliancePosture.json)**
- `GET  /v2/compliance/posture/trend` — [`get-compliance-posture-trend-v2`](openapi-specs/cspm/CompliancePosture.json:2282)
- `POST /v2/compliance/posture/trend` — [`post-compliance-posture-trend-v2`](openapi-specs/cspm/CompliancePosture.json:2370)
- `GET  /v2/compliance/posture/trend/{complianceId}` — [`get-compliance-posture-trend-for-standard-v2`](openapi-specs/cspm/CompliancePosture.json:2412)
- `POST /v2/compliance/posture/trend/{complianceId}` — [`post-compliance-posture-trend-for-standard-v2`](openapi-specs/cspm/CompliancePosture.json:2500)
- `GET  /v2/compliance/posture/trend/{complianceId}/{requirementId}` — [`get-compliance-posture-trend-for-requirement-v2`](openapi-specs/cspm/CompliancePosture.json:2554)
- `POST /v2/compliance/posture/trend/{complianceId}/{requirementId}` — [`post-compliance-posture-trend-for-requirement-v2`](openapi-specs/cspm/CompliancePosture.json:2643)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
