### PR TITLE
fix(ngts): correct /ngts base URL and align section names with NGTS

### DIFF
--- a/openapi-specs/scm/config/ngts/tlsprotect-cloud.json
+++ b/openapi-specs/scm/config/ngts/tlsprotect-cloud.json
@@ -21,8 +21,8 @@
       "description": "APIs for Certificates."
     },
     {
-      "name": "Certificate Installations",
-      "description": "APIs for Certificate Installations."
+      "name": "TLS Server Endpoints",
+      "description": "APIs for TLS Server Endpoints."
     },
     {
       "name": "Certificate Discovery",
@@ -49,8 +49,8 @@
       "description": "APIs for Credential Management."
     },
     {
-      "name": "Machine Identities",
-      "description": "APIs for Machine Identities."
+      "name": "Machine Installations",
+      "description": "APIs for Machine Installations."
     },
     {
       "name": "Machine Types",
@@ -77,28 +77,24 @@
       "description": "APIs for Certificate Auto-renewal Monitoring."
     },
     {
-      "name": "Certificate Expiration Reports",
-      "description": "APIs for Certificate Expiration Reports."
+      "name": "Certificate Tags",
+      "description": "APIs for Certificate Tags."
     },
     {
-      "name": "Tags",
-      "description": "APIs for Tags."
+      "name": "Issuer Configurations",
+      "description": "APIs for Issuer Configurations."
     },
     {
-      "name": "Workload Identity Manager Configurations",
-      "description": "APIs for Workload Identity Manager Configurations."
+      "name": "Issuer Sub CA Providers",
+      "description": "APIs for Issuer Sub CA Providers."
     },
     {
-      "name": "Workload Identity Manager Sub CA Providers",
-      "description": "APIs for Workload Identity Manager Sub CA Providers."
+      "name": "Workload Issuance Policies",
+      "description": "APIs for Workload Issuance Policies."
     },
     {
-      "name": "Workload Identity Manager Policies",
-      "description": "APIs for Workload Identity Manager Policies."
-    },
-    {
-      "name": "Workload Identity Manager Intermediate Certificates",
-      "description": "APIs for Workload Identity Manager Intermediate Certificates."
+      "name": "Issuer Certificates",
+      "description": "APIs for Issuer Certificates."
     },
     {
       "name": "Certificate Approvals",
@@ -109,8 +105,8 @@
       "description": "APIs for Certificate Revocation Approvals."
     },
     {
-      "name": "Plugins",
-      "description": "APIs for Plugins."
+      "name": "Plugins (Connectors)",
+      "description": "APIs for Plugins (Connectors)."
     },
     {
       "name": "Built-In Accounts",
@@ -870,7 +866,7 @@
         },
         "summary": "Retrieve Certificate Instances",
         "tags": [
-          "Certificate Installations"
+          "TLS Server Endpoints"
         ]
       }
     },
@@ -934,7 +930,7 @@
         },
         "summary": "Get a certificate installation details",
         "tags": [
-          "Certificate Installations"
+          "TLS Server Endpoints"
         ]
       }
     },
@@ -986,7 +982,7 @@
         },
         "summary": "Request validation for a set of",
         "tags": [
-          "Certificate Installations"
+          "TLS Server Endpoints"
         ]
       }
     },
@@ -1052,7 +1048,7 @@
         },
         "summary": "Retrieve certificate instance data matching search",
         "tags": [
-          "Certificate Installations"
+          "TLS Server Endpoints"
         ]
       }
     },
@@ -2690,7 +2686,7 @@
         },
         "summary": "Get the details of all machine",
         "tags": [
-          "Machine Identities"
+          "Machine Installations"
         ]
       },
       "post": {
@@ -2729,7 +2725,7 @@
         },
         "summary": "Add a machine identity to a",
         "tags": [
-          "Machine Identities"
+          "Machine Installations"
         ]
       }
     },
