### PR TITLE
docs(iot): IPR-1814 Device Security API usability improvements + vuln severity filter

### DIFF
--- a/openapi-specs/iot/api/public/deviceListV2.yaml
+++ b/openapi-specs/iot/api/public/deviceListV2.yaml
@@ -19,7 +19,14 @@ parameters:
   schema:
     type: integer
     maximum: 1000
-- description: A comma-separated list of device fields to include in the response. Maximum of 50 fields can be specified. Available fields can be retrieved from the device/attributes api. If omitted, only common attributes are returned (attributes specific to a third party will not be returned in this case).
+- description: >-
+    A comma-separated list of device fields to include in the response. Maximum
+    of 50 fields can be specified. Available fields can be retrieved from the
+    device/attributes api. If omitted, the full default object is returned
+    (including the nested `attr` block). When a projection IS specified, the
+    `attr` block is EXCLUDED unless `attr` is explicitly listed in the
+    projection. The `attr` block holds the `panwIoTFname_*` raw identifiers — see
+    the field-name mapping table in the IoT public API guide.
   in: query
   name: projection
   required: false

--- a/openapi-specs/iot/api/public/deviceListV2.yaml
+++ b/openapi-specs/iot/api/public/deviceListV2.yaml
@@ -21,8 +21,8 @@ parameters:
     maximum: 1000
 - description: >-
     A comma-separated list of device fields to include in the response (maximum
-    50). Available fields can be retrieved from the device/attributes API. If
-    omitted, the full default object is returned.
+    50). Valid field names are those returned by the `device/attributes` API. If
+    omitted, every field from `device/attributes` is returned for each device.
   in: query
   name: projection
   required: false

--- a/openapi-specs/iot/api/public/deviceListV2.yaml
+++ b/openapi-specs/iot/api/public/deviceListV2.yaml
@@ -20,13 +20,9 @@ parameters:
     type: integer
     maximum: 1000
 - description: >-
-    A comma-separated list of device fields to include in the response. Maximum
-    of 50 fields can be specified. Available fields can be retrieved from the
-    device/attributes api. If omitted, the full default object is returned
-    (including the nested `attr` block). When a projection IS specified, the
-    `attr` block is EXCLUDED unless `attr` is explicitly listed in the
-    projection. The `attr` block holds the `panwIoTFname_*` raw identifiers — see
-    the field-name mapping table in the IoT public API guide.
+    A comma-separated list of device fields to include in the response (maximum
+    50). Available fields can be retrieved from the device/attributes API. If
+    omitted, the full default object is returned.
   in: query
   name: projection
   required: false

--- a/openapi-specs/iot/api/public/getSite.yaml
+++ b/openapi-specs/iot/api/public/getSite.yaml
@@ -5,13 +5,13 @@ parameters:
     required: false
     schema:
       type: string
-  - description: Exact match on the site name (no wildcards). Matches the site's `external_id` (the value shown as "Name" in the Device Security GUI).
+  - description: Exact match on the site name (case-sensitive; no wildcards). Matches the site's `external_id` (the value shown as "Name" in the Device Security GUI).
     in: query
     name: name
     required: false
     schema:
       type: string
-  - description: Exact text match on the site description (no wildcards).
+  - description: Exact text match on the site description (case-sensitive; no wildcards).
     in: query
     name: description
     required: false

--- a/openapi-specs/iot/api/public/getSite.yaml
+++ b/openapi-specs/iot/api/public/getSite.yaml
@@ -5,9 +5,23 @@ parameters:
     required: false
     schema:
       type: string
+  - description: Exact match on the site name (no wildcards). Matches the site's `external_id` (the value shown as "Name" in the Device Security GUI).
+    in: query
+    name: name
+    required: false
+    schema:
+      type: string
+  - description: Exact text match on the site description (no wildcards).
+    in: query
+    name: description
+    required: false
+    schema:
+      type: string
 responses:
   '200':
