### PR TITLE
Add Switzerland region to API call documentation

### DIFF
--- a/products/sase/docs/api-call.md
+++ b/products/sase/docs/api-call.md
@@ -78,6 +78,7 @@ The `X-PANW-Region` header parameter is the region you chose when setting up you
 | jp        | Japan                        |
 | sg        | Southeast Asia               |
 | uk        | United Kingdom               |
+| ch        | Switzerland                  |
 
 
 If you need to verify which region to use, you can 


### PR DESCRIPTION
## Description
Added ch in the list of available X-PANW-Region headers

## Motivation and Context
I spent quite a long time trying to fetch data from the Prisma Access API. It's required to add X-PANW-Region. After hours of not getting data, I was investigating how Strata Cloud Manager (WebUI) performs the API requests and found the ch region there. It's not listed in the documentation, but setting my API requests to this region returned my desired data.

## How Has This Been Tested?
I tested my own API calls with ch as a region. It returned the data I was looking for.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
