### PR TITLE
ci: bump deploy workflows to node 22

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -28,7 +28,7 @@ jobs:
         - name: Setup node
           uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
           with:
-            node-version: '20'
+            node-version: '22'
             cache: 'yarn'
 
         - name: Get yarn cache
@@ -107,7 +107,7 @@ jobs:
         - name: Setup node
           uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
           with:
-            node-version: '20'
+            node-version: '22'
 
         - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
           with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Get yarn cache
         id: yarn-cache
@@ -264,7 +264,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:


### PR DESCRIPTION
## What

Bumps `deploy-preview` and `deploy-live` GitHub workflows from node **20** to **22**.

## Why

Upcoming `docusaurus-openapi-docs` releases depend on `sass-loader@^17`, which requires **node >= 22.11**. On node 20 the install fails:

```
error sass-loader@17.0.0: The engine "node" is incompatible with this module.
Expected version ">= 22.11.0". Got "20.20.2"
```

This matches the `node22` base image already used in `.gitlab-ci.yml`.

## Sequencing note

These workflows run via `pull_request_target`, so they execute from the **base branch**. This change must merge to `master` before it takes effect on any PR's deploy preview — including the canary validation PR #1387, which currently fails to build on node 20 for this exact reason. Merging this unblocks that preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)