-    description: Sites Successfully Retrieved
+    description: >-
+      Sites Successfully Retrieved. A valid request that matches no sites returns
+      HTTP 200 with an empty `list` and `total: 0` (never 404).
     content:
       application/json:
         schema:

--- a/openapi-specs/iot/api/public/getSubnet.yaml
+++ b/openapi-specs/iot/api/public/getSubnet.yaml
@@ -6,7 +6,7 @@ parameters:
     schema:
       type: string
       format: date-time
-  - description: "Number of results to return per page. Maximum 1,000; a larger value returns HTTP 400. Use offset to page through more results (e.g. with flat=true)."
+  - description: "Number of results to return per page. Maximum 1,000; a larger value returns HTTP 400. Use `offset` to page through more results (for example, with `flat=true`)."
     in: query
     name: pagelength
     required: false
@@ -27,19 +27,19 @@ parameters:
     required: false
     schema:
       type: string
-  - description: Exact match on the subnet name (no wildcards). Searches across all hierarchy levels.
+  - description: Exact match on the subnet name (case-sensitive; no wildcards). Searches across all hierarchy levels.
     in: query
     name: name
     required: false
     schema:
       type: string
-  - description: Exact match on the internal site ID. Returns matching subnets at any hierarchy level.
+  - description: Exact match on the site's internal ID (`siteid`) — distinct from the tenant's external ID and from the site's Name (`external_id`). Returns matching subnets at any hierarchy level.
     in: query
     name: siteid
     required: false
     schema:
       type: string
-  - description: Exact text match on the subnet description (no wildcards). Searches across all hierarchy levels.
+  - description: Exact text match on the subnet description (case-sensitive; no wildcards). Searches across all hierarchy levels.
     in: query
     name: description
     required: false
@@ -51,7 +51,7 @@ parameters:
     required: false
     schema:
       type: string
-  - description: "When true, returns subnets at every nesting level in one (paginated) call; the `parent` field is preserved on each object so the hierarchy can be reconstructed client-side. Page through large result sets with `pagelength` (max 1,000) and `offset`."
+  - description: "When true, returns subnets at every nesting level in one (paginated) call; the `parent` field is preserved on each object. Page through large result sets with `pagelength` (max 1,000) and `offset`."
     in: query
     name: flat
     required: false

--- a/openapi-specs/iot/api/public/getSubnet.yaml
+++ b/openapi-specs/iot/api/public/getSubnet.yaml
@@ -6,7 +6,7 @@ parameters:
     schema:
       type: string
       format: date-time
-  - description: Number of results to return per page
+  - description: "Number of results to return per page. For flat listings (flat=true) the maximum is 10,000 — larger values are capped at 10,000; use offset to retrieve subnets beyond the first page."
     in: query
     name: pagelength
     required: false
@@ -50,7 +50,7 @@ parameters:
     required: false
     schema:
       type: string
-  - description: When true, returns subnets at every nesting level in one (paginated) call; the `parent` field is preserved on each object so the hierarchy can be reconstructed client-side.
+  - description: "When true, returns subnets at every nesting level in one (paginated) call; the `parent` field is preserved on each object so the hierarchy can be reconstructed client-side. Returns at most 10,000 subnets per request — page through larger result sets with `pagelength` (max 10,000) and `offset`."
     in: query
     name: flat
     required: false

--- a/openapi-specs/iot/api/public/getSubnet.yaml
+++ b/openapi-specs/iot/api/public/getSubnet.yaml
@@ -20,15 +20,49 @@ parameters:
     schema:
       type: integer
       minimum: 0
-  - description: Parent ip prefix (e.g. 10.0.0.0/8)
+  - description: Parent ip prefix (e.g. 10.0.0.0/8). Hierarchy filter — returns direct children of this CIDR block. Mutually exclusive with `prefix`.
     in: query
     name: parent
     required: false
     schema:
       type: string