@@ -2794,7 +2790,7 @@
         },
         "summary": "Get a machine identity details",
         "tags": [
-          "Machine Identities"
+          "Machine Installations"
         ]
       },
       "delete": {
@@ -2850,7 +2846,7 @@
         },
         "summary": "Remove a machine identity",
         "tags": [
-          "Machine Identities"
+          "Machine Installations"
         ]
       },
       "patch": {
@@ -2922,7 +2918,7 @@
         },
         "summary": "Update a machine identity details",
         "tags": [
-          "Machine Identities"
+          "Machine Installations"
         ]
       }
     },
@@ -2996,7 +2992,7 @@
         },
         "summary": "Initiate a machine workflow",
         "tags": [
-          "Machine Identities"
+          "Machine Installations"
         ]
       }
     },
@@ -3047,7 +3043,7 @@
         },
         "summary": "Get the details of machine identities",
         "tags": [
-          "Machine Identities"
+          "Machine Installations"
         ]
       }
     },
@@ -4898,92 +4894,6 @@
         ]
       }
     },
-    "/v1/expirationreports/tenantconfiguration": {
-      "get": {
-        "description": "Retrieve the certificate expiration reports configuration for the current tenant",
-        "operationId": "get-v1-tenant-expiration-reports-configuration",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TenantExpirationReportsConfiguration"
-                }
-              }
-            },
-            "description": "Success"
-          },
-          "400": {
-            "description": "BadRequest"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "500": {
-            "description": "InternalServerError"
-          }
-        },
-        "summary": "Retrieve the certificate expiration reports config",
-        "tags": [
-          "Certificate Expiration Reports"
-        ]
-      },
-      "put": {
-        "description": "Update the certificate expiration reports configuration for the current tenant",
-        "operationId": "put-v1-tenant-expiration-reports-configuration",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TenantExpirationReportsConfiguration"
-              }
-            }
-          },
-          "description": "The options to apply",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TenantExpirationReportsConfiguration"
-                }
-              }
-            },
-            "description": "Success. The tenant configuration was successfully updated."
-          },
-          "400": {
-            "description": "BadRequest"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "500": {
-            "description": "InternalServerError"
-          }
-        },
-        "summary": "Update the certificate expiration reports configur",
-        "tags": [
-          "Certificate Expiration Reports"
-        ]
-      }
-    },
-    "/v1/expirationreports/trigger": {
-      "post": {
-        "description": "The certificate reports job is normally scheduled per the tenant configuration. This operation attempts to start the process for the current tenant now.",
-        "operationId": "post-v1-run-reports",
-        "responses": {
-          "204": {
-            "description": "Success. The reports check process was triggered."
-          }
-        },
-        "summary": "Attempt to initiate the certificate reports",
-        "tags": [
-          "Certificate Expiration Reports"
-        ]
-      }
-    },
     "/v1/tags": {
       "get": {
         "description": "Retrieve details of all available tags",
@@ -5022,7 +4932,7 @@
         },
         "summary": "Retrieve all tags",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       },
       "post": {
@@ -5073,7 +4983,7 @@
         },
         "summary": "Create a tag",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       }
     },
@@ -5137,7 +5047,7 @@
         },
         "summary": "Retrieve tag by name",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       },
       "delete": {
@@ -5182,7 +5092,7 @@
         },
         "summary": "Delete tag by name",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       }
     },
@@ -5246,7 +5156,7 @@
         },
         "summary": "Retrieve values for a tag",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       },
       "post": {
@@ -5309,7 +5219,7 @@
         },
         "summary": "Create tag values",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       }
     },
@@ -5366,7 +5276,7 @@
         },
         "summary": "Delete a tag value",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       }
     },
@@ -5408,7 +5318,7 @@
         },
         "summary": "Retrieve values for all tags",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       }
     },
@@ -5461,7 +5371,7 @@
         },
         "summary": "Create tags in bulk",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       }
     },
@@ -5507,7 +5417,7 @@
         },
         "summary": "Delete tags in bulk",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       }
     },
@@ -5560,7 +5470,7 @@
         },
         "summary": "Replace Add Or Delete Tags",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       }
     },
@@ -5613,7 +5523,7 @@
         },
         "summary": "Bulk operation to retrieve number of",
         "tags": [
-          "Tags"
+          "Certificate Tags"
         ]
       }
     },
