### PR TITLE
feat: add Idira (idsec) Identity Security Terraform provider to landi…

### DIFF
--- a/src/constants/terraform/index.js
+++ b/src/constants/terraform/index.js
@@ -170,7 +170,7 @@ export const TERRAFORM_PROVIDER_CONTENT = {
       title: "Prisma Cloud Compute",
       latestTag: "v0.7.0",
       description:
-        "Define your cloud workload protection suing Terraform, to protect your host, container and serverless deployments in any cloud.",
+        "Define your cloud workload protection using Terraform, to protect your host, container and serverless deployments in any cloud.",
       cta: {
         type: "double",
         content: [
@@ -201,6 +201,25 @@ export const TERRAFORM_PROVIDER_CONTENT = {
           },
           {
             link: "https://registry.terraform.io/providers/PaloAltoNetworks/bridgecrew/latest/docs",
+            text: "Docs",
+          },
+        ],
+      },
+    },
+    {
+      title: "Idira Identity Security (idsec)",
+      description:
+        "Automate identity security operations using Terraform, including privileged access management, secrets management, and identity governance within the Idira Identity Security Platform.",
+      cta: {
+        type: "double",
+        content: [
+          {
+            link: "https://registry.terraform.io/providers/cyberark/idsec/latest",
+            logoSrc: "/img/product-landing/terraform/terraform-logo.png",
+            logoAlt: "Terraform Logo",
+          },
+          {
+            link: "https://registry.terraform.io/providers/cyberark/idsec/latest/docs",
             text: "Docs",
           },
         ],


### PR DESCRIPTION
## Summary
- Adds **Idira Identity Security (idsec)** provider card to pan.dev/terraform/ under the Terraform Providers section
- Card links to the Terraform Registry: https://registry.terraform.io/providers/cyberark/idsec/latest/docs
- Fixes a pre-existing typo in the Prisma Cloud Compute description (\"suing\" → \"using\")

## Test plan
- [x] Run \`PRODUCTS_INCLUDE=contributing yarn start\` and verify the Idira card appears on \`/terraform\`
- [x] Confirm the Terraform Registry and Docs buttons link correctly
- [x] Confirm no version badge is shown on the Idira card