+  - description: Exact match on the subnet name (no wildcards). Searches across all hierarchy levels.
+    in: query
+    name: name
+    required: false
+    schema:
+      type: string
+  - description: Exact match on the internal site ID. Returns matching subnets at any hierarchy level.
+    in: query
+    name: siteid
+    required: false
+    schema:
+      type: string
+  - description: Exact text match on the subnet description (no wildcards). Searches across all hierarchy levels.
+    in: query
+    name: description
+    required: false
+    schema:
+      type: string
+  - description: Direct prefix lookup in CIDR notation (e.g. 10.105.10.0/24). Mutually exclusive with `parent`.
+    in: query
+    name: prefix
+    required: false
+    schema:
+      type: string
+  - description: When true, returns subnets at every nesting level in one (paginated) call; the `parent` field is preserved on each object so the hierarchy can be reconstructed client-side.
+    in: query
+    name: flat
+    required: false
+    schema:
+      type: boolean
 responses:
   '200':
-    description: Subnets Successfully Retrieved
+    description: >-
+      Subnets Successfully Retrieved. A valid request that matches no subnets
+      returns HTTP 200 with an empty `subnets` array and `total: 0` (never 404).
+      Every documented field is always present on each subnet object (`null`/`""`
+      when it has no value).
     content:
       application/json:
         schema:

--- a/openapi-specs/iot/api/public/getSubnet.yaml
+++ b/openapi-specs/iot/api/public/getSubnet.yaml
@@ -6,13 +6,14 @@ parameters:
     schema:
       type: string
       format: date-time
-  - description: "Number of results to return per page. For flat listings (flat=true) the maximum is 10,000 — larger values are capped at 10,000; use offset to retrieve subnets beyond the first page."
+  - description: "Number of results to return per page. Maximum 1,000; a larger value returns HTTP 400. Use offset to page through more results (e.g. with flat=true)."
     in: query
     name: pagelength
     required: false
     schema:
       type: integer
       minimum: 1
+      maximum: 1000
   - description: Offset for pagination
     in: query
     name: offset
@@ -50,7 +51,7 @@ parameters:
     required: false
     schema:
       type: string
-  - description: "When true, returns subnets at every nesting level in one (paginated) call; the `parent` field is preserved on each object so the hierarchy can be reconstructed client-side. Returns at most 10,000 subnets per request — page through larger result sets with `pagelength` (max 10,000) and `offset`."
+  - description: "When true, returns subnets at every nesting level in one (paginated) call; the `parent` field is preserved on each object so the hierarchy can be reconstructed client-side. Page through large result sets with `pagelength` (max 1,000) and `offset`."
     in: query
     name: flat
     required: false

--- a/openapi-specs/iot/api/public/vulnerabilityList.yaml
+++ b/openapi-specs/iot/api/public/vulnerabilityList.yaml
@@ -12,13 +12,13 @@ parameters:
   schema:
     type: string
     format: date-time
-- description: "The number of items in one response; that is, in one page. The default page length for vulnerabilities is 1000 and the maximum is 1000. Setting a shorter length improves response times. Note: The <b>pagelength</b> parameter is only valid when grouping vulnerability instances by device, not when grouping them by vulnerability."
+- description: "The number of items in one response; that is, in one page. The default page length for vulnerabilities is 1000 and the maximum is 1000. Setting a shorter length improves response times. <b>pagelength</b> applies to both <b>groupby=device</b> and <b>groupby=vulnerability</b>. For large tenants, a <b>groupby=vulnerability</b> response that includes the impacted device-ID arrays can be large; use a smaller <b>pagelength</b> (for example, 100) together with <b>offset</b> to page through the results and keep each response under the size limit."
   in: query
   name: pagelength
   required: false
   schema:
     type: integer