@@ -5664,7 +5574,7 @@
         },
         "summary": "Create a new Issuer configuration",
         "tags": [
-          "Workload Identity Manager Configurations"
+          "Issuer Configurations"
         ]
       },
       "get": {
@@ -5704,7 +5614,7 @@
         },
         "summary": "Get the details of all Issuer",
         "tags": [
-          "Workload Identity Manager Configurations"
+          "Issuer Configurations"
         ]
       }
     },
@@ -5767,7 +5677,7 @@
         },
         "summary": "Get configurations details for a specific",
         "tags": [
-          "Workload Identity Manager Configurations"
+          "Issuer Configurations"
         ]
       },
       "patch": {
@@ -5839,7 +5749,7 @@
         },
         "summary": "Update an Issuer configuration details",
         "tags": [
-          "Workload Identity Manager Configurations"
+          "Issuer Configurations"
         ]
       },
       "delete": {
@@ -5900,7 +5810,7 @@
         },
         "summary": "Remove an Issuer configuration",
         "tags": [
-          "Workload Identity Manager Configurations"
+          "Issuer Configurations"
         ]
       }
     },
@@ -5953,7 +5863,7 @@
         },
         "summary": "Create a new Sub CA provider",
         "tags": [
-          "Workload Identity Manager Sub CA Providers"
+          "Issuer Sub CA Providers"
         ]
       },
       "get": {
@@ -5993,7 +5903,7 @@
         },
         "summary": "Get the details of all Sub",
         "tags": [
-          "Workload Identity Manager Sub CA Providers"
+          "Issuer Sub CA Providers"
         ]
       }
     },
@@ -6056,7 +5966,7 @@
         },
         "summary": "Get a Sub CA provider details",
         "tags": [
-          "Workload Identity Manager Sub CA Providers"
+          "Issuer Sub CA Providers"
         ]
       },
       "patch": {
@@ -6128,7 +6038,7 @@
         },
         "summary": "Update a Sub CA provider details",
         "tags": [
-          "Workload Identity Manager Sub CA Providers"
+          "Issuer Sub CA Providers"
         ]
       },
       "delete": {
@@ -6189,7 +6099,7 @@
         },
         "summary": "Remove a Sub CA provider",
         "tags": [
-          "Workload Identity Manager Sub CA Providers"
+          "Issuer Sub CA Providers"
         ]
       }
     },
@@ -6240,7 +6150,7 @@
         },
         "summary": "Create a new Workload Issuance policy",
         "tags": [
-          "Workload Identity Manager Policies"
+          "Workload Issuance Policies"
         ]
       },
       "get": {
@@ -6280,7 +6190,7 @@
         },
         "summary": "Get the details of all Workload",
         "tags": [
-          "Workload Identity Manager Policies"
+          "Workload Issuance Policies"
         ]
       }
     },
@@ -6343,7 +6253,7 @@
         },
         "summary": "Get a Workload Issuance policy details",
         "tags": [
-          "Workload Identity Manager Policies"
+          "Workload Issuance Policies"
         ]
       },
       "patch": {
@@ -6413,7 +6323,7 @@
         },
         "summary": "Update a Workload Issuance policy details",
         "tags": [
-          "Workload Identity Manager Policies"
+          "Workload Issuance Policies"
         ]
       },
       "delete": {
@@ -6474,7 +6384,7 @@
         },
         "summary": "Remove a Workload Issuance policy",
         "tags": [
-          "Workload Identity Manager Policies"
+          "Workload Issuance Policies"
         ]
       }
     },
@@ -6516,7 +6426,7 @@
         },
         "summary": "Get the details of all Issuer",
         "tags": [
-          "Workload Identity Manager Intermediate Certificates"
+          "Issuer Certificates"
         ]
       }
     },
@@ -7375,7 +7285,7 @@
         },
         "summary": "Retrieve all plugins",
         "tags": [
-          "Plugins"
+          "Plugins (Connectors)"
         ]
       },
       "post": {
@@ -7404,7 +7314,7 @@
         },
         "summary": "Create a local plugin",
         "tags": [
-          "Plugins"
+          "Plugins (Connectors)"
         ]
       }
     },
