### PR TITLE
Document the SYSTEM_ACCOUNT user type

### DIFF
--- a/openapi-specs/cspm/UserProfile.json
+++ b/openapi-specs/cspm/UserProfile.json
@@ -230,7 +230,8 @@
             "description": "User type. Default is USER_ACCOUNT.",
             "enum": [
               "USER_ACCOUNT",
-              "SERVICE_ACCOUNT"
+              "SERVICE_ACCOUNT",
+              "SYSTEM_ACCOUNT"
             ],
             "type": "string"
           },


### PR DESCRIPTION
## Summary

Add `SYSTEM_ACCOUNT` to the `user_type` enum in the List Users V3 OpenAPI schema.

The API can return this value, but the schema documented only `USER_ACCOUNT` and `SERVICE_ACCOUNT`. Including the missing enum value keeps the response documentation aligned with the API.

Closes #1087.

## Validation

- `python3 -m json.tool openapi-specs/cspm/UserProfile.json`
- Prettier check for `openapi-specs/cspm/UserProfile.json`