-- description: "In addition to the pagelength parameter, offset gets items on subsequent pages. For example, if the page length of your first request is 100, you get the first 100 vulnerabilities. To get the next 100, add offset=100 to your second request. This skips the first 100 vulnerabilities and gets the next 100 starting from 101. Note: The <b>offset</b> parameter is only valid when grouping vulnerability instances by device, not when grouping them by vulnerability."
+- description: "In addition to the pagelength parameter, offset gets items on subsequent pages. For example, if the page length of your first request is 100, you get the first 100 vulnerabilities. To get the next 100, add offset=100 to your second request. This skips the first 100 vulnerabilities and gets the next 100 starting from 101. <b>offset</b> applies to both <b>groupby=device</b> and <b>groupby=vulnerability</b>; use it with <b>pagelength</b> to page through a large <b>groupby=vulnerability</b> result."
   in: query
   name: offset
   required: false
@@ -48,7 +48,7 @@ parameters:
   required: false
   schema:
     type: string
-- description: "Controls whether the impacted device IDs are included in each vulnerability item. Valid values are <b>yes</b> and <b>no</b>. When omitted (or <b>yes</b>), each vulnerability item includes the full list of impacted device IDs. Set <b>includeDeviceIdList=no</b> to return only the device counts and omit the device-ID arrays — this produces a much smaller, faster response. For large tenants, a <b>groupby=vulnerability</b> response that includes the device-ID arrays can be very large; either page through the results (<b>pagelength</b>/<b>offset</b>) or use <b>includeDeviceIdList=no</b> to avoid exceeding the response size limit."
+- description: "Controls whether the impacted device IDs are included in each vulnerability item. Valid values are <b>yes</b> and <b>no</b>. When omitted (or <b>yes</b>), each vulnerability item includes the full list of impacted device IDs. Set <b>includeDeviceIdList=no</b> to return only the device counts and omit the device-ID arrays — this produces a much smaller, faster response. For large tenants, a <b>groupby=vulnerability</b> response that includes the device-ID arrays can be very large. <b>If a request fails with HTTP 400 because the response is too large, set <b>includeDeviceIdList=no</b> to return counts only, and/or reduce <b>pagelength</b> (for example, 100) and page through with <b>offset</b>, to bring each response under the size limit.</b>"
   in: query
   name: includeDeviceIdList
   required: false

--- a/openapi-specs/iot/api/public/vulnerabilityList.yaml
+++ b/openapi-specs/iot/api/public/vulnerabilityList.yaml
@@ -1,5 +1,5 @@
 parameters:
-- description: Optional field setting the start of a time range for retrieving vulnerability instances. For example, to get all instances since November 3, 2020, starting at 00:00 AM in the Pacific Time Zone(UTC-8), the start time would be <b>stime=2020-11-3T08:00Z</b>. <br />If you prefer to specify the time in your local time rather than adjusting it to UTC time, you can also format the start time as <b>2020-11-03T:00:00-08:00</b>. Especially when starting at a later hour in the day, this format involves less calculating. For example, if you want to get vulnerability instances starting from 6:00 PM on November 3, 2020, entering <b>2020-11-03T18:00-08:00</b> is much simpler than entering <b>2020-11-04T02:00Z</b>.
+- description: Optional field setting the start of a time range for retrieving vulnerability instances. For example, to get all instances since November 3, 2020, starting at 00:00 AM in the Pacific Time Zone(UTC-8), the start time would be `stime=2020-11-3T08:00Z`. If you prefer to specify the time in your local time rather than adjusting it to UTC time, you can also format the start time as `2020-11-03T:00:00-08:00`. Especially when starting at a later hour in the day, this format involves less calculating. For example, if you want to get vulnerability instances starting from 6:00 PM on November 3, 2020, entering `2020-11-03T18:00-08:00` is much simpler than entering `2020-11-04T02:00Z`.
   in: query
   name: stime
   required: false
