### PR TITLE
fix: updated scm cloudngfw operation candidate push route param devic…

### DIFF
--- a/openapi-specs/scm/config/cloudngfw/operations/config-operations-march.yaml
+++ b/openapi-specs/scm/config/cloudngfw/operations/config-operations-march.yaml
@@ -156,10 +156,10 @@ paths:
                       description: The target devices for the configuration push
                       uniqueItems: true
                       items:
-                        type: number
+                        type: string
                         maxLength: 16
-                      example: [007951000388704, 007951000388707, 007051000239252]
-                  required: 
+                      example: ["007951000388704", "007951000388707", "007051000239252"]
+                  required:
                     -  folders
       responses:
         '201':


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Changed openapi spec for stratacloudmanager-cloudngfw-operations-push `devices` parameter from number[] to string[].
More information is on the issue attached below.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1403

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has not. Any guide on how to test?

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