@@ -7426,7 +7336,7 @@
         },
         "summary": "Retrieve plugin by ID",
         "tags": [
-          "Plugins"
+          "Plugins (Connectors)"
         ],
         "parameters": [
           {
@@ -7465,7 +7375,7 @@
         },
         "summary": "Update a local plugin",
         "tags": [
-          "Plugins"
+          "Plugins (Connectors)"
         ],
         "parameters": [
           {
@@ -7489,7 +7399,7 @@
         },
         "summary": "Delete a local plugin",
         "tags": [
-          "Plugins"
+          "Plugins (Connectors)"
         ],
         "parameters": [
           {
@@ -7522,7 +7432,7 @@
         },
         "summary": "Disable a plugin",
         "tags": [
-          "Plugins"
+          "Plugins (Connectors)"
         ],
         "parameters": [
           {
@@ -7546,7 +7456,7 @@
         },
         "summary": "Remove plugin disablement",
         "tags": [
-          "Plugins"
+          "Plugins (Connectors)"
         ],
         "parameters": [
           {
@@ -7579,7 +7489,7 @@
         },
         "summary": "Retrieve all disabled plugins",
         "tags": [
-          "Plugins"
+          "Plugins (Connectors)"
         ]
       }
     },

--- a/openapi-specs/scm/config/ngts/tlsprotect-cloud.json
+++ b/openapi-specs/scm/config/ngts/tlsprotect-cloud.json
@@ -11,7 +11,7 @@
   },
   "servers": [
     {
-      "url": "https://api.strata.paloaltonetworks.com",
+      "url": "https://api.strata.paloaltonetworks.com/ngts",
       "description": "Strata Cloud Manager API"
     }
   ],

--- a/products/scm/api/config/ngts/ngts-api.md
+++ b/products/scm/api/config/ngts/ngts-api.md
@@ -56,7 +56,7 @@ The API endpoint pages let you authorize and run API calls directly from the doc
 All API requests use the following base URL. HTTPS is required for all requests.
 
 ```
-https://api.strata.paloaltonetworks.com
+https://api.strata.paloaltonetworks.com/ngts
 ```
 
 ## JSON


### PR DESCRIPTION
## What

Two related fixes to the NGTS / Venafi TLS Protect Cloud API reference on pan.dev.

### 1. Missing `/ngts` base-URL segment
Endpoint URLs rendered without the `/ngts` segment and were not callable as shown. The SCM gateway fronts the entire NGTS API under `/ngts`:

- Before: `https://api.strata.paloaltonetworks.com/outagedetection/v1/certificaterequests`
- After:  `https://api.strata.paloaltonetworks.com/ngts/outagedetection/v1/certificaterequests`

Fixed by adding `/ngts` to `servers[].url` (one change covers all endpoints) and updating the hand-authored Base URL section in `ngts-api.md`.

### 2. Align section names with NGTS terminology (pan.dev only)
Renamed API reference categories (OpenAPI tags) to match NGTS naming, and removed the Certificate Expiration Reports section:

| Before | After |
|--------|-------|
| Certificate Installations | TLS Server Endpoints |
| Machine Identities | Machine Installations |
| Tags | Certificate Tags |
| Workload Identity Manager Configurations | Issuer Configurations |
| Workload Identity Manager Sub CA Providers | Issuer Sub CA Providers |
| Workload Identity Manager Policies | Workload Issuance Policies |
| Workload Identity Manager Intermediate Certificates | Issuer Certificates |
| Plugins | Plugins (Connectors) |
| Certificate Expiration Reports | **removed** (section + its 3 `/v1/expirationreports/*` endpoints) |

## Notes
- Changes are in `openapi-specs/scm/config/ngts/tlsprotect-cloud.json` (+ Base URL line in `ngts-api.md`). The sidebar categories and per-endpoint pages are generated from the spec at build time (`yarn gen-all`), so no generated files are committed.
- pan.dev only — the Dev Central / readme.io docs are unaffected.

## Verification
- `yarn clean-api-docs ngts && yarn gen-api-docs ngts` regenerates the sidebar with the new category labels (verified `TLS Server Endpoints` etc.) and drops the Expiration Reports section.
- Rendered endpoints show `https://api.strata.paloaltonetworks.com/ngts/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