@@ -12,13 +12,13 @@ parameters:
   schema:
     type: string
     format: date-time
-- description: "The number of items in one response; that is, in one page. The default page length for vulnerabilities is 1000 and the maximum is 1000. Setting a shorter length improves response times. <b>pagelength</b> applies to both <b>groupby=device</b> and <b>groupby=vulnerability</b>. For large tenants, a <b>groupby=vulnerability</b> response that includes the impacted device-ID arrays can be large; use a smaller <b>pagelength</b> (for example, 100) together with <b>offset</b> to page through the results and keep each response under the size limit."
+- description: "The number of items in one response; that is, in one page. The default page length for vulnerabilities is 1000 and the maximum is 1000. Setting a shorter length improves response times. `pagelength` applies to both `groupby=device` and `groupby=vulnerability`. For large tenants, a `groupby=vulnerability` response that includes the impacted device ID arrays can be large; use a smaller `pagelength` (for example, 100) together with `offset` to page through the results and keep each response under the size limit."
   in: query
   name: pagelength
   required: false
   schema:
     type: integer
-- description: "In addition to the pagelength parameter, offset gets items on subsequent pages. For example, if the page length of your first request is 100, you get the first 100 vulnerabilities. To get the next 100, add offset=100 to your second request. This skips the first 100 vulnerabilities and gets the next 100 starting from 101. <b>offset</b> applies to both <b>groupby=device</b> and <b>groupby=vulnerability</b>; use it with <b>pagelength</b> to page through a large <b>groupby=vulnerability</b> result."
+- description: "In addition to the `pagelength` parameter, `offset` gets items on subsequent pages. For example, if the page length of your first request is 100, you get the first 100 vulnerabilities. To get the next 100, add `offset=100` to your second request. This skips the first 100 vulnerabilities and gets the next 100 starting from 101. `offset` applies to both `groupby=device` and `groupby=vulnerability`; use it with `pagelength` to page through a large `groupby=vulnerability` result."
   in: query
   name: offset
   required: false
@@ -36,19 +36,19 @@ parameters:
   required: false
   schema:
     type: string
-- description: "Optional filter that restricts results to vulnerabilities of a given severity. Valid values are <b>Critical</b>, <b>High</b>, <b>Medium</b>, and <b>Low</b> (case-sensitive). If no value is passed, vulnerabilities of all severities are returned."
+- description: "Optional filter that restricts results to vulnerabilities of a given severity. Valid values are `Critical`, `High`, `Medium`, and `Low` (case-sensitive). If no value is passed, vulnerabilities of all severities are returned."
   in: query
   name: severity
   required: false
   schema:
     type: string
-- description: "How results are grouped. <b>groupby=vulnerability</b> (default): one item per vulnerability, listing the impacted device IDs. <b>groupby=device</b>: one item per device ID, each with a single vulnerability. To get all vulnerabilities for one device, use <b>groupby=vulnerability&deviceid=&lt;id&gt;</b> (the device's MAC address, or its IP for static-IP devices)."
+- description: "How results are grouped. `groupby=vulnerability` (default): one item per vulnerability, listing the impacted device IDs. `groupby=device`: one item per device ID, each with a single vulnerability. To get all vulnerabilities for one device, use `groupby=vulnerability&deviceid=<id>` (the device's MAC address, or its IP for static-IP devices)."
   in: query
   name: groupby
   required: false
   schema:
     type: string
