### PR TITLE
Changes to Device Security Public APIs for IPR-1048: Enhance Subnet Create and Subnet Upload APIs

### DIFF
--- a/openapi-specs/iot/components/examples.yaml
+++ b/openapi-specs/iot/components/examples.yaml
@@ -1439,7 +1439,8 @@ examples:
         "description": "Subnet example description create",
         "static": true,
         "monitored": true,
-        "name": "Example Subnet"
+        "name": "Example Subnet",
+        "site": "HQ-East"
       }
     ]
 
@@ -1459,7 +1460,8 @@ examples:
         "description": "Subnet example description create",
         "static": true,
         "monitored": true,
-        "name": "Example PUT Update Subnet"
+        "name": "Example PUT Update Subnet",
+        "shared_block": true
       }
     ]
 

--- a/openapi-specs/iot/components/schemas.yaml
+++ b/openapi-specs/iot/components/schemas.yaml
@@ -1918,6 +1918,18 @@ schemas:
         name:
           type: string
           description: Name of the subnet
+        site:
+          type: string
+          description: >-
+            Name of the site to assign this subnet to. Site-based subnet assignment tenants
+            only (check the Sites page of the Device Security UI); mutually exclusive with
+            `shared_block`.
+        shared_block:
+          type: boolean
+          description: >-
+            Marks the subnet as a parent prefix whose IP space is reused across the tenant's
+            network segments. Site-based subnet assignment tenants only; mutually exclusive
+            with `site`.
 
   CreateSubnetResponse:
     type: object
@@ -2010,6 +2022,18 @@ schemas:
         name:
           type: string
           description: Name of the subnet
+        site:
+          type: string
+          description: >-
+            Name of the site to assign this subnet to. Site-based subnet assignment tenants
+            only (check the Sites page of the Device Security UI); mutually exclusive with
+            `shared_block`.
+        shared_block:
+          type: boolean
+          description: >-
+            Marks the subnet as a parent prefix whose IP space is reused across the tenant's
+            network segments. Site-based subnet assignment tenants only; mutually exclusive
+            with `site`.
 
   UpdateSubnetResponse:
     type: object


### PR DESCRIPTION
## Description

  Document new optional `site` and `shared_block` fields on the `POST /subnet` (createSubnet) and `PUT /subnet` (updateSubnet) public API payloads. Updates schema definitions and payload examples in `openapi-specs/iot/components/{schemas,examples}.yaml`.

  ## Motivation and Context

  Backend change IPR-1048 added two new optional fields to the bulk subnet create/update APIs. The fields are mutually exclusive and only valid for tenants in site-based subnet assignment mode. Documenting them so API consumers know when and how to use them.

  ## How Has This Been Tested?

  Edited YAML only; verified the new properties render under the existing `CreateSubnetPayloadSchema` / `UpdateSubnetPayloadSchema` and that the updated payload examples remain valid JSON.

  ## Screenshots (if appropriate)

  N/A

  ## Types of changes

  - New feature (non-breaking change which adds functionality)

  ## Checklist

  - [x] I have updated the documentation accordingly.
  - [x] I have read the **CONTRIBUTING** document.
  - [ ] I have added tests to cover my changes if appropriate.
  - [ ] All new and existing tests passed.