### PR TITLE
style(docs): modernize markdown table styling

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -21,7 +21,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("/fonts/Inter-Regular.woff2") format("woff2"),
+  src:
+    url("/fonts/Inter-Regular.woff2") format("woff2"),
     url("/fonts/Inter-Regular.woff") format("woff");
 }
 
@@ -98,13 +99,15 @@ html:has(body):has(div):has(div):has(.homepage) {
   /* END SIDEBAR VARS */
 
   /* START FONTS */
-  --ifm-font-family-base: "Plus Jakarta Sans", ui-sans-serif, system-ui,
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
-    Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+  --ifm-font-family-base:
+    "Plus Jakarta Sans", ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+    "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol", "Noto Color Emoji";
   --ifm-heading-font-family: "Metropolis Semi Bold", sans-serif;
-  --ifm-font-family-monospace: "Fira Code", SFMono-Regular, Menlo, Monaco,
-    Consolas, "Liberation Mono", "Courier New", monospace;
+  --ifm-font-family-monospace:
+    "Fira Code", SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
   --ifm-font-size-base: 95%;
   /* END FONTS */
 
@@ -315,7 +318,9 @@ html[data-theme="dark"] {
     border: 1px solid var(--ifm-color-primary);
     color: var(--ifm-color-primary);
 
-    &:not(.responseTabActive_node_modules-docusaurus-theme-openapi-docs-lib-next-theme-ApiTabs-styles-module) {
+    &:not(
+      .responseTabActive_node_modules-docusaurus-theme-openapi-docs-lib-next-theme-ApiTabs-styles-module
+    ) {
       opacity: 0.6;
     }
 
@@ -342,7 +347,9 @@ html[data-theme="dark"] {
     border: 1px solid var(--ifm-color-primary);
     color: var(--ifm-color-primary);
 
-    &:not(.schemaTabActive_node_modules-docusaurus-theme-openapi-docs-lib-next-theme-SchemaTabs-styles-module) {
+    &:not(
+      .schemaTabActive_node_modules-docusaurus-theme-openapi-docs-lib-next-theme-SchemaTabs-styles-module
+    ) {
       opacity: 0.6;
     }
 
@@ -581,6 +588,77 @@ html[data-theme="dark"] {
   }
 }
 /* END TOC */
+
+/* START MARKDOWN TABLES */
+.markdown {
+  table {
+    margin: 1.5rem 0 var(--ifm-spacing-vertical);
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  table thead {
+    background-color: transparent;
+  }
+
+  table thead tr {
+    border-top: 0;
+    border-bottom: 1px solid var(--ifm-color-gray-300);
+  }
+
+  table thead th {
+    padding: 0.75rem 1rem;
+    font-weight: 600;
+    color: var(--ifm-color-gray-700);
+    text-align: left;
+    background-color: transparent;
+    border: 0;
+  }
+
+  table tbody tr {
+    background-color: transparent;
+    border-top: 0;
+    border-bottom: 1px solid var(--ifm-color-gray-200);
+    transition: background-color 0.15s ease-in-out;
+  }
+
+  table tbody tr:nth-child(2n) {
+    background-color: transparent;
+  }
+
+  table tbody tr:last-child {
+    border-bottom: 0;
+  }
+
+  table tbody tr:hover {
+    background-color: var(--ifm-color-gray-100);
+  }
+
+  table tbody td {
+    padding: 0.75rem 1rem;
+    border: 0;
+    vertical-align: top;
+  }
+}
+
+html[data-theme="dark"] .markdown {
+  table thead tr {
+    border-bottom-color: var(--ifm-color-gray-700);
+  }
+
+  table thead th {
+    color: var(--ifm-color-gray-300);
+  }
+
+  table tbody tr {
+    border-bottom-color: var(--ifm-color-gray-800);
+  }
+
+  table tbody tr:hover {
+    background-color: var(--ifm-color-gray-900);
+  }
+}
+/* END MARKDOWN TABLES */
 
 /* START LINK BUG */
 a {


### PR DESCRIPTION
## Summary

Replaces the default Infima table look with a borderless treatment used across Stripe/Vercel/Linear/Tailwind docs.

Before → After:
- Outer + cell borders → gone
- Zebra stripes → gone
- 2px header underline → 1px hairline
- Bold header → semibold, muted color
- Adds subtle row hover tint
- Adds 0.75rem × 1rem cell padding

Scoped to `.markdown table` so OpenAPI grids and component tables are untouched. Infima's existing `display: block; overflow: auto` handles horizontal scroll on narrow screens — kept as-is.

Dark mode variants use `--ifm-color-gray-700/800/900` for dividers and hover.

## Test plan

- [ ] Preview any docs page with a table (e.g. `/expedition/docs/expedition_workflow_migration`)
- [ ] Toggle light/dark theme and confirm dividers + hover work in both
- [ ] Resize to mobile width, confirm wide tables still scroll horizontally
- [ ] Spot-check an OpenAPI page to confirm those tables are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)