-- description: "Controls whether the impacted device IDs are included in each vulnerability item. Valid values are <b>yes</b> and <b>no</b>. When omitted (or <b>yes</b>), each vulnerability item includes the full list of impacted device IDs. Set <b>includeDeviceIdList=no</b> to return only the device counts and omit the device-ID arrays — this produces a much smaller, faster response. For large tenants, a <b>groupby=vulnerability</b> response that includes the device-ID arrays can be very large. <b>If a request fails with HTTP 400 because the response is too large, set <b>includeDeviceIdList=no</b> to return counts only, and/or reduce <b>pagelength</b> (for example, 100) and page through with <b>offset</b>, to bring each response under the size limit.</b>"
+- description: "Controls whether the impacted device IDs are included in each vulnerability item. Valid values are `yes` and `no`. When omitted (or `yes`), each vulnerability item includes the full list of impacted device IDs. Set `includeDeviceIdList=no` to return only the device counts and omit the device ID arrays — this produces a much smaller, faster response. For large tenants, a `groupby=vulnerability` response that includes the device ID arrays can be very large. If a request fails with HTTP 400 because the response is too large, set `includeDeviceIdList=no` to return counts only, and/or reduce `pagelength` (for example, 100) and page through with `offset`, to bring each response under the size limit."
   in: query
   name: includeDeviceIdList
   required: false

--- a/openapi-specs/iot/api/public/vulnerabilityList.yaml
+++ b/openapi-specs/iot/api/public/vulnerabilityList.yaml
@@ -42,7 +42,7 @@ parameters:
   required: false
   schema:
     type: string
-- description: "The grouping of device vulnerability instances in query results. Each <b>groupby</b> option results in a different JSON object structure in the response. <b>groupby=vulnerability</b> (the default) organizes results into groups by vulnerability. Each vulnerability and the device IDs impacted are an item in the items list. <b>groupby=device</b> organizes results into groups by device ID. Each device ID and a single vulnerability are an item in the items list. <br /> To request all vulnerability instances for a specific device, the value is the string <b>vulnerability</b> followed by <b>&deviceid='<'device_id'>'</b>, where the device ID is either a MAC address or, for static IP devices, an IP address. (Entering an IP address for a device whose device identifier is a MAC address doesn’t work. Similarly, entering a MAC address for a device whose device identifier is an IP address also doesn’t work.)"
+- description: "How results are grouped. <b>groupby=vulnerability</b> (default): one item per vulnerability, listing the impacted device IDs. <b>groupby=device</b>: one item per device ID, each with a single vulnerability. To get all vulnerabilities for one device, use <b>groupby=vulnerability&deviceid=&lt;id&gt;</b> (the device's MAC address, or its IP for static-IP devices)."
   in: query
   name: groupby
   required: false

--- a/openapi-specs/iot/api/public/vulnerabilityList.yaml
+++ b/openapi-specs/iot/api/public/vulnerabilityList.yaml
@@ -36,6 +36,12 @@ parameters:
   required: false
   schema:
     type: string
+- description: "Optional filter that restricts results to vulnerabilities of a given severity. Valid values are <b>Critical</b>, <b>High</b>, <b>Medium</b>, and <b>Low</b> (case-sensitive). If no value is passed, vulnerabilities of all severities are returned."
+  in: query
+  name: severity
+  required: false
+  schema:
+    type: string
 - description: "The grouping of device vulnerability instances in query results. Each <b>groupby</b> option results in a different JSON object structure in the response. <b>groupby=vulnerability</b> (the default) organizes results into groups by vulnerability. Each vulnerability and the device IDs impacted are an item in the items list. <b>groupby=device</b> organizes results into groups by device ID. Each device ID and a single vulnerability are an item in the items list. <br /> To request all vulnerability instances for a specific device, the value is the string <b>vulnerability</b> followed by <b>&deviceid='<'device_id'>'</b>, where the device ID is either a MAC address or, for static IP devices, an IP address. (Entering an IP address for a device whose device identifier is a MAC address doesn’t work. Similarly, entering a MAC address for a device whose device identifier is an IP address also doesn’t work.)"
   in: query
   name: groupby

--- a/openapi-specs/iot/api/public/vulnerabilityList.yaml
+++ b/openapi-specs/iot/api/public/vulnerabilityList.yaml
@@ -48,6 +48,15 @@ parameters:
   required: false
   schema:
     type: string
+- description: "Controls whether the impacted device IDs are included in each vulnerability item. Valid values are <b>yes</b> and <b>no</b>. When omitted (or <b>yes</b>), each vulnerability item includes the full list of impacted device IDs. Set <b>includeDeviceIdList=no</b> to return only the device counts and omit the device-ID arrays — this produces a much smaller, faster response. For large tenants, a <b>groupby=vulnerability</b> response that includes the device-ID arrays can be very large; either page through the results (<b>pagelength</b>/<b>offset</b>) or use <b>includeDeviceIdList=no</b> to avoid exceeding the response size limit."
+  in: query
+  name: includeDeviceIdList
+  required: false
+  schema:
+    type: string
+    enum:
+      - "yes"
+      - "no"
 responses:
   '200':
     description: Successful Response (We only show some important fields here.)

--- a/openapi-specs/iot/components/examples.yaml
+++ b/openapi-specs/iot/components/examples.yaml
@@ -1344,6 +1344,7 @@ examples:
           "external_id": "HQ",
           "description": "This is the campus HQ.",
           "location": "3000 Tannery Way Santa Clara, CA",
+          "group": "North-America",
           "subnetsList": ["10.0.0.0/8"],
           "segmentIdsList": ["48", "49"],
           "created_at": "2023-01-15T12:30:45.000Z",
@@ -1392,7 +1393,7 @@ examples:
         "name": "HQ",
         "description": "California Company Headquarters",
         "firewallsList": ["7F7B14BAE015426"],
-        "siteid": "1"
+        "site": "HQ"
       }
     ]
 

--- a/openapi-specs/iot/components/schemas.yaml
+++ b/openapi-specs/iot/components/schemas.yaml
@@ -532,9 +532,21 @@ schemas:
       deviceid:
         type: string
         description: The device ID, which IoT Security uses to identify and track a device (always included)
+      site_name:
+        type: string
+        nullable: true
+        description: >-
+          The friendly site name (equivalent to the site's external_id) the
+          device is assigned to; `null` when the device has no site. Returned in
+          the default response alongside `siteid`.
       attr:
         type: string
-        description: The user defined custom attributes associated with the device (always included)
+        description: >-
+          Nested block of internal device attributes, including the
+          `panwIoTFname_*` raw identifiers (see the field-name mapping in the IoT
+          public API guide). Returned by default (when no `projection` is
+          specified). When a `projection` is supplied, `attr` is EXCLUDED unless
+          `attr` is explicitly listed in the projection.
 
 
   DeviceTags:
@@ -1649,11 +1661,15 @@ schemas:
           properties:
             external_id:
               type: string
-              description: 'Unique external identifier for the site'
+              description: >-
+                The site's friendly name — the same value shown as "Name" in the
+                Device Security GUI. Use this to reference a site.
               example: 'Example Site 1'
             siteid:
               type: string
-              description: 'Internal system identifier for the site'
+              description: >-
+                Internal, system-generated identifier (auto-assigned). Not set by
+                users and not intended for referencing sites in API calls.
               example: '32'
             location:
               type: string
@@ -1663,6 +1679,14 @@ schemas:
               type: string
               description: 'Detailed description of the site'
               example: 'This is a test api body description'
+            group:
+              type: string
+              nullable: true
+              description: >-
+                The group the site belongs to, by name. This is the site's parent
+                group (for example a region, country, or business unit), not a
+                parent site. `null` when the site is not in any group.
+              example: 'Finland-Region'
             subnetsList:
               type: array
               description: 'List of subnets associated with this site in CIDR notation'
@@ -1692,6 +1716,14 @@ schemas:
         location:
           type: string
           description: Physical location of the site
+        group:
+          type: string
+          nullable: true
+          description: >-
+            Set the group the site belongs to, by group name (the parent group —
+            e.g. a region, country, or business unit; not a parent site). `null`
+            removes the site from its group. The group must already exist; it is
+            never auto-created. An unknown group name returns HTTP 400.
         subnetsList:
           type: array
           description: List of subnets associated with this site
@@ -1759,7 +1791,19 @@ schemas:
             description: Firewall identifier
         siteid:
           type: string
-          description: ID of the site this network segment belongs to
+          description: >-
+            Internal ID of the site this network segment belongs to. Optional;
+            `site` (the friendly name) is the preferred, human-friendly way to
+            target a site.
+        site:
+          type: string
+          description: >-
+            Friendly site name — the same value shown as "Name" in the Device
+            Security GUI (the site's external_id). Resolved server-side to the
+            internal siteid, so you don't need to look up the site ID first.
+            Optional; `siteid` is still accepted. Supplying both `site` and a
+            conflicting `siteid`, or a `site` name that doesn't exist in the
+            tenant, returns HTTP 400.
 
   CreateNetworkSegmentResponse:
     type: object

--- a/openapi-specs/iot/components/schemas.yaml
+++ b/openapi-specs/iot/components/schemas.yaml
@@ -536,17 +536,15 @@ schemas:
         type: string
         nullable: true
         description: >-
-          The friendly site name (equivalent to the site's external_id) the
-          device is assigned to; `null` when the device has no site. Returned in
-          the default response alongside `siteid`.
+          The site name (the site's `external_id`) the device is assigned to;
+          `null` when the device has no site. Returned in the default response
+          alongside `siteid`.
       attr:
         type: string
         description: >-
-          Nested block of internal device attributes, including the
-          `panwIoTFname_*` raw identifiers (see the field-name mapping in the IoT
-          public API guide). Returned by default (when no `projection` is
-          specified). When a `projection` is supplied, `attr` is EXCLUDED unless
-          `attr` is explicitly listed in the projection.
+          Nested block of internal device attributes (the `panwIoTFname_*` raw
+          identifiers). Returned by default; may be omitted when a `projection`
+          is specified.
 
 
   DeviceTags:
@@ -1662,8 +1660,9 @@ schemas:
             external_id:
               type: string
               description: >-
-                The site's friendly name — the same value shown as "Name" in the
-                Device Security GUI. Use this to reference a site.
+                The site's name — the `external_id` is the same value as the
+                site's "Name" attribute in the Device Security GUI. Use this to
+                reference a site.
               example: 'Example Site 1'
             siteid:
               type: string
@@ -1793,17 +1792,15 @@ schemas:
           type: string
           description: >-
             Internal ID of the site this network segment belongs to. Optional;
-            `site` (the friendly name) is the preferred, human-friendly way to
-            target a site.
+            use `site` instead to target a site by name.
         site:
           type: string
           description: >-
-            Friendly site name — the same value shown as "Name" in the Device
-            Security GUI (the site's external_id). Resolved server-side to the
-            internal siteid, so you don't need to look up the site ID first.
-            Optional; `siteid` is still accepted. Supplying both `site` and a
-            conflicting `siteid`, or a `site` name that doesn't exist in the
-            tenant, returns HTTP 400.
+            Site name — the same value shown as "Name" in the Device Security
+            GUI (the site's `external_id`). You don't need to look up the
+            internal site ID first. Optionally, `siteid` is still accepted.
+            Supplying both `site` and a conflicting `siteid`, or a `site` name
+            that doesn't exist in the tenant, returns HTTP 400.
 
   CreateNetworkSegmentResponse:
     type: object


### PR DESCRIPTION
Documents the IPR-1814 Device Security public API usability changes (subnet `name/siteid/description/prefix/flat`, site `name/description/group`, device `site_name`/`attr` projection, networkSegment friendly `site`) and adds the previously-undocumented **`severity`** filter (Critical/High/Medium/Low) on `GET /vulnerability/list`.

Branched directly off `main` per code-owner guidance. Supersedes #1400.