### PR TITLE
fix(ngts): refresh NGTS spec (path cleanup + fingerprint field clarification)

### DIFF
--- a/openapi-specs/scm/config/ngts/tlsprotect-cloud.json
+++ b/openapi-specs/scm/config/ngts/tlsprotect-cloud.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "TLS Protect Cloud API for Strata Cloud Manager",
-    "description": "Use the TLS Protect Cloud APIs to manage certificates, certificate requests, applications, machine identities, users, teams, event logs, and more. This Open API spec file was created on June 04, 2026. © 2026 Palo Alto Networks, Inc. Palo Alto Networks is a registered trademark of Palo Alto Networks. A list of our trademarks can be found at https://www.paloaltonetworks.com/company/trademarks.html. All other marks mentioned herein may be trademarks of their respective companies.",
+    "description": "Use the TLS Protect Cloud APIs to manage certificates, certificate requests, applications, machine identities, users, teams, event logs, and more. This Open API spec file was created on September 10, 2026. © 2026 Palo Alto Networks, Inc. Palo Alto Networks is a registered trademark of Palo Alto Networks. A list of our trademarks can be found at https://www.paloaltonetworks.com/company/trademarks.html. All other marks mentioned herein may be trademarks of their respective companies.",
     "version": "1.0.0",
     "license": {
       "name": "MIT",
@@ -109,12 +109,12 @@
       "description": "APIs for Plugins (Connectors)."
     },
     {
-      "name": "Built-In Accounts",
-      "description": "APIs for Built-In Accounts."
+      "name": "Built-in Accounts",
+      "description": "APIs for Built-in Accounts."
     }
   ],
   "paths": {
-    "/outagedetection/v1/certificates": {
+    "/v1/certificates": {
       "get": {
         "description": "This endpoint allows you to retrieve all your certificates according to a specified criteria. This API provides a quick way to gather certificate details in order to install the certificates where they are needed.\n\nUse the `subject` query parameter to limit the search based on the certificate subject common name.",
         "operationId": "certificates_getAll",
@@ -175,12 +175,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -190,12 +190,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -214,7 +214,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CertificateImportRequest1"
+                "$ref": "#/components/schemas/CertificateImportRequest2"
               }
             }
           }
@@ -224,7 +224,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CertificateImportResponse1"
+                  "$ref": "#/components/schemas/CertificateImportResponse2"
                 }
               }
             },
@@ -234,7 +234,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -244,7 +244,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -257,7 +257,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificates/{id}": {
+    "/v1/certificates/{id}": {
       "get": {
         "description": "Retrieves the details of the certificate that has the specified `id`.",
         "operationId": "certificates_getById",
@@ -305,7 +305,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -315,7 +315,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -325,7 +325,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -338,7 +338,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificates/{id}/contents": {
+    "/v1/certificates/{id}/contents": {
       "get": {
         "description": "Exports the certificate that has the specified `id` in PEM or DER format. Chain CA certificates are included for PEM format when `chainOrder` is EE_FIRST or ROOT_FIRST.",
         "operationId": "certificates_getContentsById",
@@ -366,7 +366,7 @@
             }
           },
           {
-            "description": "Format of certificate in response.",
+            "description": "Encoding of the certificate payload",
             "in": "query",
             "name": "format",
             "schema": {
@@ -386,6 +386,18 @@
                 "EE_ONLY",
                 "EE_FIRST",
                 "ROOT_FIRST"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Format to which the certificate will be exported to",
+            "in": "query",
+            "name": "containerFormat",
+            "schema": {
+              "enum": [
+                "RAW",
+                "PKCS7"
               ],
               "type": "string"
             }
@@ -416,17 +428,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "application/octet-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -436,17 +448,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "application/octet-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -456,17 +468,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "application/octet-stream": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -479,7 +491,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificates/validation": {
+    "/v1/certificates/validation": {
       "post": {
         "description": "Submits one or more certificates for TLS validation.",
         "operationId": "certificates_validation",
@@ -507,7 +519,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -517,7 +529,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -530,7 +542,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificates/retirement": {
+    "/v1/certificates/retirement": {
       "post": {
         "description": "This endpoint retires one or more certificates by using the **certificateIds** parameter to match a specified value.",
         "operationId": "certificateretirement_retireCertificates",
@@ -558,7 +570,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -568,7 +580,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -581,7 +593,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificates/recovery": {
+    "/v1/certificates/recovery": {
       "post": {
         "description": "Recover the certificates specified by `certificateIds`, including any previous versions of those certificates.",
         "operationId": "certificateretirement_recoverCertificates",
@@ -609,7 +621,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -619,7 +631,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -632,7 +644,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificates/deletion": {
+    "/v1/certificates/deletion": {
       "post": {
         "description": "Permanently deletes the retired certificates specified by `certificateIds` from the inventory.",
         "operationId": "certificateretirement_deleteCertificates",
@@ -654,7 +666,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -664,7 +676,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -677,7 +689,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificatesearch": {
+    "/v1/certificatesearch": {
       "post": {
         "description": "This endpoint retrieves certificate data according to specified search criteria based on commonly used field search parameters. Some examples are `signatureHashAlgorithm`, `validityEnd`, and `issuerCN`. For more information, see [common search parameters](https://docs.venafi.cloud/api/about-api-search-fields/).\n",
         "operationId": "certificates_search_getByExpression",
@@ -728,12 +740,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -743,12 +755,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -761,7 +773,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificateinstances": {
+    "/v1/certificateinstances": {
       "get": {
         "description": "Use this endpoint allows you to retrieve certificate instances according to specified criteria. Total certificate instances are the sum of the number of certificate installations, plus the total number of certificates that have no installations. Trusted CA certificates are not counted. For more information, see [certificate instances](https://docs.venafi.cloud/CSH_view_instances).\n\nUse query parameters to limit your search based on certificate criteria.",
         "operationId": "certificateinstances_getAll",
@@ -788,8 +800,12 @@
                 "MACHINE_DISCOVERY",
                 "KUBERNETES_DISCOVERY",
                 "AWS_DISCOVERY",
+                "AKAMAI_DISCOVERY",
                 "AZURE_DISCOVERY",
-                "GCP_DISCOVERY"
+                "GCP_DISCOVERY",
+                "CODESIGN_ISSUANCE",
+                "ACME_ISSUANCE",
+                "SCEP_ISSUANCE"
               ],
               "type": "string"
             }
@@ -837,12 +853,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -852,12 +868,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -870,7 +886,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificateinstances/{id}": {
+    "/v1/certificateinstances/{id}": {
       "get": {
         "description": "Retrieves the details of the certificate installation that has the specified `id`.",
         "operationId": "certificateinstances_getById",
@@ -901,7 +917,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -911,7 +927,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -921,7 +937,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -934,7 +950,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificateinstances/validation": {
+    "/v1/certificateinstances/validation": {
       "post": {
         "description": "Submits one or more certificate installation for TLS validation.",
         "operationId": "certificateinstances_validation",
@@ -963,7 +979,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -973,7 +989,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -986,7 +1002,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificateinstancesearch": {
+    "/v1/certificateinstancesearch": {
       "post": {
         "description": "Use this endpoint to retrieve certificate instance data according to specified search criteria based on commonly used field search parameters. Some examples are `signatureHashAlgorithm`, `validityEnd`, and `issuerCN`. For more information, see [common search parameters](https://docs.venafi.cloud/api/about-api-search-fields/#common-search-parameters)",
         "operationId": "certificateinstances_search_getByExpression",
@@ -1019,12 +1035,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1034,12 +1050,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1367,7 +1383,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CertificateImportRequest2"
+                "$ref": "#/components/schemas/CertificateImportRequest1"
               }
             }
           }
@@ -1377,7 +1393,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CertificateImportResponse2"
+                  "$ref": "#/components/schemas/CertificateImportResponse1"
                 }
               }
             },
@@ -1387,7 +1403,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -1397,7 +1413,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -1441,7 +1457,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -1451,7 +1467,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -1461,7 +1477,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse5"
+                  "$ref": "#/components/schemas/ErrorResponse6"
                 }
               }
             },
@@ -1474,7 +1490,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificaterequests": {
+    "/v1/certificaterequests": {
       "get": {
         "description": "Retrieves the details of all certificate requests.",
         "operationId": "certificaterequests_getAll",
@@ -1493,7 +1509,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1503,7 +1519,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1542,7 +1558,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1552,7 +1568,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1565,7 +1581,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificaterequests/{id}": {
+    "/v1/certificaterequests/{id}": {
       "get": {
         "description": "Retrieves the details of the certificate request with the specified `id`.",
         "operationId": "certificaterequests_getById",
@@ -1597,7 +1613,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1607,7 +1623,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1617,7 +1633,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1630,7 +1646,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificaterequests/{id}/resubmission": {
+    "/v1/certificaterequests/{id}/resubmission": {
       "post": {
         "description": "Resubmits the certificate request that has the specified `id`.",
         "operationId": "certificaterequests_resubmitById",
@@ -1657,7 +1673,7 @@
           }
         },
         "responses": {
-          "200": {
+          "201": {
             "content": {
               "application/json": {
                 "schema": {
@@ -1671,7 +1687,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1681,7 +1697,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1691,7 +1707,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1704,7 +1720,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificaterequests/validation": {
+    "/v1/certificaterequests/validation": {
       "post": {
         "description": "This operation validates a proposed certificate request without actually submitting it.Checks for compliance with the specified issuing template and verifies all other references are valid (e.g., `existingCertificateId` is the UUID of an inventory certificate).",
         "operationId": "certificaterequests_validation",
@@ -1718,7 +1734,7 @@
           }
         },
         "responses": {
-          "201": {
+          "200": {
             "content": {
               "application/json": {
                 "schema": {
@@ -1732,7 +1748,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1742,7 +1758,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1755,7 +1771,7 @@
         ]
       }
     },
-    "/outagedetection/v1/certificaterequestssearch": {
+    "/v1/certificaterequestssearch": {
       "post": {
         "description": "Retrieves the details of certificate requests that match the specified [search expression](https://docs.venafi.cloud/CSH_api_search).",
         "operationId": "getCertificateRequestsByExpression",
@@ -1783,7 +1799,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -1793,7 +1809,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -2667,7 +2683,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2677,7 +2693,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2716,7 +2732,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2761,7 +2777,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2771,7 +2787,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2781,7 +2797,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2817,7 +2833,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2827,7 +2843,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2837,7 +2853,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2889,7 +2905,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2899,7 +2915,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2909,7 +2925,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2963,7 +2979,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2973,7 +2989,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -2983,7 +2999,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3024,7 +3040,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3034,7 +3050,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3089,7 +3105,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3099,7 +3115,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3138,7 +3154,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3183,7 +3199,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3193,7 +3209,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3203,7 +3219,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3239,7 +3255,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3249,7 +3265,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3259,7 +3275,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3311,7 +3327,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3321,7 +3337,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3331,7 +3347,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3385,7 +3401,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3393,6 +3409,47 @@
           }
         },
         "summary": "Initiate the workflow",
+        "tags": [
+          "Machines"
+        ]
+      }
+    },
+    "/v1/machines/workflows": {
+      "post": {
+        "description": "Triggers test connection workflow on a machine connector.",
+        "operationId": "machines_initiateTestConnectionWorkflow",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestConnectionWorkflowRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MachineInformation"
+                }
+              }
+            },
+            "description": "Test connection workflow initiated successfully."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse8"
+                }
+              }
+            },
+            "description": "Request conditions failed."
+          }
+        },
+        "summary": "Initiate workflow (currently supported test connec",
         "tags": [
           "Machines"
         ]
@@ -3437,7 +3494,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3447,7 +3504,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3485,7 +3542,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3495,7 +3552,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3505,7 +3562,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3515,7 +3572,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3560,7 +3617,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3570,7 +3627,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3580,7 +3637,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3625,7 +3682,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3635,7 +3692,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3645,7 +3702,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse3"
+                  "$ref": "#/components/schemas/ErrorResponse8"
                 }
               }
             },
@@ -3686,7 +3743,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3696,7 +3753,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3745,12 +3802,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3760,12 +3817,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               },
               "text/csv": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3800,7 +3857,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3810,7 +3867,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse9"
+                  "$ref": "#/components/schemas/ErrorResponse3"
                 }
               }
             },
@@ -3848,7 +3905,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -3858,7 +3915,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -3868,7 +3925,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -3942,7 +3999,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -3952,7 +4009,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -3962,7 +4019,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4047,7 +4104,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4057,7 +4114,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4067,7 +4124,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4119,7 +4176,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4129,7 +4186,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4139,7 +4196,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4180,7 +4237,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4221,7 +4278,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4292,7 +4349,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4302,7 +4359,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4355,7 +4412,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4365,7 +4422,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4410,7 +4467,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4420,7 +4477,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4430,7 +4487,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse6"
+                  "$ref": "#/components/schemas/ErrorResponse9"
                 }
               }
             },
@@ -4496,7 +4553,7 @@
         ]
       }
     },
-    "/outagedetection/v1/inventorymonitoringconfig/{type}": {
+    "/v1/inventorymonitoringconfig/{type}": {
       "get": {
         "description": "Retrieves the details of the inventory monitoring configuration by configuration type",
         "operationId": "inventorymonitoringconfiguration_getByType",
@@ -4530,7 +4587,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -4540,7 +4597,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -4550,7 +4607,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -4606,7 +4663,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -4616,7 +4673,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -4629,7 +4686,7 @@
         ]
       }
     },
-    "/outagedetection/v1/inventorymonitoringconfig/{type}/scheduler": {
+    "/v1/inventorymonitoringconfig/{type}/scheduler": {
       "put": {
         "description": "Update inventory monitoring scheduler by type",
         "operationId": "inventorymonitoringconfigurationscheduler_update",
@@ -4673,7 +4730,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -4683,7 +4740,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse4"
+                  "$ref": "#/components/schemas/ErrorResponse7"
                 }
               }
             },
@@ -4913,7 +4970,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -4923,7 +4980,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -4964,7 +5021,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -4974,7 +5031,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5018,7 +5075,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5028,7 +5085,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5038,7 +5095,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5073,7 +5130,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5083,7 +5140,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5127,7 +5184,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5137,7 +5194,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5147,7 +5204,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5200,7 +5257,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5210,7 +5267,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5257,7 +5314,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5267,7 +5324,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5299,7 +5356,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5309,7 +5366,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5352,7 +5409,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5362,7 +5419,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5398,7 +5455,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5408,7 +5465,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5451,7 +5508,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5461,7 +5518,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5504,7 +5561,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5514,7 +5571,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse8"
+                  "$ref": "#/components/schemas/ErrorResponse4"
                 }
               }
             },
@@ -5529,7 +5586,8 @@
     },
     "/v1/distributedissuers/configurations": {
       "post": {
-        "description": "Adds a new Issuer Configuration, which links the following together - Sub CA Provider, Policies used to determine which certificates can be issued, and the IdP (Identity Provider) the Issuer should trust when receiving signed JWTs from its clients.",
+        "deprecated": true,
+        "description": "Adds a new Issuer Configuration, which links the following together - Sub CA Provider, Policies used to determine which certificates can be issued, and the IdP (Identity Provider) the Issuer should trust when receiving signed JWTs from its clients.\n\nDeprecated: use `POST /v1/distributedissuers/configurations/DISTRIBUTED_ISSUER` instead. This alias creates a `DISTRIBUTED_ISSUER` configuration and behaves identically.",
         "operationId": "configurations_create",
         "requestBody": {
           "content": {
@@ -5545,7 +5603,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtendedConfigurationInformation"
+                  "$ref": "#/components/schemas/ExtendedConfigurationGetResponse"
                 }
               }
             },
@@ -5555,21 +5613,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Possible causes, by error code:\n- 10006: Malformed JSON body or an unknown/unrecognized field;\n  `minTlsVersion` is not TLS12 or TLS13; `clientAuthentication.type` is\n  missing or unknown; or a cloud-provider `regions` value is not a\n  recognized AWS or Google region.\n- 50200: `name` is empty.\n- 50201: `subCaProviderId` is missing.\n- 50202: The `policyIds` list is empty.\n- 50205: A configuration with the same `name` already exists.\n- 50207: JWT_JWKS `urls` list is empty.\n- 50208: JWT_OIDC `baseUrl` is empty.\n- 50209: JWT_OIDC `audience` is empty.\n- 50212: AWS `accountIds` contains a value that is not a 12-digit string.\n- 50213: AWS `accountIds` list is empty.\n- 50214: AWS `regions` is missing.\n- 50216: Azure `subscriptionIds` list is empty.\n- 50218: Google `projectIdentifiers` contains an invalid identifier.\n- 50219: Google `projectIdentifiers` list is empty.\n- 50220: Google `regions` is missing.\n- 50221: `name` is longer than 64 characters.\n- 50222: A JWT_JWKS URL is not a valid HTTPS URL of at most 2048 characters.\n- 50223: JWT_OIDC `baseUrl` is longer than 2048 characters.\n- 50224: JWT_OIDC `audience` is longer than 256 characters.\n- 50225: `clientAuthorization` configuration custom-claim alias exceeds 128 characters.\n- 50226: `clientAuthorization` allow-all-policies custom-claim alias exceeds 128 characters.\n- 50227: `clientAuthorization` allowed-policies custom-claim alias exceeds 128 characters.\n- 50228: `advancedSettings` is invalid (e.g. `includeRawCertDataInAuditLog`\n  is true while `enableIssuanceAuditLog` is disabled).\n- 50229: JWT_STANDARD_CLAIMS `clients` list is empty.\n- 50230: Two JWT_STANDARD_CLAIMS clients share the same issuer/JWKS-URI pair.\n- 50231: A JWT_STANDARD_CLAIMS client issuer is not a valid HTTPS URL while `jwksUri` is absent.\n- 50232: JWT_STANDARD_CLAIMS `audience` is empty.\n- 50233: JWT_STANDARD_CLAIMS `audience` is longer than 256 characters.\n- 50234: A JWT_STANDARD_CLAIMS client `name` is empty.\n- 50235: A JWT_STANDARD_CLAIMS client `name` is longer than 64 characters.\n- 50236: A JWT_STANDARD_CLAIMS client `issuer` is empty.\n- 50237: A JWT_STANDARD_CLAIMS client `issuer` is longer than 2048 characters.\n- 50238: A JWT_STANDARD_CLAIMS client `jwksUri` is longer than 2048 characters.\n- 50239: A JWT_STANDARD_CLAIMS client `jwksUri` is invalid.\n- 50240: A JWT_STANDARD_CLAIMS client `subjects` list is empty.\n- 50241: A JWT_STANDARD_CLAIMS client `allowedPolicyIds` list is empty.\n- 50242: JWT_OIDC `baseUrl` is not a valid HTTPS URL."
           },
-          "412": {
+          "404": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The referenced entity was not found. Possible causes, by error code:\n- 50203: The referenced Sub CA provider does not exist in this tenant.\n- 50204: One or more of the referenced policies do not exist in this tenant."
           }
         },
         "summary": "Create a new Issuer configuration",
@@ -5585,31 +5643,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConfigurationResponse"
+                  "$ref": "#/components/schemas/ConfigurationListResponse"
                 }
               }
             },
             "description": "All Issuer configurations."
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
           }
         },
         "summary": "Get the details of all Issuer",
@@ -5629,6 +5667,7 @@
             "name": "id",
             "required": true,
             "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
@@ -5638,7 +5677,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtendedConfigurationInformation"
+                  "$ref": "#/components/schemas/ExtendedConfigurationGetResponse"
                 }
               }
             },
@@ -5648,31 +5687,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Possible causes, by error code:\n- 10055: The `id` path parameter is not a valid UUID."
           },
           "404": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Specified Issuer configuration was not found."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
+            "description": "The referenced entity was not found. Possible causes, by error code:\n- 10051: No Issuer configuration with the given `id` exists in this tenant."
           }
         },
         "summary": "Get configurations details for a specific",
@@ -5681,7 +5710,8 @@
         ]
       },
       "patch": {
-        "description": "Updates (replaces) fields on an Issuer configuration that has the specified `id`. Only fields specified in the request will be updated. Fields not specified in the request are not modified.",
+        "deprecated": true,
+        "description": "Updates (replaces) fields on an Issuer configuration that has the specified `id`. Only fields specified in the request will be updated. Fields not specified in the request are not modified.\n\nDeprecated: use `PATCH /v1/distributedissuers/configurations/DISTRIBUTED_ISSUER/{id}` instead. This alias updates a `DISTRIBUTED_ISSUER` configuration and behaves identically; it returns not-found for a configuration of any other kind.",
         "operationId": "configurations_update",
         "parameters": [
           {
@@ -5690,6 +5720,7 @@
             "name": "id",
             "required": true,
             "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
@@ -5710,7 +5741,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtendedConfigurationInformation"
+                  "$ref": "#/components/schemas/ExtendedConfigurationGetResponse"
                 }
               }
             },
@@ -5720,31 +5751,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Supplied fields are validated with the same\nrules as on create. Possible causes, by error code:\n- 10006: Malformed JSON body or an unknown/immutable field (e.g.\n  `companyId`, `subTsgId`); `minTlsVersion` is not TLS12 or TLS13;\n  `clientAuthentication.type` is missing or unknown; or a cloud-provider\n  `regions` value is not a recognized AWS or Google region.\n- 10055: The `id` path parameter is not a valid UUID.\n- 50200: `name` is empty.\n- 50205: A different configuration with the same `name` already exists.\n- 50207: JWT_JWKS `urls` list is empty.\n- 50208: JWT_OIDC `baseUrl` is empty.\n- 50209: JWT_OIDC `audience` is empty.\n- 50212: AWS `accountIds` contains a value that is not a 12-digit string.\n- 50213: AWS `accountIds` list is empty.\n- 50214: AWS `regions` is missing.\n- 50216: Azure `subscriptionIds` list is empty.\n- 50218: Google `projectIdentifiers` contains an invalid identifier.\n- 50219: Google `projectIdentifiers` list is empty.\n- 50220: Google `regions` is missing.\n- 50221: `name` is longer than 64 characters.\n- 50222: A JWT_JWKS URL is not a valid HTTPS URL of at most 2048 characters.\n- 50223: JWT_OIDC `baseUrl` is longer than 2048 characters.\n- 50224: JWT_OIDC `audience` is longer than 256 characters.\n- 50225: `clientAuthorization` configuration custom-claim alias exceeds 128 characters.\n- 50226: `clientAuthorization` allow-all-policies custom-claim alias exceeds 128 characters.\n- 50227: `clientAuthorization` allowed-policies custom-claim alias exceeds 128 characters.\n- 50228: `advancedSettings` is invalid.\n- 50229: JWT_STANDARD_CLAIMS `clients` list is empty.\n- 50230: Two JWT_STANDARD_CLAIMS clients share the same issuer/JWKS-URI pair.\n- 50231: A JWT_STANDARD_CLAIMS client issuer is not a valid HTTPS URL while `jwksUri` is absent.\n- 50232: JWT_STANDARD_CLAIMS `audience` is empty.\n- 50233: JWT_STANDARD_CLAIMS `audience` is longer than 256 characters.\n- 50234: A JWT_STANDARD_CLAIMS client `name` is empty.\n- 50235: A JWT_STANDARD_CLAIMS client `name` is longer than 64 characters.\n- 50236: A JWT_STANDARD_CLAIMS client `issuer` is empty.\n- 50237: A JWT_STANDARD_CLAIMS client `issuer` is longer than 2048 characters.\n- 50238: A JWT_STANDARD_CLAIMS client `jwksUri` is longer than 2048 characters.\n- 50239: A JWT_STANDARD_CLAIMS client `jwksUri` is invalid.\n- 50240: A JWT_STANDARD_CLAIMS client `subjects` list is empty.\n- 50241: A JWT_STANDARD_CLAIMS client `allowedPolicyIds` list is empty.\n- 50242: JWT_OIDC `baseUrl` is not a valid HTTPS URL."
           },
           "404": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Specified Issuer configuration was not found."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
+            "description": "The referenced entity was not found. Possible causes, by error code:\n- 10051: No Issuer configuration with the given `id` exists in this tenant.\n- 50203: A newly referenced Sub CA provider does not exist in this tenant.\n- 50204: One or more newly referenced policies do not exist in this tenant."
           }
         },
         "summary": "Update an Issuer configuration details",
@@ -5762,6 +5783,7 @@
             "name": "id",
             "required": true,
             "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
@@ -5781,31 +5803,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Possible causes, by error code:\n- 10055: The `id` path parameter is not a valid UUID."
           },
           "404": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Issuer configuration was not found."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
+            "description": "The referenced entity was not found. Possible causes, by error code:\n- 10051: No Issuer configuration with the given `id` exists in this tenant."
           }
         },
         "summary": "Remove an Issuer configuration",
@@ -5822,7 +5834,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SubCaProviderCreateRequest"
+                "$ref": "#/components/schemas/SubCAProviderCreateRequest"
               }
             }
           },
@@ -5834,7 +5846,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SubCaProviderInformation"
+                  "$ref": "#/components/schemas/SubCAProviderGetResponse"
                 }
               }
             },
@@ -5844,21 +5856,31 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Possible causes, by error code:\n- 10006: Malformed JSON body or an unknown/unrecognized field; or sharing\n  is requested outside a Strata context or with both `shareWithAll` and\n  `sharedWithSubTsgIds` set.\n- 50301: `name` is empty.\n- 50302: `caAccountId` is missing.\n- 50303: `caProductOptionId` is missing.\n- 50304: `validityPeriod` is empty or not a valid ISO-8601 period.\n- 50305: `commonName` is empty.\n- 50306: `keyAlgorithm` is empty.\n- 50308: `caType` is not a supported Sub CA type.\n- 50310: `caType` is empty.\n- 50311: A Sub CA provider with the same `name` already exists.\n- 50312: `name` is longer than 64 characters.\n- 50313: `commonName` is longer than 64 characters.\n- 50314: `organization` is longer than 64 characters.\n- 50315: `organizationalUnit` is longer than 64 characters.\n- 50316: `locality` is longer than 64 characters.\n- 50317: `stateOrProvince` is longer than 64 characters.\n- 50318: `country` is longer than 64 characters.\n- 50319: When signing is enabled, the PKCS11 partition label is empty or\n  longer than 32 characters, or the PIN is empty.\n- 50320: A PKCS11 allowed client library is not a 64-character SHA-256 hash.\n- 50321: The PKCS11 partition serial number is not up to 18 numeric/hex characters.\n- 50322: A sub-TSG id is not a 10-digit number starting with 1."
           },
-          "412": {
+          "403": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was forbidden. Possible causes, by error code:\n- 1002: The operation is restricted to the primary TSG; sub-TSG callers are rejected."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "The referenced entity was not found. Possible causes, by error code:\n- 50307: The referenced CA account does not exist (or belongs to another tenant).\n- 50309: The referenced CA product option does not exist on that CA account."
           }
         },
         "summary": "Create a new Sub CA provider",
@@ -5868,37 +5890,17 @@
       },
       "get": {
         "description": "Returns a list of all the subordinate CA providers along with their details.",
-        "operationId": "subcaprovider_getAll",
+        "operationId": "subcaproviders_getAll",
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SubCaProviderResponse"
+                  "$ref": "#/components/schemas/SubCAProviderListResponse"
                 }
               }
             },
             "description": "All Sub CA providers with details."
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
           }
         },
         "summary": "Get the details of all Sub",
@@ -5918,6 +5920,7 @@
             "name": "id",
             "required": true,
             "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
@@ -5927,7 +5930,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SubCaProviderInformation"
+                  "$ref": "#/components/schemas/SubCAProviderGetResponse"
                 }
               }
             },
@@ -5937,31 +5940,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Possible causes, by error code:\n- 10055: The `id` path parameter is not a valid UUID."
           },
           "404": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Specified sub CA provider was not found."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
+            "description": "The referenced entity was not found. Possible causes, by error code:\n- 10051: No Sub CA provider with the given `id` exists in this tenant."
           }
         },
         "summary": "Get a Sub CA provider details",
@@ -5979,6 +5972,7 @@
             "name": "id",
             "required": true,
             "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
@@ -5987,7 +5981,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SubCaProviderUpdateRequest"
+                "$ref": "#/components/schemas/SubCAProviderUpdateRequest"
               }
             }
           },
@@ -5999,7 +5993,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SubCaProviderInformation"
+                  "$ref": "#/components/schemas/SubCAProviderGetResponse"
                 }
               }
             },
@@ -6009,31 +6003,31 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Supplied fields are validated with the same\nrules as on create. Possible causes, by error code:\n- 10006: Malformed JSON body or an unknown/unrecognized field; or sharing\n  is requested outside a Strata context or with both `shareWithAll` and\n  `sharedWithSubTsgIds` set.\n- 10055: The `id` path parameter is not a valid UUID.\n- 50301: `name` is empty.\n- 50304: `validityPeriod` is not a valid ISO-8601 period.\n- 50305: `commonName` is empty.\n- 50311: A different Sub CA provider with the same `name` already exists.\n- 50312: `name` is longer than 64 characters.\n- 50313: `commonName` is longer than 64 characters.\n- 50314: `organization` is longer than 64 characters.\n- 50315: `organizationalUnit` is longer than 64 characters.\n- 50316: `locality` is longer than 64 characters.\n- 50317: `stateOrProvince` is longer than 64 characters.\n- 50318: `country` is longer than 64 characters.\n- 50319: When signing is enabled, the PKCS11 partition label is empty or\n  longer than 32 characters, or the PIN is empty.\n- 50320: A PKCS11 allowed client library is not a 64-character SHA-256 hash.\n- 50321: The PKCS11 partition serial number is not up to 18 numeric/hex characters.\n- 50322: A sub-TSG id is not a 10-digit number starting with 1.\n- 50247: HSM signing cannot be enabled because the Sub CA provider is\n  referenced by one or more forward-trust proxy configurations."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "The request was forbidden. Possible causes, by error code:\n- 1002: The operation is restricted to the primary TSG; sub-TSG callers are rejected."
           },
           "404": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Specified Sub CA provider was not found."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
+            "description": "The referenced entity was not found. Possible causes, by error code:\n- 10051: No Sub CA provider with the given `id` exists in this tenant.\n- 50307: When `caProductOptionId` is changed, the referenced CA account\n  does not exist (or belongs to another tenant).\n- 50309: When `caProductOptionId` is changed, the referenced CA product\n  option does not exist on that CA account."
           }
         },
         "summary": "Update a Sub CA provider details",
@@ -6051,6 +6045,7 @@
             "name": "id",
             "required": true,
             "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
@@ -6060,7 +6055,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SubCaProviderDeleteResponse"
+                  "$ref": "#/components/schemas/SubCAProviderDeleteResponse"
                 }
               }
             },
@@ -6070,31 +6065,31 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Possible causes, by error code:\n- 10055: The `id` path parameter is not a valid UUID.\n- 50300: The Sub CA provider cannot be deleted because it is still\n  referenced by one or more Issuer configurations; the response lists the\n  blocking configuration ids."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "The request was forbidden. Possible causes, by error code:\n- 1002: The operation is restricted to the primary TSG; sub-TSG callers are rejected."
           },
           "404": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Specified sub CA provider was not found."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
+            "description": "The referenced entity was not found. Possible causes, by error code:\n- 10051: No Sub CA provider with the given `id` exists in this tenant."
           }
         },
         "summary": "Remove a Sub CA provider",
@@ -6121,7 +6116,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtendedPolicyInformation"
+                  "$ref": "#/components/schemas/ExtendedPolicyGetResponse"
                 }
               }
             },
@@ -6131,21 +6126,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Possible causes, by error code:\n- 10006: Malformed JSON body or an unknown/unrecognized field; a\n  `keyUsages` value is unsupported; a `keyAlgorithm` allowed or default\n  value is unsupported; or sharing is requested outside a Strata context\n  or with both `shareWithAll` and `sharedWithSubTsgIds` set.\n- 50100: `name` is empty.\n- 50101: `validityPeriod` is empty or not a valid ISO-8601 period.\n- 50102: `subject` is omitted from the body.\n- 50103: `sans` is omitted from the body.\n- 50104: `keyUsages` list is empty.\n- 50105: `extendedKeyUsages` list is empty.\n- 50106: `keyAlgorithm` is omitted.\n- 50107: `keyAlgorithm.allowedValues` list is empty.\n- 50108: `keyAlgorithm.defaultValue` is empty.\n- 50111: A policy with the same `name` already exists.\n- 50112: Invalid subject common name.\n- 50113: Invalid subject organization.\n- 50114: Invalid subject organizational unit.\n- 50115: Invalid subject locality.\n- 50116: Invalid subject state or province.\n- 50117: Invalid subject country.\n- 50118: Invalid SAN DNS name.\n- 50119: Invalid SAN IP address.\n- 50120: Invalid SAN RFC822/email name.\n- 50121: Invalid SAN URI.\n- 50122: `name` is longer than 64 characters.\n- 50123: `extendedKeyUsages` contains a value unsupported by Workload Identity Manager.\n- 50124: A sub-TSG id is not a 10-digit number starting with 1."
           },
-          "412": {
+          "403": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was forbidden. Possible causes, by error code:\n- 1002: The operation is restricted to the primary TSG; sub-TSG callers are rejected."
           }
         },
         "summary": "Create a new Workload Issuance policy",
@@ -6161,31 +6156,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PolicyResponse"
+                  "$ref": "#/components/schemas/PolicyListResponse"
                 }
               }
             },
             "description": "All Workload Issuance policies; details in response body."
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
           }
         },
         "summary": "Get the details of all Workload",
@@ -6205,6 +6180,7 @@
             "name": "id",
             "required": true,
             "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
@@ -6214,7 +6190,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtendedPolicyInformation"
+                  "$ref": "#/components/schemas/ExtendedPolicyGetResponse"
                 }
               }
             },
@@ -6224,31 +6200,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Possible causes, by error code:\n- 10055: The `id` path parameter is not a valid UUID."
           },
           "404": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Specified Workload Issuance policy was not found."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
+            "description": "The referenced entity was not found. Possible causes, by error code:\n- 10051: No Workload Issuance policy with the given `id` exists in this tenant."
           }
         },
         "summary": "Get a Workload Issuance policy details",
@@ -6266,6 +6232,7 @@
             "name": "id",
             "required": true,
             "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
@@ -6284,7 +6251,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExtendedPolicyInformation"
+                  "$ref": "#/components/schemas/ExtendedPolicyGetResponse"
                 }
               }
             },
@@ -6294,31 +6261,31 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Supplied fields are validated with the same\nrules as on create. Possible causes, by error code:\n- 10006: Malformed JSON body or an unknown/unrecognized field; a\n  `keyUsages` value is unsupported; a `keyAlgorithm` allowed or default\n  value is unsupported; or sharing is requested outside a Strata context\n  or with both `shareWithAll` and `sharedWithSubTsgIds` set.\n- 10055: The `id` path parameter is not a valid UUID.\n- 50100: `name` is empty.\n- 50101: `validityPeriod` is not a valid ISO-8601 period.\n- 50107: `keyAlgorithm.allowedValues` list is empty (only when `keyAlgorithm` is supplied).\n- 50108: `keyAlgorithm.defaultValue` is empty (only when `keyAlgorithm` is supplied).\n- 50111: A different policy with the same `name` already exists.\n- 50112: Invalid subject common name.\n- 50113: Invalid subject organization.\n- 50114: Invalid subject organizational unit.\n- 50115: Invalid subject locality.\n- 50116: Invalid subject state or province.\n- 50117: Invalid subject country.\n- 50118: Invalid SAN DNS name.\n- 50119: Invalid SAN IP address.\n- 50120: Invalid SAN RFC822/email name.\n- 50121: Invalid SAN URI.\n- 50122: `name` is longer than 64 characters.\n- 50123: `extendedKeyUsages` contains a value unsupported by Workload Identity Manager.\n- 50124: A sub-TSG id is not a 10-digit number starting with 1."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "The request was forbidden. Possible causes, by error code:\n- 1002: The operation is restricted to the primary TSG; sub-TSG callers are rejected."
           },
           "404": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Workload Issuance policy was not found."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
+            "description": "The referenced entity was not found. Possible causes, by error code:\n- 10051: No Workload Issuance policy with the given `id` exists in this tenant."
           }
         },
         "summary": "Update a Workload Issuance policy details",
@@ -6336,6 +6303,7 @@
             "name": "id",
             "required": true,
             "schema": {
+              "format": "uuid",
               "type": "string"
             }
           }
@@ -6355,31 +6323,31 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Incomplete or malformed request."
+            "description": "The request was rejected. Possible causes, by error code:\n- 10055: The `id` path parameter is not a valid UUID.\n- 50110: The policy cannot be deleted because it is still referenced by\n  one or more Issuer configurations; the response lists the blocking\n  configuration ids."
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse10"
+                }
+              }
+            },
+            "description": "The request was forbidden. Possible causes, by error code:\n- 1002: The operation is restricted to the primary TSG; sub-TSG callers are rejected."
           },
           "404": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
+                  "$ref": "#/components/schemas/ErrorResponse10"
                 }
               }
             },
-            "description": "Specified Workload Issuance policy was not found."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
+            "description": "The referenced entity was not found. Possible causes, by error code:\n- 10051: No Workload Issuance policy with the given `id` exists in this tenant."
           }
         },
         "summary": "Remove a Workload Issuance policy",
@@ -6397,31 +6365,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IntermediateCertificateResponse"
+                  "$ref": "#/components/schemas/IntermediateCertificateListResponse"
                 }
               }
             },
             "description": "All Issuer intermediate certificates and details."
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
-          },
-          "412": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse7"
-                }
-              }
-            },
-            "description": "Incomplete or malformed request."
           }
         },
         "summary": "Get the details of all Issuer",
@@ -7520,7 +7468,7 @@
         },
         "summary": "Retrieves all the Service Accounts the",
         "tags": [
-          "Built-In Accounts"
+          "Built-in Accounts"
         ]
       },
       "post": {
@@ -7560,7 +7508,7 @@
         },
         "summary": "Creates a Service Account",
         "tags": [
-          "Built-In Accounts"
+          "Built-in Accounts"
         ]
       }
     },
@@ -7608,7 +7556,7 @@
         },
         "summary": "Gets a Service Account",
         "tags": [
-          "Built-In Accounts"
+          "Built-in Accounts"
         ]
       },
       "patch": {
@@ -7658,7 +7606,7 @@
         },
         "summary": "Updates a Service Account",
         "tags": [
-          "Built-In Accounts"
+          "Built-in Accounts"
         ]
       },
       "delete": {
@@ -7697,7 +7645,7 @@
         },
         "summary": "Deletes a Service Account",
         "tags": [
-          "Built-In Accounts"
+          "Built-in Accounts"
         ]
       }
     },
@@ -7728,7 +7676,7 @@
         },
         "summary": "Retrieves all the Service Accounts Scopes",
         "tags": [
-          "Built-In Accounts"
+          "Built-in Accounts"
         ]
       }
     },
@@ -7776,7 +7724,7 @@
         },
         "summary": "Regenerate the OCI registry token for",
         "tags": [
-          "Built-In Accounts"
+          "Built-in Accounts"
         ]
       }
     },
@@ -7835,7 +7783,7 @@
         },
         "summary": "Updates a Service Account credentials",
         "tags": [
-          "Built-In Accounts"
+          "Built-in Accounts"
         ]
       }
     }
@@ -8098,7 +8046,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse10"
+              "$ref": "#/components/schemas/ErrorResponse5"
             }
           }
         },
@@ -8108,7 +8056,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse10"
+              "$ref": "#/components/schemas/ErrorResponse5"
             }
           }
         },
@@ -8118,7 +8066,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse10"
+              "$ref": "#/components/schemas/ErrorResponse5"
             }
           }
         },
@@ -8128,7 +8076,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse10"
+              "$ref": "#/components/schemas/ErrorResponse5"
             }
           }
         },
@@ -8138,7 +8086,7 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse10"
+              "$ref": "#/components/schemas/ErrorResponse5"
             }
           }
         },
@@ -8146,6 +8094,67 @@
       }
     },
     "schemas": {
+      "AWSCloudProvider": {
+        "properties": {
+          "accountIds": {
+            "description": "Array of AWS account IDs each of which should be a 12-digit identifier",
+            "example": [
+              "123456789012"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "regions": {
+            "description": "Array of AWS regions",
+            "example": [
+              "us-west-1"
+            ],
+            "items": {
+              "enum": [
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2",
+                "af-south-1",
+                "ap-east-1",
+                "ap-south-2",
+                "ap-southeast-3",
+                "ap-southeast-4",
+                "ap-south-1",
+                "ap-northeast-3",
+                "ap-northeast-2",
+                "ap-southeast-1",
+                "ap-southeast-2",
+                "ap-northeast-1",
+                "ca-central-1",
+                "eu-central-1",
+                "eu-west-1",
+                "eu-west-2",
+                "eu-south-1",
+                "eu-west-3",
+                "eu-south-2",
+                "eu-north-1",
+                "eu-central-2",
+                "me-south-1",
+                "me-central-1",
+                "sa-east-1",
+                "us-gov-east-1",
+                "us-gov-west-1"
+              ],
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "accountIds",
+          "regions"
+        ],
+        "type": "object"
+      },
       "ActivityLogCondition": {
         "description": "A Condition for filtering",
         "properties": {
@@ -8258,7 +8267,7 @@
             "$ref": "#/components/schemas/BaseActivityLogOrdering"
           },
           "paging": {
-            "$ref": "#/components/schemas/Page2"
+            "$ref": "#/components/schemas/Page1"
           }
         },
         "type": "object"
@@ -8421,7 +8430,7 @@
         ],
         "type": "object"
       },
-      "AdvancedSettingsInformation": {
+      "AdvancedSettings": {
         "properties": {
           "enableIssuanceAuditLog": {
             "description": "Whether audit log entries must be generated for each issued certificate",
@@ -8463,9 +8472,6 @@
         "description": "Can be any value - string, number, boolean, array or object."
       },
       "AnyValue8": {
-        "description": "Can be any value - string, number, boolean, array or object."
-      },
-      "AnyValue9": {
         "description": "Can be any value - string, number, boolean, array or object."
       },
       "ApiClientInformation": {
@@ -8699,68 +8705,7 @@
         ],
         "type": "string"
       },
-      "AwsCloudProviderInformation": {
-        "properties": {
-          "accountIds": {
-            "description": "Array of AWS account IDs each of which should be a 12-digit identifier",
-            "example": [
-              "123456789012"
-            ],
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "type": "array"
-          },
-          "regions": {
-            "description": "Array of AWS regions",
-            "example": [
-              "us-west-1"
-            ],
-            "items": {
-              "enum": [
-                "us-east-1",
-                "us-east-2",
-                "us-west-1",
-                "us-west-2",
-                "af-south-1",
-                "ap-east-1",
-                "ap-south-2",
-                "ap-southeast-3",
-                "ap-southeast-4",
-                "ap-south-1",
-                "ap-northeast-3",
-                "ap-northeast-2",
-                "ap-southeast-1",
-                "ap-southeast-2",
-                "ap-northeast-1",
-                "ca-central-1",
-                "eu-central-1",
-                "eu-west-1",
-                "eu-west-2",
-                "eu-south-1",
-                "eu-west-3",
-                "eu-south-2",
-                "eu-north-1",
-                "eu-central-2",
-                "me-south-1",
-                "me-central-1",
-                "sa-east-1",
-                "us-gov-east-1",
-                "us-gov-west-1"
-              ],
-              "type": "string"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "accountIds",
-          "regions"
-        ],
-        "type": "object"
-      },
-      "AzureCloudProviderInformation": {
+      "AzureCloudProvider": {
         "properties": {
           "subscriptionIds": {
             "description": "Array of Azure subscription IDs each of which should be UUID",
@@ -8875,6 +8820,23 @@
         },
         "type": "object"
       },
+      "CAType": {
+        "description": "Type of CA this Sub CA provider works with",
+        "enum": [
+          "MOCKCA",
+          "DIGICERT",
+          "GLOBALSIGN",
+          "BUILTIN",
+          "ENTRUST",
+          "MICROSOFT",
+          "ACME",
+          "ZTPKI",
+          "GLOBALSIGNMSSL",
+          "TPP"
+        ],
+        "example": "BUILTIN",
+        "type": "string"
+      },
       "CMSAuthenticationType": {
         "description": "The authentication type for the privileged access management:\n  * `certificate` - For authentication with a Certificate bundle\n  * `userPassword` - For authentication with user and password\n  * `token` - For authentication with token\n  * `appRole` - For authentication with AppRole\n",
         "enum": [
@@ -8952,7 +8914,7 @@
         "type": "string"
       },
       "CSRAttributesInformation": {
-        "description": "Represents CSR attributes for certificate requests. Required when isVaaSGenerated is set to true and reuseCSR to false.",
+        "description": "Represents CSR attributes when system is expected to generate the CSR bytes. Required when submitting regular certificate signing request i.e. isVaaSGenerated is set to true. Required when renewing a certificate i.e. renewType is set to SYSTEM_GENERATED_CSR.",
         "example": {
           "commonName": "localhost",
           "country": "MX",
@@ -9109,6 +9071,7 @@
               "format": "uuid",
               "type": "string"
             },
+            "minItems": 1,
             "type": "array"
           }
         },
@@ -9177,6 +9140,7 @@
           },
           "certificate": {
             "description": "Certificate base64 encoded format (PEM without header/footer",
+            "minLength": 1,
             "type": "string"
           },
           "certificateUsageMetadata": {
@@ -9248,25 +9212,6 @@
       },
       "CertificateImportRequest1": {
         "properties": {
-          "certificates": {
-            "description": "Base64 encoding certificate content.",
-            "items": {
-              "$ref": "#/components/schemas/CertificateImportInfo"
-            },
-            "type": "array"
-          },
-          "overrideBlocklist": {
-            "description": "Imports the certificate even if it's present in the Certificates blocklist.",
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "certificates"
-        ],
-        "type": "object"
-      },
-      "CertificateImportRequest2": {
-        "properties": {
           "edgeInstanceId": {
             "description": "Id for edge instance",
             "format": "uuid",
@@ -9294,7 +9239,41 @@
         ],
         "type": "object"
       },
+      "CertificateImportRequest2": {
+        "properties": {
+          "certificates": {
+            "description": "Base64 encoding certificate content.",
+            "items": {
+              "$ref": "#/components/schemas/CertificateImportInfo"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "overrideBlocklist": {
+            "description": "Imports the certificate even if it's present in the Certificates blocklist.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "certificates"
+        ],
+        "type": "object"
+      },
       "CertificateImportResponse1": {
+        "properties": {
+          "creationDate": {
+            "description": "Import creation date of certificates and private keys",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "Import id used to check the status of the bulk operation",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "CertificateImportResponse2": {
         "properties": {
           "certificateInformations": {
             "description": "A collection of information about certificates that were newly imported.",
@@ -9311,20 +9290,6 @@
             },
             "description": "Certificate import statistics",
             "type": "object"
-          }
-        },
-        "type": "object"
-      },
-      "CertificateImportResponse2": {
-        "properties": {
-          "creationDate": {
-            "description": "Import creation date of certificates and private keys",
-            "format": "date-time",
-            "type": "string"
-          },
-          "id": {
-            "description": "Import id used to check the status of the bulk operation",
-            "type": "string"
           }
         },
         "type": "object"
@@ -9696,7 +9661,64 @@
               "UNKNOWN",
               "SHA1_WITH_RSAandMGF1",
               "GOST_R3411_94_WITH_GOST_R3410_2001",
-              "GOST_R3411_94_WITH_GOST_R3410_94"
+              "GOST_R3411_94_WITH_GOST_R3410_94",
+              "SHA256_WITH_RSAandMGF1",
+              "SHA384_WITH_RSAandMGF1",
+              "SHA512_WITH_RSAandMGF1",
+              "SHA224_WITH_RSAandMGF1",
+              "SHA224_WITH_RSA_ENCRYPTION",
+              "DSA_WITH_SHA224",
+              "DSA_WITH_SHA256",
+              "DSA_WITH_SHA384",
+              "DSA_WITH_SHA512",
+              "ED25519",
+              "ED448",
+              "EC_DSA_WITH_SHA3_224",
+              "EC_DSA_WITH_SHA3_256",
+              "EC_DSA_WITH_SHA3_384",
+              "EC_DSA_WITH_SHA3_512",
+              "SHA3_224_WITH_RSA_ENCRYPTION",
+              "SHA3_256_WITH_RSA_ENCRYPTION",
+              "SHA3_384_WITH_RSA_ENCRYPTION",
+              "SHA3_512_WITH_RSA_ENCRYPTION",
+              "EC_GDSA_WITH_SHA1",
+              "EC_GDSA_WITH_RIPEMD160",
+              "RSA_WITH_RIPEMD128",
+              "RSA_WITH_RIPEMD160",
+              "RSA_WITH_RIPEMD256",
+              "SHA3_224_WITH_RSAandMGF1",
+              "SHA3_256_WITH_RSAandMGF1",
+              "SHA3_384_WITH_RSAandMGF1",
+              "SHA3_512_WITH_RSAandMGF1",
+              "SHA512_224_WITH_RSA_ENCRYPTION",
+              "SHA512_256_WITH_RSA_ENCRYPTION",
+              "DSA_WITH_SHA3_224",
+              "DSA_WITH_SHA3_256",
+              "DSA_WITH_SHA3_384",
+              "DSA_WITH_SHA3_512",
+              "CVC_ECDSA_WITH_SHA1",
+              "CVC_ECDSA_WITH_SHA224",
+              "CVC_ECDSA_WITH_SHA256",
+              "CVC_ECDSA_WITH_SHA384",
+              "CVC_ECDSA_WITH_SHA512",
+              "PLAIN_ECDSA_WITH_SHA1",
+              "PLAIN_ECDSA_WITH_RIPEMD160",
+              "PLAIN_ECDSA_WITH_SHA224",
+              "PLAIN_ECDSA_WITH_SHA256",
+              "PLAIN_ECDSA_WITH_SHA384",
+              "PLAIN_ECDSA_WITH_SHA512",
+              "PLAIN_ECDSA_WITH_SHA3_224",
+              "PLAIN_ECDSA_WITH_SHA3_256",
+              "PLAIN_ECDSA_WITH_SHA3_384",
+              "PLAIN_ECDSA_WITH_SHA3_512",
+              "GOST_R3411_2012_256_WITH_ECGOST_2012_256",
+              "GOST_R3411_2012_512_WITH_ECGOST_2012_512",
+              "SM2_WITH_SHA256",
+              "SM2_WITH_SM3",
+              "SHAKE128_WITH_RSA_PSS",
+              "SHAKE256_WITH_RSA_PSS",
+              "SHAKE128_WITH_ECDSA",
+              "SHAKE256_WITH_ECDSA"
             ],
             "example": "SHA256_WITH_RSA_ENCRYPTION",
             "type": "string"
@@ -9712,7 +9734,21 @@
               "SHA384",
               "SHA512",
               "UNKNOWN",
-              "GOSTR3411_94"
+              "GOSTR3411_94",
+              "SHA3_224",
+              "SHA3_256",
+              "SHA3_384",
+              "SHA3_512",
+              "RIPEMD128",
+              "RIPEMD160",
+              "RIPEMD256",
+              "SHA512_224",
+              "SHA512_256",
+              "SM3",
+              "GOSTR3411_2012_256",
+              "GOSTR3411_2012_512",
+              "SHAKE128",
+              "SHAKE256"
             ],
             "example": "SHA256",
             "type": "string"
@@ -9828,6 +9864,11 @@
             "format": "int32",
             "type": "integer"
           },
+          "tsgId": {
+            "description": "TSG ID of a tenant in NGTS environment",
+            "example": "1234567890",
+            "type": "string"
+          },
           "validityEnd": {
             "description": "The date a certificate validity ends",
             "example": "2023-01-24T09:12:28Z",
@@ -9898,8 +9939,12 @@
               "MACHINE_DISCOVERY",
               "KUBERNETES_DISCOVERY",
               "AWS_DISCOVERY",
+              "AKAMAI_DISCOVERY",
               "AZURE_DISCOVERY",
-              "GCP_DISCOVERY"
+              "GCP_DISCOVERY",
+              "CODESIGN_ISSUANCE",
+              "ACME_ISSUANCE",
+              "SCEP_ISSUANCE"
             ],
             "example": "USER_SCAN",
             "type": "string"
@@ -10016,6 +10061,11 @@
             "description": "SSL validation status message",
             "example": "Certificate installation is using older versions of certificate",
             "type": "string"
+          },
+          "tsgId": {
+            "description": "TSG ID of a tenant in NGTS",
+            "example": "1625722485",
+            "type": "string"
           }
         },
         "type": "object"
@@ -10032,6 +10082,7 @@
               "format": "uuid",
               "type": "string"
             },
+            "minItems": 1,
             "type": "array"
           }
         },
@@ -10054,7 +10105,8 @@
               "ZTPKI",
               "GLOBALSIGNMSSL",
               "TPP",
-              "CONNECTOR"
+              "CONNECTOR",
+              "BUILTIN_GEN2"
             ],
             "type": "string"
           },
@@ -10084,6 +10136,13 @@
           "csrUploadAllowed": {
             "type": "boolean"
           },
+          "customExtendedKeyUsageOidValues": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
+          },
           "description": {
             "type": "string"
           },
@@ -10101,7 +10160,27 @@
             "items": {
               "enum": [
                 "SERVER",
-                "CLIENT"
+                "CLIENT",
+                "CODE_SIGNING",
+                "EMAIL_PROTECTION",
+                "IPSEC_ENDSYSTEM",
+                "IPSEC_TUNNEL",
+                "IPSEC_USER",
+                "TIME_STAMPING",
+                "OCSP_SIGNING",
+                "DVCS",
+                "SBGP_CERT_AA_SERVER",
+                "SCVP_RESPONDER",
+                "EAP_OVER_PPP",
+                "EAP_OVER_LAN",
+                "SCVP_SERVER",
+                "SCVP_CLIENT",
+                "IPSEC_IKE",
+                "CAPWAP_AC",
+                "CAPWAP_WTP",
+                "IPSEC_IKE_INTERMEDIATE",
+                "SMARTCARD_LOGON",
+                "ANY"
               ],
               "type": "string"
             },
@@ -10127,6 +10206,24 @@
               "$ref": "#/components/schemas/KeyTypeInformation"
             },
             "type": "array"
+          },
+          "keyUsageValues": {
+            "items": {
+              "enum": [
+                "digitalSignature",
+                "nonRepudiation",
+                "keyEncipherment",
+                "dataEncipherment",
+                "keyAgreement",
+                "keyCertSign",
+                "cRLSign",
+                "encipherOnly",
+                "decipherOnly"
+              ],
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
           },
           "locationId": {
             "format": "uuid",
@@ -10205,6 +10302,12 @@
             },
             "type": "array"
           },
+          "sanUpnRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "shareWithAll": {
             "type": "boolean"
           },
@@ -10274,7 +10377,8 @@
               "ZTPKI",
               "GLOBALSIGNMSSL",
               "TPP",
-              "CONNECTOR"
+              "CONNECTOR",
+              "BUILTIN_GEN2"
             ],
             "type": "string"
           },
@@ -10291,6 +10395,12 @@
           },
           "csrUploadAllowed": {
             "type": "boolean"
+          },
+          "customExtendedKeyUsageOidValues": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "description": {
             "maxLength": 1024,
@@ -10310,7 +10420,27 @@
             "items": {
               "enum": [
                 "SERVER",
-                "CLIENT"
+                "CLIENT",
+                "CODE_SIGNING",
+                "EMAIL_PROTECTION",
+                "IPSEC_ENDSYSTEM",
+                "IPSEC_TUNNEL",
+                "IPSEC_USER",
+                "TIME_STAMPING",
+                "OCSP_SIGNING",
+                "DVCS",
+                "SBGP_CERT_AA_SERVER",
+                "SCVP_RESPONDER",
+                "EAP_OVER_PPP",
+                "EAP_OVER_LAN",
+                "SCVP_SERVER",
+                "SCVP_CLIENT",
+                "IPSEC_IKE",
+                "CAPWAP_AC",
+                "CAPWAP_WTP",
+                "IPSEC_IKE_INTERMEDIATE",
+                "SMARTCARD_LOGON",
+                "ANY"
               ],
               "type": "string"
             },
@@ -10332,6 +10462,24 @@
               "$ref": "#/components/schemas/KeyTypeParameters1"
             },
             "type": "array"
+          },
+          "keyUsageValues": {
+            "items": {
+              "enum": [
+                "digitalSignature",
+                "nonRepudiation",
+                "keyEncipherment",
+                "dataEncipherment",
+                "keyAgreement",
+                "keyCertSign",
+                "cRLSign",
+                "encipherOnly",
+                "decipherOnly"
+              ],
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": true
           },
           "locationId": {
             "format": "uuid",
@@ -10386,6 +10534,12 @@
             "type": "array"
           },
           "sanUniformResourceIdentifierRegexes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "sanUpnRegexes": {
             "items": {
               "type": "string"
             },
@@ -10491,6 +10645,7 @@
               "format": "uuid",
               "type": "string"
             },
+            "minItems": 1,
             "type": "array"
           }
         },
@@ -10872,7 +11027,7 @@
             "$ref": "#/components/schemas/CustomAttributes2"
           },
           "errorInformation": {
-            "$ref": "#/components/schemas/ErrorInformation4"
+            "$ref": "#/components/schemas/ErrorInformation6"
           },
           "finalApproverId": {
             "description": "UUID of the final approver if configured",
@@ -10924,6 +11079,11 @@
             "format": "date-time",
             "type": "string"
           },
+          "originalCertificateFingerprint": {
+            "description": "The fingerprint of the certificate this request duplicates. Only present when the certificate request was created by duplicating a certificate.",
+            "example": "6D4C95512C117B004191F1A096ECAD13242FCD9F",
+            "type": "string"
+          },
           "status": {
             "description": "The status of the certificate request",
             "enum": [
@@ -10966,6 +11126,11 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "tsgId": {
+            "description": "TSG ID of a tenant in NGTS environment",
+            "example": "1234567890",
+            "type": "string"
           },
           "validityPeriod": {
             "description": "ISO8601 Period Format",
@@ -11289,7 +11454,7 @@
             "$ref": "#/components/schemas/CustomAttributesInformation"
           },
           "errorInformation": {
-            "$ref": "#/components/schemas/ErrorInformation4"
+            "$ref": "#/components/schemas/ErrorInformation6"
           },
           "finalApproverId": {
             "description": "UUID of the final approver if configured",
@@ -11321,6 +11486,12 @@
             "format": "int32",
             "type": "integer"
           },
+          "keyPairId": {
+            "description": "UUID of the key pair used to sign the csr",
+            "example": "ce9c2cc0-9131-11ed-a8f1-bf0e7991f912",
+            "format": "uuid",
+            "type": "string"
+          },
           "keyType": {
             "description": "Certificate request key type",
             "enum": [
@@ -11339,6 +11510,11 @@
             "description": "The date a certificate request was modified",
             "example": "2023-01-11T09:12:28Z",
             "format": "date-time",
+            "type": "string"
+          },
+          "originalCertificateFingerprint": {
+            "description": "The fingerprint of the certificate this request duplicates. Only present when the certificate request was created by duplicating a certificate.",
+            "example": "6D4C95512C117B004191F1A096ECAD13242FCD9F",
             "type": "string"
           },
           "status": {
@@ -11380,6 +11556,11 @@
             "type": "array",
             "uniqueItems": true
           },
+          "tsgId": {
+            "description": "TSG ID of a tenant in NGTS environment",
+            "example": "1234567890",
+            "type": "string"
+          },
           "validityPeriod": {
             "description": "ISO8601 Period Format",
             "example": "P10M",
@@ -11406,13 +11587,14 @@
             "type": "string"
           },
           "certificateOwnerUserId": {
-            "description": "Certificate owner UUID",
+            "deprecated": true,
+            "description": "Certificate owner UUID. Deprecated. Certificate Owner is the User that triggers the issuance",
             "example": "a305d810-886f-11ed-9ccf-0dbf748eb1ae",
             "format": "uuid",
             "type": "string"
           },
           "certificateSigningRequest": {
-            "description": "A certificate signing request(CSR) in PEM format. Required when reuseCSR and isVaaSGenerated are set to false.",
+            "description": "A certificate signing request(CSR) in PEM format when client is expected to provide the CSR bytes. Required when submitting regular certificate signing request i.e. isVaaSGenerated is set to false. Required when renewing a certificate i.e. renewType is set to USER_PROVIDED_CSR.",
             "type": "string"
           },
           "certificateUsageMetadata": {
@@ -11440,8 +11622,13 @@
           "customAttributes": {
             "$ref": "#/components/schemas/CustomAttributesInformation"
           },
+          "existingCertificateFingerprint": {
+            "description": "Fingerprint of an existing inventory certificate to renew, as an alternative to existingCertificateId. Mutually exclusive with existingCertificateId. If the fingerprint does not match a certificate in inventory, the request proceeds as a new certificate issuance rather than a renewal.",
+            "example": "6D4C95512C117B004191F1A096ECAD13242FCD9F",
+            "type": "string"
+          },
           "existingCertificateId": {
-            "description": "Existing certificate UUID. Required when reuseCSR is set to true.",
+            "description": "Existing certificate UUID. Required when renewType is set to CLONED_CSR_WITH_NEW_PRIVATE_KEY or REUSE_CSR.",
             "example": "b505d810-886f-11ed-9ccf-0dbf748eb1ae",
             "format": "uuid",
             "type": "string"
@@ -11451,8 +11638,31 @@
             "example": true,
             "type": "boolean"
           },
+          "keyPairId": {
+            "description": "Key pair UUID",
+            "example": "a305d810-886f-11ed-9ccf-0dbf748eb1ae",
+            "format": "uuid",
+            "type": "string"
+          },
+          "locationId": {
+            "description": "Location UUID",
+            "example": "a305d810-886f-11ed-9ccf-0dbf748eb1ae",
+            "format": "uuid",
+            "type": "string"
+          },
+          "renewType": {
+            "description": "Specifies how we obtain CSR and Private Key on cert renewal. Not applicable in other cases. When used the reuseCSR param is not read",
+            "enum": [
+              "USER_PROVIDED_CSR",
+              "SYSTEM_GENERATED_CSR",
+              "REUSE_CSR",
+              "CLONED_CSR_WITH_NEW_PRIVATE_KEY"
+            ],
+            "example": "USER_PROVIDED_CSR(User is providing CSR to use); SYSTEM_GENERATED_CSR(System will generate new CSR and Private Key); CLONED_CSR_WITH_NEW_PRIVATE_KEY(System will generate new CSR and Private Key using attributes from current CSR)",
+            "type": "string"
+          },
           "reuseCSR": {
-            "description": "Specifies whether an existing CSR is reused",
+            "description": "Specifies whether an existing CSR is reused; Deprecated in favor of renewType",
             "example": true,
             "type": "boolean"
           },
@@ -11475,8 +11685,6 @@
           }
         },
         "required": [
-          "applicationId",
-          "certificateIssuingTemplateId",
           "isVaaSGenerated"
         ],
         "type": "object"
@@ -11549,6 +11757,9 @@
       },
       "CertificateRequestResubmissionRequest": {
         "properties": {
+          "apiClientInformation": {
+            "$ref": "#/components/schemas/ApiClientInformation"
+          },
           "certificateIssuingTemplateId": {
             "description": "Certificate issuing template UUID",
             "example": "a305d810-886f-11ed-9ccf-dbf748eb1ae0",
@@ -11556,7 +11767,8 @@
             "type": "string"
           },
           "certificateOwnerUserId": {
-            "description": "Certificate owner UUID",
+            "deprecated": true,
+            "description": "Certificate owner UUID. Deprecated. Certificate Owner is the User that triggers the issuance",
             "example": "a305d810-886f-11ed-4bbe-dbf748eb1ae0",
             "format": "uuid",
             "type": "string"
@@ -11623,6 +11835,7 @@
               "format": "uuid",
               "type": "string"
             },
+            "minItems": 1,
             "type": "array"
           }
         },
@@ -11924,6 +12137,7 @@
               "format": "uuid",
               "type": "string"
             },
+            "minItems": 1,
             "type": "array"
           }
         },
@@ -11961,7 +12175,21 @@
               "SHA384",
               "SHA512",
               "UNKNOWN",
-              "GOSTR3411_94"
+              "GOSTR3411_94",
+              "SHA3_224",
+              "SHA3_256",
+              "SHA3_384",
+              "SHA3_512",
+              "RIPEMD128",
+              "RIPEMD160",
+              "RIPEMD256",
+              "SHA512_224",
+              "SHA512_256",
+              "SM3",
+              "GOSTR3411_2012_256",
+              "GOSTR3411_2012_512",
+              "SHAKE128",
+              "SHAKE256"
             ],
             "example": "SHA256",
             "type": "string"
@@ -12023,7 +12251,64 @@
               "UNKNOWN",
               "SHA1_WITH_RSAandMGF1",
               "GOST_R3411_94_WITH_GOST_R3410_2001",
-              "GOST_R3411_94_WITH_GOST_R3410_94"
+              "GOST_R3411_94_WITH_GOST_R3410_94",
+              "SHA256_WITH_RSAandMGF1",
+              "SHA384_WITH_RSAandMGF1",
+              "SHA512_WITH_RSAandMGF1",
+              "SHA224_WITH_RSAandMGF1",
+              "SHA224_WITH_RSA_ENCRYPTION",
+              "DSA_WITH_SHA224",
+              "DSA_WITH_SHA256",
+              "DSA_WITH_SHA384",
+              "DSA_WITH_SHA512",
+              "ED25519",
+              "ED448",
+              "EC_DSA_WITH_SHA3_224",
+              "EC_DSA_WITH_SHA3_256",
+              "EC_DSA_WITH_SHA3_384",
+              "EC_DSA_WITH_SHA3_512",
+              "SHA3_224_WITH_RSA_ENCRYPTION",
+              "SHA3_256_WITH_RSA_ENCRYPTION",
+              "SHA3_384_WITH_RSA_ENCRYPTION",
+              "SHA3_512_WITH_RSA_ENCRYPTION",
+              "EC_GDSA_WITH_SHA1",
+              "EC_GDSA_WITH_RIPEMD160",
+              "RSA_WITH_RIPEMD128",
+              "RSA_WITH_RIPEMD160",
+              "RSA_WITH_RIPEMD256",
+              "SHA3_224_WITH_RSAandMGF1",
+              "SHA3_256_WITH_RSAandMGF1",
+              "SHA3_384_WITH_RSAandMGF1",
+              "SHA3_512_WITH_RSAandMGF1",
+              "SHA512_224_WITH_RSA_ENCRYPTION",
+              "SHA512_256_WITH_RSA_ENCRYPTION",
+              "DSA_WITH_SHA3_224",
+              "DSA_WITH_SHA3_256",
+              "DSA_WITH_SHA3_384",
+              "DSA_WITH_SHA3_512",
+              "CVC_ECDSA_WITH_SHA1",
+              "CVC_ECDSA_WITH_SHA224",
+              "CVC_ECDSA_WITH_SHA256",
+              "CVC_ECDSA_WITH_SHA384",
+              "CVC_ECDSA_WITH_SHA512",
+              "PLAIN_ECDSA_WITH_SHA1",
+              "PLAIN_ECDSA_WITH_RIPEMD160",
+              "PLAIN_ECDSA_WITH_SHA224",
+              "PLAIN_ECDSA_WITH_SHA256",
+              "PLAIN_ECDSA_WITH_SHA384",
+              "PLAIN_ECDSA_WITH_SHA512",
+              "PLAIN_ECDSA_WITH_SHA3_224",
+              "PLAIN_ECDSA_WITH_SHA3_256",
+              "PLAIN_ECDSA_WITH_SHA3_384",
+              "PLAIN_ECDSA_WITH_SHA3_512",
+              "GOST_R3411_2012_256_WITH_ECGOST_2012_256",
+              "GOST_R3411_2012_512_WITH_ECGOST_2012_512",
+              "SM2_WITH_SHA256",
+              "SM2_WITH_SM3",
+              "SHAKE128_WITH_RSA_PSS",
+              "SHAKE256_WITH_RSA_PSS",
+              "SHAKE128_WITH_ECDSA",
+              "SHAKE256_WITH_ECDSA"
             ],
             "example": "SHA256_WITH_RSA_ENCRYPTION",
             "type": "string"
@@ -12056,19 +12341,24 @@
         },
         "type": "object"
       },
-      "ClientAuthenticationInformation": {
+      "ClientAuthentication": {
         "discriminator": {
+          "mapping": {
+            "JWT_JWKS": "#/components/schemas/JWTJWKSAuthentication",
+            "JWT_OIDC": "#/components/schemas/JWTOIDCAuthentication",
+            "JWT_STANDARD_CLAIMS": "#/components/schemas/JWTStandardClaimsAuthentication"
+          },
           "propertyName": "type"
         },
         "oneOf": [
           {
-            "$ref": "#/components/schemas/JwtStandardClaimsAuthenticationInformation"
+            "$ref": "#/components/schemas/JWTStandardClaimsAuthentication"
           },
           {
-            "$ref": "#/components/schemas/JwtJwksAuthenticationInformation"
+            "$ref": "#/components/schemas/JWTJWKSAuthentication"
           },
           {
-            "$ref": "#/components/schemas/JwtOidcAuthenticationInformation"
+            "$ref": "#/components/schemas/JWTOIDCAuthentication"
           }
         ],
         "properties": {
@@ -12081,59 +12371,24 @@
         ],
         "type": "object"
       },
-      "ClientAuthenticationOpenApi": {
-        "discriminator": {
-          "mapping": {
-            "JWT_JWKS": "#/components/schemas/JwtJwksAuthenticationOpenApi",
-            "JWT_OIDC": "#/components/schemas/JwtOidcAuthenticationOpenApi",
-            "JWT_STANDARD_CLAIMS": "#/components/schemas/JwtStandardClaimsAuthenticationOpenApi"
-          },
-          "propertyName": "type"
-        },
-        "properties": {
-          "type": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "ClientAuthenticationRequestOpenApi": {
-        "properties": {
-          "clientAuthentication": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/JwtStandardClaimsAuthenticationOpenApi"
-              },
-              {
-                "$ref": "#/components/schemas/JwtJwksAuthenticationOpenApi"
-              },
-              {
-                "$ref": "#/components/schemas/JwtOidcAuthenticationOpenApi"
-              }
-            ],
-            "type": "object"
-          }
-        },
-        "type": "object"
-      },
-      "ClientAuthorizationInformation": {
+      "ClientAuthorization": {
         "properties": {
           "customClaimsAliases": {
-            "$ref": "#/components/schemas/CustomClaimsAliasesInformation"
+            "$ref": "#/components/schemas/CustomClaimsAliases"
           }
         },
         "type": "object"
       },
-      "CloudProvidersInformation": {
+      "CloudProviders": {
         "properties": {
           "aws": {
-            "$ref": "#/components/schemas/AwsCloudProviderInformation"
+            "$ref": "#/components/schemas/AWSCloudProvider"
           },
           "azure": {
-            "$ref": "#/components/schemas/AzureCloudProviderInformation"
+            "$ref": "#/components/schemas/AzureCloudProvider"
           },
           "google": {
-            "$ref": "#/components/schemas/GoogleCloudProviderInformation"
+            "$ref": "#/components/schemas/GoogleCloudProvider"
           }
         },
         "type": "object"
@@ -12187,66 +12442,19 @@
         "type": "object"
       },
       "ConfigurationCreateRequest": {
-        "properties": {
-          "advancedSettings": {
-            "$ref": "#/components/schemas/AdvancedSettingsInformation"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ConfigurationUpdateRequest"
           },
-          "clientAuthentication": {
-            "$ref": "#/components/schemas/ClientAuthenticationInformation"
-          },
-          "clientAuthorization": {
-            "$ref": "#/components/schemas/ClientAuthorizationInformation"
-          },
-          "cloudProviders": {
-            "$ref": "#/components/schemas/CloudProvidersInformation"
-          },
-          "minTlsVersion": {
-            "description": "Minimum required TLS protocol version",
-            "enum": [
-              "TLS12",
-              "TLS13"
+          {
+            "required": [
+              "name",
+              "policyIds",
+              "subCaProviderId"
             ],
-            "type": "string"
-          },
-          "name": {
-            "description": "Name of the configuration",
-            "example": "Some configuration",
-            "maxLength": 64,
-            "type": "string"
-          },
-          "policyIds": {
-            "description": "Array of UUIDs of policies to associate with the new configuration",
-            "example": [
-              "8ae92800-b1e0-11ed-859d-b39255f965ee"
-            ],
-            "format": "uuid",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "minItems": 1,
-            "type": "array"
-          },
-          "serviceAccountIds": {
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "subCaProviderId": {
-            "description": "UUID of Sub CA provider to associate with the new configuration",
-            "example": "2f3c6030-b1e0-11ed-a3ed-e3dbaf56a746",
-            "format": "uuid",
-            "type": "string"
+            "type": "object"
           }
-        },
-        "required": [
-          "name",
-          "policyIds",
-          "subCaProviderId"
-        ],
-        "type": "object"
+        ]
       },
       "ConfigurationDeleteResponse": {
         "properties": {
@@ -12264,41 +12472,33 @@
         },
         "type": "object"
       },
-      "ConfigurationInformation": {
+      "ConfigurationGetResponse": {
+        "discriminator": {
+          "mapping": {
+            "DISTRIBUTED_ISSUER": "#/components/schemas/DistributedIssuerConfigurationGetResponse",
+            "FORWARD_TRUST_PROXY": "#/components/schemas/ForwardTrustProxyConfigurationGetResponse"
+          },
+          "propertyName": "issuerKind"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DistributedIssuerConfigurationGetResponse"
+          },
+          {
+            "$ref": "#/components/schemas/ForwardTrustProxyConfigurationGetResponse"
+          }
+        ],
         "properties": {
-          "advancedSettings": {
-            "$ref": "#/components/schemas/AdvancedSettingsInformation"
-          },
-          "clientAuthentication": {
-            "$ref": "#/components/schemas/ClientAuthenticationInformation"
-          },
-          "clientAuthorization": {
-            "$ref": "#/components/schemas/ClientAuthorizationInformation"
-          },
-          "cloudProviders": {
-            "$ref": "#/components/schemas/CloudProvidersInformation"
-          },
           "companyId": {
             "description": "UUID specific to your company",
             "example": "03eb6e61-9806-11ed-84f2-c747fb71e467",
             "format": "uuid",
             "type": "string"
           },
-          "controllerAllowedPolicyIds": {
-            "description": "Array of UUIDs of policies that the kubernetes controller is permitted to use",
-            "example": [
-              "8ae92800-b1e0-11ed-859d-b39255f965ee"
-            ],
-            "format": "uuid",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
-          },
           "creationDate": {
             "description": "When the configuration was initially created",
-            "example": "2022-10-10T14:50:41.710+00:00",
+            "example": "2022-10-10T14:50:41.71Z",
+            "format": "date-time",
             "type": "string"
           },
           "id": {
@@ -12307,23 +12507,18 @@
             "format": "uuid",
             "type": "string"
           },
-          "longLivedCertCount": {
-            "description": "Number of long lived certificates",
-            "example": 2,
-            "format": "int64",
-            "type": "integer"
-          },
-          "minTlsVersion": {
-            "description": "Minimum required TLS protocol version",
+          "issuerKind": {
+            "description": "The kind of issuer this configuration represents",
             "enum": [
-              "TLS12",
-              "TLS13"
+              "DISTRIBUTED_ISSUER",
+              "FORWARD_TRUST_PROXY"
             ],
             "type": "string"
           },
           "modificationDate": {
             "description": "When the configuration was last modified",
-            "example": "2023-12-12T20:00:10.500+00:00",
+            "example": "2023-12-12T20:00:10.5Z",
+            "format": "date-time",
             "type": "string"
           },
           "name": {
@@ -12331,62 +12526,22 @@
             "example": "Some configuration",
             "type": "string"
           },
-          "policyIds": {
-            "description": "Array of UUIDs of policies to associate with the configuration",
-            "example": [
-              "8ae92800-b1e0-11ed-859d-b39255f965ee"
-            ],
-            "format": "uuid",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "serviceAccountIds": {
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "shortLivedCertCount": {
-            "description": "Number of short lived certificates",
-            "example": 20,
-            "format": "int64",
-            "type": "integer"
-          },
           "subTsgId": {
             "description": "Sub-TSG ID that owns this configuration (null for Primary TSG)",
             "example": "a007d406bf",
             "type": "string"
-          },
-          "ultraShortLivedCertCount": {
-            "description": "Number of ultra short lived certificates",
-            "example": 200,
-            "format": "int64",
-            "type": "integer"
-          },
-          "unixSocketAllowedPolicyIds": {
-            "description": "Array of UUIDs of policies that are permitted to be used when using the unix socket",
-            "example": [
-              "8ae92800-b1e0-11ed-859d-b39255f965ee"
-            ],
-            "format": "uuid",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
           }
         },
+        "required": [
+          "issuerKind"
+        ],
         "type": "object"
       },
-      "ConfigurationResponse": {
+      "ConfigurationListResponse": {
         "properties": {
           "configurations": {
             "items": {
-              "$ref": "#/components/schemas/ExtendedConfigurationInformation"
+              "$ref": "#/components/schemas/ExtendedConfigurationGetResponse"
             },
             "type": "array"
           }
@@ -12396,24 +12551,19 @@
       "ConfigurationUpdateRequest": {
         "properties": {
           "advancedSettings": {
-            "$ref": "#/components/schemas/AdvancedSettingsInformation"
+            "$ref": "#/components/schemas/AdvancedSettings"
           },
           "clientAuthentication": {
-            "$ref": "#/components/schemas/ClientAuthenticationRequestOpenApi"
+            "$ref": "#/components/schemas/ClientAuthentication"
           },
           "clientAuthorization": {
-            "$ref": "#/components/schemas/ClientAuthorizationInformation"
+            "$ref": "#/components/schemas/ClientAuthorization"
           },
           "cloudProviders": {
-            "$ref": "#/components/schemas/CloudProvidersInformation"
+            "$ref": "#/components/schemas/CloudProviders"
           },
           "minTlsVersion": {
-            "description": "Minimum required TLS protocol version",
-            "enum": [
-              "TLS12",
-              "TLS13"
-            ],
-            "type": "string"
+            "$ref": "#/components/schemas/MinTLSVersion"
           },
           "name": {
             "description": "Name of the configuration",
@@ -12426,11 +12576,11 @@
             "example": [
               "8ae92800-b1e0-11ed-859d-b39255f965ee"
             ],
-            "format": "uuid",
             "items": {
               "format": "uuid",
               "type": "string"
             },
+            "minItems": 1,
             "type": "array"
           },
           "serviceAccountIds": {
@@ -12752,6 +12902,7 @@
             "items": {
               "type": "string"
             },
+            "minItems": 1,
             "type": "array",
             "uniqueItems": true
           },
@@ -12765,7 +12916,7 @@
         ],
         "type": "object"
       },
-      "CustomClaimsAliasesInformation": {
+      "CustomClaimsAliases": {
         "properties": {
           "allowAllPolicies": {
             "maxLength": 128,
@@ -12971,6 +13122,100 @@
         ],
         "example": "DESC",
         "type": "string"
+      },
+      "DistributedIssuerConfigurationGetResponse": {
+        "properties": {
+          "advancedSettings": {
+            "$ref": "#/components/schemas/AdvancedSettings"
+          },
+          "clientAuthentication": {
+            "$ref": "#/components/schemas/ClientAuthentication"
+          },
+          "clientAuthorization": {
+            "$ref": "#/components/schemas/ClientAuthorization"
+          },
+          "cloudProviders": {
+            "$ref": "#/components/schemas/CloudProviders"
+          },
+          "controllerAllowedPolicyIds": {
+            "description": "Array of UUIDs of policies that the kubernetes controller is permitted to use",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "issuerKind": {
+            "description": "The kind of issuer this configuration represents",
+            "enum": [
+              "DISTRIBUTED_ISSUER"
+            ],
+            "type": "string"
+          },
+          "longLivedCertCount": {
+            "description": "Number of long lived certificates",
+            "example": 2,
+            "format": "int64",
+            "type": "integer"
+          },
+          "minTlsVersion": {
+            "$ref": "#/components/schemas/MinTLSVersion"
+          },
+          "policyIds": {
+            "description": "Array of UUIDs of policies to associate with the configuration",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "serviceAccountIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "shortLivedCertCount": {
+            "description": "Number of short lived certificates",
+            "example": 20,
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalCertCount": {
+            "description": "Total number of certificates — the sum of `longLivedCertCount`, `shortLivedCertCount` and `ultraShortLivedCertCount`. Derived, read-only.",
+            "example": 222,
+            "format": "int64",
+            "type": "integer"
+          },
+          "ultraShortLivedCertCount": {
+            "description": "Number of ultra short lived certificates",
+            "example": 200,
+            "format": "int64",
+            "type": "integer"
+          },
+          "unixSocketAllowedPolicyIds": {
+            "description": "Array of UUIDs of policies that are permitted to be used when using the unix socket",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "issuerKind"
+        ],
+        "type": "object"
       },
       "EdgeInstanceConnectionDetails": {
         "properties": {
@@ -13404,7 +13649,7 @@
             "type": "string"
           },
           "keyAlgorithm": {
-            "$ref": "#/components/schemas/KeyAlgorithm"
+            "$ref": "#/components/schemas/KeyAlgorithm1"
           },
           "lastBackupDate": {
             "format": "date-time",
@@ -13435,7 +13680,7 @@
         },
         "type": "object"
       },
-      "Error": {
+      "Error1": {
         "description": "Hold the error details.",
         "properties": {
           "args": {
@@ -13458,6 +13703,28 @@
           "code",
           "message"
         ],
+        "type": "object"
+      },
+      "Error2": {
+        "description": "A single error. The numeric `code` is stable and matches the codes listed at the start of each cause in the endpoints' error-response descriptions, so clients can branch on it instead of parsing `message`.",
+        "properties": {
+          "args": {
+            "description": "Positional values interpolated into the message (e.g. the offending field value or entity id).",
+            "items": {
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "code": {
+            "description": "Stable numeric error code identifying the specific failure.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "message": {
+            "description": "Human-readable description of the error.",
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "ErrorInformation1": {
@@ -13604,24 +13871,6 @@
         },
         "type": "object"
       },
-      "ErrorInformation9": {
-        "properties": {
-          "args": {
-            "items": {
-              "$ref": "#/components/schemas/AnyValue9"
-            },
-            "type": "array"
-          },
-          "code": {
-            "format": "int32",
-            "type": "integer"
-          },
-          "message": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
       "ErrorResponse1": {
         "properties": {
           "errors": {
@@ -13634,12 +13883,10 @@
         "type": "object"
       },
       "ErrorResponse10": {
-        "description": "Holds the response body returned for errors.",
         "properties": {
           "errors": {
-            "description": "List of encountered errors.",
             "items": {
-              "$ref": "#/components/schemas/Error"
+              "$ref": "#/components/schemas/Error2"
             },
             "type": "array"
           }
@@ -13680,10 +13927,12 @@
         "type": "object"
       },
       "ErrorResponse5": {
+        "description": "Holds the response body returned for errors.",
         "properties": {
           "errors": {
+            "description": "List of encountered errors.",
             "items": {
-              "$ref": "#/components/schemas/ErrorInformation5"
+              "$ref": "#/components/schemas/Error1"
             },
             "type": "array"
           }
@@ -13694,7 +13943,7 @@
         "properties": {
           "errors": {
             "items": {
-              "$ref": "#/components/schemas/ErrorInformation6"
+              "$ref": "#/components/schemas/ErrorInformation5"
             },
             "type": "array"
           }
@@ -13705,7 +13954,7 @@
         "properties": {
           "errors": {
             "items": {
-              "$ref": "#/components/schemas/ErrorInformation7"
+              "$ref": "#/components/schemas/ErrorInformation6"
             },
             "type": "array"
           }
@@ -13716,7 +13965,7 @@
         "properties": {
           "errors": {
             "items": {
-              "$ref": "#/components/schemas/ErrorInformation8"
+              "$ref": "#/components/schemas/ErrorInformation7"
             },
             "type": "array"
           }
@@ -13727,7 +13976,7 @@
         "properties": {
           "errors": {
             "items": {
-              "$ref": "#/components/schemas/ErrorInformation9"
+              "$ref": "#/components/schemas/ErrorInformation8"
             },
             "type": "array"
           }
@@ -13778,32 +14027,50 @@
         },
         "type": "object"
       },
-      "Expression": {
-        "type": "object"
-      },
       "ExpressionNode": {
+        "description": "A node in the recursive search filter tree. A compound node uses an AND/OR `operator` and nests child nodes in `operands`; a leaf node uses a comparison `operator` on a `field` with `value` or `values`.",
         "properties": {
-          "compound": {
-            "type": "boolean"
-          },
           "field": {
+            "description": "The field a leaf operator targets. One of: id, name, configuration, issuerKind, validity, validFrom, longLivedCertCount, shortLivedCertCount, ultraShortLivedCertCount, totalCertCount, tsgID.",
+            "example": "name",
             "type": "string"
           },
           "operands": {
+            "description": "Child nodes combined by a compound (AND/OR) operator.",
             "items": {
               "$ref": "#/components/schemas/ExpressionNode"
             },
             "type": "array"
           },
           "operator": {
+            "description": "The filter operator. AND/OR are compound operators that combine `operands`; the rest are leaf comparisons on a `field`. Matching is case-insensitive.",
+            "enum": [
+              "AND",
+              "OR",
+              "EQ",
+              "NOT_EQ",
+              "CONTAINS",
+              "NOT_CONTAINS",
+              "STARTS_WITH",
+              "ENDS_WITH",
+              "IS_EMPTY",
+              "IS_NOT_EMPTY",
+              "IS_ANY_OF",
+              "GT",
+              "GTE",
+              "LT",
+              "LTE"
+            ],
+            "example": "EQ",
             "type": "string"
           },
           "value": {
-            "type": "string"
+            "$ref": "#/components/schemas/SearchOperand"
           },
           "values": {
+            "description": "Operands for a multi-value operator (IS_ANY_OF), or an alternative to `value`.",
             "items": {
-              "type": "string"
+              "$ref": "#/components/schemas/SearchOperand"
             },
             "type": "array"
           }
@@ -14156,7 +14423,64 @@
               "UNKNOWN",
               "SHA1_WITH_RSAandMGF1",
               "GOST_R3411_94_WITH_GOST_R3410_2001",
-              "GOST_R3411_94_WITH_GOST_R3410_94"
+              "GOST_R3411_94_WITH_GOST_R3410_94",
+              "SHA256_WITH_RSAandMGF1",
+              "SHA384_WITH_RSAandMGF1",
+              "SHA512_WITH_RSAandMGF1",
+              "SHA224_WITH_RSAandMGF1",
+              "SHA224_WITH_RSA_ENCRYPTION",
+              "DSA_WITH_SHA224",
+              "DSA_WITH_SHA256",
+              "DSA_WITH_SHA384",
+              "DSA_WITH_SHA512",
+              "ED25519",
+              "ED448",
+              "EC_DSA_WITH_SHA3_224",
+              "EC_DSA_WITH_SHA3_256",
+              "EC_DSA_WITH_SHA3_384",
+              "EC_DSA_WITH_SHA3_512",
+              "SHA3_224_WITH_RSA_ENCRYPTION",
+              "SHA3_256_WITH_RSA_ENCRYPTION",
+              "SHA3_384_WITH_RSA_ENCRYPTION",
+              "SHA3_512_WITH_RSA_ENCRYPTION",
+              "EC_GDSA_WITH_SHA1",
+              "EC_GDSA_WITH_RIPEMD160",
+              "RSA_WITH_RIPEMD128",
+              "RSA_WITH_RIPEMD160",
+              "RSA_WITH_RIPEMD256",
+              "SHA3_224_WITH_RSAandMGF1",
+              "SHA3_256_WITH_RSAandMGF1",
+              "SHA3_384_WITH_RSAandMGF1",
+              "SHA3_512_WITH_RSAandMGF1",
+              "SHA512_224_WITH_RSA_ENCRYPTION",
+              "SHA512_256_WITH_RSA_ENCRYPTION",
+              "DSA_WITH_SHA3_224",
+              "DSA_WITH_SHA3_256",
+              "DSA_WITH_SHA3_384",
+              "DSA_WITH_SHA3_512",
+              "CVC_ECDSA_WITH_SHA1",
+              "CVC_ECDSA_WITH_SHA224",
+              "CVC_ECDSA_WITH_SHA256",
+              "CVC_ECDSA_WITH_SHA384",
+              "CVC_ECDSA_WITH_SHA512",
+              "PLAIN_ECDSA_WITH_SHA1",
+              "PLAIN_ECDSA_WITH_RIPEMD160",
+              "PLAIN_ECDSA_WITH_SHA224",
+              "PLAIN_ECDSA_WITH_SHA256",
+              "PLAIN_ECDSA_WITH_SHA384",
+              "PLAIN_ECDSA_WITH_SHA512",
+              "PLAIN_ECDSA_WITH_SHA3_224",
+              "PLAIN_ECDSA_WITH_SHA3_256",
+              "PLAIN_ECDSA_WITH_SHA3_384",
+              "PLAIN_ECDSA_WITH_SHA3_512",
+              "GOST_R3411_2012_256_WITH_ECGOST_2012_256",
+              "GOST_R3411_2012_512_WITH_ECGOST_2012_512",
+              "SM2_WITH_SHA256",
+              "SM2_WITH_SM3",
+              "SHAKE128_WITH_RSA_PSS",
+              "SHAKE256_WITH_RSA_PSS",
+              "SHAKE128_WITH_ECDSA",
+              "SHAKE256_WITH_ECDSA"
             ],
             "example": "SHA256_WITH_RSA_ENCRYPTION",
             "type": "string"
@@ -14172,7 +14496,21 @@
               "SHA384",
               "SHA512",
               "UNKNOWN",
-              "GOSTR3411_94"
+              "GOSTR3411_94",
+              "SHA3_224",
+              "SHA3_256",
+              "SHA3_384",
+              "SHA3_512",
+              "RIPEMD128",
+              "RIPEMD160",
+              "RIPEMD256",
+              "SHA512_224",
+              "SHA512_256",
+              "SM3",
+              "GOSTR3411_2012_256",
+              "GOSTR3411_2012_512",
+              "SHAKE128",
+              "SHAKE256"
             ],
             "example": "SHA256",
             "type": "string"
@@ -14288,6 +14626,11 @@
             "format": "int32",
             "type": "integer"
           },
+          "tsgId": {
+            "description": "TSG ID of a tenant in NGTS environment",
+            "example": "1234567890",
+            "type": "string"
+          },
           "validityEnd": {
             "description": "The date a certificate validity ends",
             "example": "2023-01-24T09:12:28Z",
@@ -14361,8 +14704,12 @@
               "MACHINE_DISCOVERY",
               "KUBERNETES_DISCOVERY",
               "AWS_DISCOVERY",
+              "AKAMAI_DISCOVERY",
               "AZURE_DISCOVERY",
-              "GCP_DISCOVERY"
+              "GCP_DISCOVERY",
+              "CODESIGN_ISSUANCE",
+              "ACME_ISSUANCE",
+              "SCEP_ISSUANCE"
             ],
             "example": "USER_SCAN",
             "type": "string"
@@ -14479,6 +14826,11 @@
             "description": "SSL validation status message",
             "example": "Certificate installation is using older versions of certificate",
             "type": "string"
+          },
+          "tsgId": {
+            "description": "TSG ID of a tenant in NGTS",
+            "example": "1625722485",
+            "type": "string"
           }
         },
         "type": "object"
@@ -14498,267 +14850,86 @@
         },
         "type": "object"
       },
-      "ExtendedConfigurationInformation": {
-        "properties": {
-          "advancedSettings": {
-            "$ref": "#/components/schemas/AdvancedSettingsInformation"
+      "ExtendedConfigurationGetResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ConfigurationGetResponse"
           },
-          "clientAuthentication": {
-            "$ref": "#/components/schemas/ClientAuthenticationInformation"
-          },
-          "clientAuthorization": {
-            "$ref": "#/components/schemas/ClientAuthorizationInformation"
-          },
-          "cloudProviders": {
-            "$ref": "#/components/schemas/CloudProvidersInformation"
-          },
-          "companyId": {
-            "description": "UUID specific to your company",
-            "example": "03eb6e61-9806-11ed-84f2-c747fb71e467",
-            "format": "uuid",
-            "type": "string"
-          },
-          "controllerAllowedPolicyIds": {
-            "description": "Array of UUIDs of policies that the kubernetes controller is permitted to use",
-            "example": [
-              "8ae92800-b1e0-11ed-859d-b39255f965ee"
-            ],
-            "format": "uuid",
-            "items": {
-              "format": "uuid",
-              "type": "string"
+          {
+            "properties": {
+              "policies": {
+                "description": "The subset of `policyDefinitions` whose id also appears in `policyIds` — i.e. the policies the configuration itself considers active, excluding those referenced only by a JWT client's `allowedPolicyIds`.",
+                "items": {
+                  "$ref": "#/components/schemas/PolicyGetResponse"
+                },
+                "type": "array"
+              },
+              "policyDefinitions": {
+                "description": "Every policy this configuration references — the union of `policyIds` and every JWT_STANDARD_CLAIMS client's per-client `allowedPolicyIds`. Equal to `policies` when no JWT client grants a policy outside `policyIds`; otherwise a strict superset.",
+                "items": {
+                  "$ref": "#/components/schemas/PolicyGetResponse"
+                },
+                "type": "array"
+              },
+              "subCaProvider": {
+                "$ref": "#/components/schemas/SubCAProviderGetResponse"
+              }
             },
-            "type": "array"
-          },
-          "creationDate": {
-            "description": "When the configuration was initially created",
-            "example": "2022-10-10T14:50:41.710+00:00",
-            "type": "string"
-          },
-          "id": {
-            "description": "UUID of the configuration",
-            "example": "7268d820-a08d-11ed-bbc0-252385d6d389",
-            "format": "uuid",
-            "type": "string"
-          },
-          "longLivedCertCount": {
-            "description": "Number of long lived certificates",
-            "example": 2,
-            "format": "int64",
-            "type": "integer"
-          },
-          "minTlsVersion": {
-            "description": "Minimum required TLS protocol version",
-            "enum": [
-              "TLS12",
-              "TLS13"
-            ],
-            "type": "string"
-          },
-          "modificationDate": {
-            "description": "When the configuration was last modified",
-            "example": "2023-12-12T20:00:10.500+00:00",
-            "type": "string"
-          },
-          "name": {
-            "description": "Name of the configuration",
-            "example": "Some configuration",
-            "type": "string"
-          },
-          "policies": {
-            "items": {
-              "$ref": "#/components/schemas/PolicyInformation"
-            },
-            "type": "array"
-          },
-          "policyDefinitions": {
-            "items": {
-              "$ref": "#/components/schemas/PolicyInformation"
-            },
-            "type": "array"
-          },
-          "policyIds": {
-            "description": "Array of UUIDs of policies to associate with the configuration",
-            "example": [
-              "8ae92800-b1e0-11ed-859d-b39255f965ee"
-            ],
-            "format": "uuid",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "serviceAccountIds": {
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "shortLivedCertCount": {
-            "description": "Number of short lived certificates",
-            "example": 20,
-            "format": "int64",
-            "type": "integer"
-          },
-          "subCaProvider": {
-            "$ref": "#/components/schemas/SubCaProviderInformation"
-          },
-          "subTsgId": {
-            "description": "Sub-TSG ID that owns this configuration (null for Primary TSG)",
-            "example": "a007d406bf",
-            "type": "string"
-          },
-          "ultraShortLivedCertCount": {
-            "description": "Number of ultra short lived certificates",
-            "example": 200,
-            "format": "int64",
-            "type": "integer"
-          },
-          "unixSocketAllowedPolicyIds": {
-            "description": "Array of UUIDs of policies that are permitted to be used when using the unix socket",
-            "example": [
-              "8ae92800-b1e0-11ed-859d-b39255f965ee"
-            ],
-            "format": "uuid",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
+            "type": "object"
           }
-        },
-        "type": "object"
+        ]
       },
-      "ExtendedPolicyInformation": {
-        "properties": {
-          "companyId": {
-            "description": "UUID specific to your company",
-            "example": "03eb6e61-9806-11ed-84f2-c747fb71e467",
-            "format": "uuid",
-            "type": "string"
+      "ExtendedKeyUsage": {
+        "description": "Extended key usage",
+        "enum": [
+          "ANY",
+          "SERVER_AUTH",
+          "CLIENT_AUTH",
+          "CODE_SIGNING",
+          "EMAIL_PROTECTION",
+          "IPSEC_ENDSYSTEM",
+          "IPSEC_TUNNEL",
+          "IPSEC_USER",
+          "TIME_STAMPING",
+          "OCSP_SIGNING",
+          "DVCS",
+          "SBGP_CERT_AA_SERVER_AUTH",
+          "SCVP_RESPONDER",
+          "EAP_OVER_PPP",
+          "EAP_OVER_LAN",
+          "SCVP_SERVER",
+          "SCVP_CLIENT",
+          "IPSEC_IKE",
+          "CAPWAP_AC",
+          "CAPWAP_WTP",
+          "IPSEC_IKE_INTERMEDIATE",
+          "SMARTCARD_LOGON"
+        ],
+        "type": "string"
+      },
+      "ExtendedPolicyGetResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PolicyGetResponse"
           },
-          "configurations": {
-            "items": {
-              "$ref": "#/components/schemas/ConfigurationInformation"
+          {
+            "properties": {
+              "configurations": {
+                "items": {
+                  "$ref": "#/components/schemas/ConfigurationGetResponse"
+                },
+                "type": "array"
+              }
             },
-            "type": "array"
-          },
-          "creationDate": {
-            "description": "When the policy was initially created",
-            "example": "2022-10-10T14:50:41.710+00:00",
-            "type": "string"
-          },
-          "extendedKeyUsages": {
-            "description": "Extended key usages",
-            "example": [
-              "CLIENT_AUTH",
-              "SERVER_AUTH"
-            ],
-            "items": {
-              "enum": [
-                "ANY",
-                "SERVER_AUTH",
-                "CLIENT_AUTH",
-                "CODE_SIGNING",
-                "EMAIL_PROTECTION",
-                "IPSEC_ENDSYSTEM",
-                "IPSEC_TUNNEL",
-                "IPSEC_USER",
-                "TIME_STAMPING",
-                "OCSP_SIGNING",
-                "DVCS",
-                "SBGP_CERT_AA_SERVER_AUTH",
-                "SCVP_RESPONDER",
-                "EAP_OVER_PPP",
-                "EAP_OVER_LAN",
-                "SCVP_SERVER",
-                "SCVP_CLIENT",
-                "IPSEC_IKE",
-                "CAPWAP_AC",
-                "CAPWAP_WTP",
-                "IPSEC_IKE_INTERMEDIATE",
-                "SMARTCARD_LOGON"
-              ],
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "id": {
-            "description": "UUID of the policy",
-            "example": "8ae92800-b1e0-11ed-859d-b39255f965ee",
-            "format": "uuid",
-            "type": "string"
-          },
-          "keyAlgorithm": {
-            "$ref": "#/components/schemas/KeyAlgorithmInformation"
-          },
-          "keyUsages": {
-            "description": "Key usages",
-            "example": [
-              "keyEncipherment",
-              "digitalSignature"
-            ],
-            "items": {
-              "enum": [
-                "digitalSignature",
-                "nonRepudiation",
-                "keyEncipherment",
-                "dataEncipherment",
-                "keyAgreement",
-                "keyCertSign",
-                "cRLSign",
-                "encipherOnly",
-                "decipherOnly"
-              ],
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "modificationDate": {
-            "description": "When the policy was last modified",
-            "example": "2023-12-12T20:00:10.500+00:00",
-            "type": "string"
-          },
-          "name": {
-            "description": "Name of the policy",
-            "example": "Some policy",
-            "type": "string"
-          },
-          "sans": {
-            "$ref": "#/components/schemas/SansInformation"
-          },
-          "shareWithAll": {
-            "description": "Shared with all sub-TSGs",
-            "example": false,
-            "type": "boolean"
-          },
-          "sharedWithSubTsgIds": {
-            "items": {
-              "description": "Sub-TSG IDs this policy is shared with",
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": true
-          },
-          "subject": {
-            "$ref": "#/components/schemas/SubjectAttributesInformation"
-          },
-          "validityPeriod": {
-            "description": "ISO8601 Period Format",
-            "example": "P30D",
-            "format": "PnYnMnDTnHnMnS",
-            "type": "string"
+            "type": "object"
           }
-        },
-        "type": "object"
+        ]
       },
       "Facet": {
         "properties": {
           "domain": {
             "additionalProperties": {
-              "$ref": "#/components/schemas/AnyValue4"
+              "$ref": "#/components/schemas/AnyValue6"
             },
             "type": "object"
           },
@@ -14783,7 +14954,7 @@
             "$ref": "#/components/schemas/BaseOrdering"
           },
           "paging": {
-            "$ref": "#/components/schemas/Page1"
+            "$ref": "#/components/schemas/Page2"
           }
         },
         "type": "object"
@@ -14835,6 +15006,28 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "ForwardTrustProxyConfigurationGetResponse": {
+        "description": "Configuration that issues forward-trust proxy intermediate certificates. It references only a Sub CA provider; the policy, client authentication/authorization, cloud-provider, advanced-settings, min-TLS-version and service-account fields do not apply.",
+        "properties": {
+          "issuerKind": {
+            "description": "The kind of issuer this configuration represents",
+            "enum": [
+              "FORWARD_TRUST_PROXY"
+            ],
+            "type": "string"
+          },
+          "subCaProviderId": {
+            "description": "UUID of the Sub CA provider associated with the configuration",
+            "example": "7268d820-a08d-11ed-bbc0-252385d6d389",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "issuerKind"
+        ],
         "type": "object"
       },
       "GeneralNamesData1": {
@@ -15062,7 +15255,7 @@
         },
         "type": "array"
       },
-      "GoogleCloudProviderInformation": {
+      "GoogleCloudProvider": {
         "properties": {
           "projectIdentifiers": {
             "description": "Array of Google project identifiers each of which should be a string with int64 number or 6 to 30 lowercase letters, digits, or hyphens, should start with a letter and not contain trailing hyphens",
@@ -15245,8 +15438,12 @@
               "MACHINE_DISCOVERY",
               "KUBERNETES_DISCOVERY",
               "AWS_DISCOVERY",
+              "AKAMAI_DISCOVERY",
               "AZURE_DISCOVERY",
-              "GCP_DISCOVERY"
+              "GCP_DISCOVERY",
+              "CODESIGN_ISSUANCE",
+              "ACME_ISSUANCE",
+              "SCEP_ISSUANCE"
             ],
             "example": "USER_PROVIDED",
             "type": "string"
@@ -15299,6 +15496,11 @@
             "description": "UUID of a managed certificate",
             "example": "17488880-e2de-11ed-aed6-79d407efea73",
             "format": "uuid",
+            "type": "string"
+          },
+          "tsgId": {
+            "description": "TSG ID of a tenant in NGTS environment",
+            "example": "1234567890",
             "type": "string"
           }
         },
@@ -15540,7 +15742,8 @@
         },
         "type": "object"
       },
-      "IntermediateCertificateInformation": {
+      "IntermediateCertificateGetResponse": {
+        "description": "An intermediate certificate request and, once it has been signed, the\ncertificate it produced.\n\nThe x509 properties (`fingerprint`, `subject`, `subjectKeyId`,\n`issuer`, `issuerKeyId`, `serialNumber`, `keyAlgorithm`,\n`signatureAlgorithm`, `validityStart`, `validityEnd`) are derived from\nthe certificate, so they are absent before `ISSUED`, and may also be\nabsent when the stored bytes cannot be decoded as an X.509 certificate.\n`commonName` comes from the signing request and is present from the\nfirst status onwards.",
         "properties": {
           "certificate": {
             "description": "Intermediate certificate bytes in PEM format",
@@ -15559,15 +15762,16 @@
             "type": "string"
           },
           "configuration": {
-            "$ref": "#/components/schemas/ConfigurationInformation"
+            "$ref": "#/components/schemas/ConfigurationGetResponse"
           },
           "creationDate": {
             "description": "When the intermediate certificate was created",
-            "example": "2022-10-10T14:50:41.710+00:00",
+            "example": "2022-10-10T14:50:41.71Z",
+            "format": "date-time",
             "type": "string"
           },
           "errorInformation": {
-            "$ref": "#/components/schemas/ErrorInformation7"
+            "$ref": "#/components/schemas/Error2"
           },
           "fingerprint": {
             "description": "Intermediate certificate fingerprint",
@@ -15579,6 +15783,11 @@
             "format": "uuid",
             "type": "string"
           },
+          "issuer": {
+            "description": "Full issuer distinguished name of the Intermediate certificate, in RFC 2253 form.",
+            "example": "CN=Example Root CA,O=Example Inc,C=US",
+            "type": "string"
+          },
           "issuerCertificates": {
             "description": "Intermediate certificate chain bytes in PEM format",
             "items": {
@@ -15586,6 +15795,16 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "issuerKeyId": {
+            "description": "Authority Key Identifier of the Intermediate certificate, identifying the issuer key that signed it, hex-encoded in lowercase without separators. Omitted when the certificate carries no Authority Key Identifier extension.",
+            "example": "b7e4028f16ca395d0e1cb84a2f7739c05e8d1a63",
+            "type": "string"
+          },
+          "keyAlgorithm": {
+            "description": "Public key algorithm of the Intermediate certificate together with\nits size, spelled the way the `KeyAlgorithm` enum spells it, so that\nit can be compared directly against the `keyAlgorithm` the\n`configuration` asked for.\n\nThe size is the modulus bit length in decimal for RSA keys, for\nexample `RSA_2048`, and the undashed curve name for elliptic-curve\nkeys, for example `EC_P256`. An Ed25519 key has a single size and is\nreported as `EC_ED25519`. This field is deliberately not typed as\nthe `KeyAlgorithm` enum: a certificate signed elsewhere may carry a\nkey outside that set, and such a key is still reported here in the\nsame spelling. Omitted altogether for a key this service cannot\ndescribe, rather than reported with the algorithm alone.",
+            "example": "RSA_2048",
+            "type": "string"
           },
           "longLivedCertCount": {
             "description": "Number of long lived certificates",
@@ -15595,7 +15814,13 @@
           },
           "modificationDate": {
             "description": "When the intermediate certificate was last modified",
-            "example": "2023-12-12T20:00:10.500+00:00",
+            "example": "2023-12-12T20:00:10.5Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "serialNumber": {
+            "description": "Serial number of the Intermediate certificate, hex-encoded in lowercase without separators and without a leading `0x`.",
+            "example": "a1b2c3d4e5f60718293a4b5c6d7e8f9",
             "type": "string"
           },
           "shortLivedCertCount": {
@@ -15604,14 +15829,46 @@
             "format": "int64",
             "type": "integer"
           },
+          "signatureAlgorithm": {
+            "description": "Algorithm the issuer used to sign the Intermediate certificate",
+            "example": "SHA256-RSA",
+            "type": "string"
+          },
           "status": {
             "description": "Status of the Intermediate certificate request",
+            "enum": [
+              "NEW",
+              "PENDING",
+              "REQUESTED",
+              "ISSUED",
+              "REJECTED",
+              "CANCELLED",
+              "REVOKED",
+              "FAILED",
+              "DELETED"
+            ],
             "example": "ISSUED",
             "type": "string"
           },
           "subTsgId": {
             "description": "Sub-TSG ID this intermediate certificate belongs to; null for non-NGTS tenants",
             "type": "string"
+          },
+          "subject": {
+            "description": "Full subject distinguished name of the Intermediate certificate, in RFC 2253 form.",
+            "example": "CN=example.com,OU=Engineering,O=Example Inc,C=US",
+            "type": "string"
+          },
+          "subjectKeyId": {
+            "description": "Subject Key Identifier of the Intermediate certificate, hex-encoded in lowercase without separators. Omitted when the certificate carries no Subject Key Identifier extension.",
+            "example": "3f2a91c0d47e5b8619fa03cd7e21b4859d0c6af2",
+            "type": "string"
+          },
+          "totalCertCount": {
+            "description": "Total number of certificates — the sum of `longLivedCertCount`, `shortLivedCertCount` and `ultraShortLivedCertCount`. Derived, read-only.",
+            "example": 111,
+            "format": "int64",
+            "type": "integer"
           },
           "ultraShortLivedCertCount": {
             "description": "Number of ultra short lived certificates",
@@ -15621,10 +15878,12 @@
           },
           "validityEnd": {
             "description": "Intermediate certificate validity end date",
+            "format": "date-time",
             "type": "string"
           },
           "validityStart": {
             "description": "Intermediate certificate validity start date",
+            "format": "date-time",
             "type": "string"
           },
           "workflowId": {
@@ -15634,11 +15893,11 @@
         },
         "type": "object"
       },
-      "IntermediateCertificateResponse": {
+      "IntermediateCertificateListResponse": {
         "properties": {
           "intermediateCertificates": {
             "items": {
-              "$ref": "#/components/schemas/IntermediateCertificateInformation"
+              "$ref": "#/components/schemas/IntermediateCertificateGetResponse"
             },
             "type": "array"
           }
@@ -15789,56 +16048,13 @@
         ],
         "type": "object"
       },
-      "JwtClient": {
+      "JWTClient": {
         "properties": {
           "allowedPolicyIds": {
             "description": "Array of UUIDs of policies that the client is permitted to use",
             "example": [
               "8ae92800-b1e0-11ed-859d-b39255f965ee"
             ],
-            "format": "uuid",
-            "items": {
-              "format": "uuid",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "issuer": {
-            "description": "Issuer of the JWT",
-            "example": "https://kubernetes.default.svc",
-            "type": "string"
-          },
-          "jwksUri": {
-            "description": "URL used to pull the trusted singing keys used for validation",
-            "example": "https://www.example.com:6443/jwks",
-            "type": "string"
-          },
-          "name": {
-            "description": "Name of the client",
-            "example": "Some client",
-            "type": "string"
-          },
-          "subjects": {
-            "description": "Array of subjects of the JWT",
-            "example": [
-              "system:serviceaccount:venafi:application-team-1"
-            ],
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "JwtClientInformation": {
-        "properties": {
-          "allowedPolicyIds": {
-            "description": "Array of UUIDs of policies that the client is permitted to use",
-            "example": [
-              "8ae92800-b1e0-11ed-859d-b39255f965ee"
-            ],
-            "format": "uuid",
             "items": {
               "format": "uuid",
               "type": "string"
@@ -15853,7 +16069,7 @@
             "type": "string"
           },
           "jwksUri": {
-            "description": "URL used to pull the trusted singing keys used for validation",
+            "description": "URL used to pull the trusted signing keys used for validation",
             "example": "https://www.example.com:6443/jwks",
             "maxLength": 2048,
             "type": "string"
@@ -15884,170 +16100,137 @@
         ],
         "type": "object"
       },
-      "JwtJwksAuthenticationInformation": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ClientAuthenticationInformation"
-          },
-          {
-            "properties": {
-              "urls": {
-                "description": "Array of JWT JWKS urls",
-                "example": [
-                  "https://jwks.example.com"
-                ],
-                "items": {
-                  "type": "string"
-                },
-                "minItems": 1,
-                "type": "array"
-              }
+      "JWTJWKSAuthentication": {
+        "properties": {
+          "allowedPolicyIds": {
+            "description": "Array of UUIDs of policies that the client is permitted to use. Server-populated on responses from the parent configuration's policyIds; ignored on requests.",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
             },
-            "type": "object"
+            "readOnly": true,
+            "type": "array"
+          },
+          "type": {
+            "description": "Discriminator for the client authentication method",
+            "enum": [
+              "JWT_JWKS"
+            ],
+            "type": "string"
+          },
+          "urls": {
+            "description": "Array of JWT JWKS urls",
+            "example": [
+              "https://jwks.example.com"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
           }
-        ],
+        },
         "required": [
+          "type",
           "urls"
         ],
         "type": "object"
       },
-      "JwtJwksAuthenticationOpenApi": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ClientAuthenticationOpenApi"
-          },
-          {
-            "properties": {
-              "urls": {
-                "description": "Array of JWT JWKS urls",
-                "example": [
-                  "https://jwks.example.com"
-                ],
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              }
+      "JWTOIDCAuthentication": {
+        "properties": {
+          "allowedPolicyIds": {
+            "description": "Array of UUIDs of policies that the client is permitted to use. Server-populated on responses from the parent configuration's policyIds; ignored on requests.",
+            "example": [
+              "8ae92800-b1e0-11ed-859d-b39255f965ee"
+            ],
+            "items": {
+              "format": "uuid",
+              "type": "string"
             },
-            "type": "object"
-          }
-        ],
-        "type": "object"
-      },
-      "JwtOidcAuthenticationInformation": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ClientAuthenticationInformation"
+            "readOnly": true,
+            "type": "array"
           },
-          {
-            "properties": {
-              "audience": {
-                "description": "OpenId audience",
-                "example": "Client1",
-                "maxLength": 256,
-                "type": "string"
-              },
-              "baseUrl": {
-                "description": "JWT OpenId base URL",
-                "example": "https://openid.example.com",
-                "maxLength": 2048,
-                "type": "string"
-              }
-            },
-            "type": "object"
+          "audience": {
+            "description": "OpenId audience",
+            "example": "Client1",
+            "maxLength": 256,
+            "type": "string"
+          },
+          "baseUrl": {
+            "description": "JWT OpenId base URL",
+            "example": "https://openid.example.com",
+            "maxLength": 2048,
+            "type": "string"
+          },
+          "type": {
+            "description": "Discriminator for the client authentication method",
+            "enum": [
+              "JWT_OIDC"
+            ],
+            "type": "string"
           }
-        ],
+        },
         "required": [
+          "type",
           "audience",
           "baseUrl"
         ],
         "type": "object"
       },
-      "JwtOidcAuthenticationOpenApi": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ClientAuthenticationOpenApi"
+      "JWTStandardClaimsAuthentication": {
+        "properties": {
+          "audience": {
+            "description": "Recipients that the JWT is intended for",
+            "example": "Client1",
+            "maxLength": 256,
+            "type": "string"
           },
-          {
-            "properties": {
-              "audience": {
-                "description": "OpenId audience",
-                "example": "Alpha testers",
-                "type": "string"
-              },
-              "baseUrl": {
-                "description": "JWT OpenId base URL",
-                "example": "https://oidc.example.com/",
-                "type": "string"
-              }
+          "clients": {
+            "description": "List with clients, identified by processing JWTs that include standard/registered claims",
+            "items": {
+              "$ref": "#/components/schemas/JWTClient"
             },
-            "type": "object"
-          }
-        ],
-        "type": "object"
-      },
-      "JwtStandardClaimsAuthenticationInformation": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ClientAuthenticationInformation"
+            "minItems": 1,
+            "type": "array"
           },
-          {
-            "properties": {
-              "audience": {
-                "description": "Recipients that the JWT is intended for",
-                "example": "Client1",
-                "maxLength": 256,
-                "type": "string"
-              },
-              "clients": {
-                "description": "List with clients, identified by processing JWTs that include standard/registered claims",
-                "items": {
-                  "$ref": "#/components/schemas/JwtClientInformation"
-                },
-                "minItems": 1,
-                "type": "array"
-              }
-            },
-            "type": "object"
+          "type": {
+            "description": "Discriminator for the client authentication method",
+            "enum": [
+              "JWT_STANDARD_CLAIMS"
+            ],
+            "type": "string"
           }
-        ],
+        },
         "required": [
+          "type",
           "audience",
           "clients"
         ],
         "type": "object"
       },
-      "JwtStandardClaimsAuthenticationOpenApi": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ClientAuthenticationOpenApi"
-          },
-          {
-            "properties": {
-              "audience": {
-                "description": "Recipients that the JWT is intended for",
-                "example": "Client1",
-                "type": "string"
-              },
-              "clients": {
-                "description": "List with clients, identified by processing JWTs that include standard/registered claims",
-                "items": {
-                  "$ref": "#/components/schemas/JwtClient"
-                },
-                "type": "array"
-              }
-            },
-            "type": "object"
-          }
-        ],
-        "type": "object"
-      },
-      "KeyAlgorithm": {
+      "KeyAlgorithm1": {
         "enum": [
           "RSA",
           "ED25519",
           "VSAT_HPKE"
         ],
+        "type": "string"
+      },
+      "KeyAlgorithm2": {
+        "description": "Key algorithm type",
+        "enum": [
+          "RSA_2048",
+          "RSA_3072",
+          "RSA_4096",
+          "EC_P256",
+          "EC_P384",
+          "EC_P521",
+          "EC_ED25519"
+        ],
+        "example": "EC_P256",
         "type": "string"
       },
       "KeyAlgorithmInformation": {
@@ -16056,33 +16239,13 @@
           "allowedValues": {
             "description": "Key algorithm allowed values",
             "items": {
-              "enum": [
-                "RSA_2048",
-                "RSA_3072",
-                "RSA_4096",
-                "EC_P256",
-                "EC_P384",
-                "EC_P521",
-                "EC_ED25519"
-              ],
-              "type": "string"
+              "$ref": "#/components/schemas/KeyAlgorithm2"
             },
             "minItems": 1,
             "type": "array"
           },
           "defaultValue": {
-            "description": "Key algorithm default value",
-            "enum": [
-              "RSA_2048",
-              "RSA_3072",
-              "RSA_4096",
-              "EC_P256",
-              "EC_P384",
-              "EC_P521",
-              "EC_ED25519"
-            ],
-            "example": "RSA_4096",
-            "type": "string"
+            "$ref": "#/components/schemas/KeyAlgorithm2"
           }
         },
         "required": [
@@ -16162,11 +16325,24 @@
           }
         },
         "required": [
-          "keyCurve",
-          "keyLength",
           "keyType"
         ],
         "type": "object"
+      },
+      "KeyUsage": {
+        "description": "Key usage",
+        "enum": [
+          "digitalSignature",
+          "nonRepudiation",
+          "keyEncipherment",
+          "dataEncipherment",
+          "keyAgreement",
+          "keyCertSign",
+          "cRLSign",
+          "encipherOnly",
+          "decipherOnly"
+        ],
+        "type": "string"
       },
       "LastModifiedBy": {
         "description": "The ID of the user whom modified the credential.",
@@ -16325,7 +16501,13 @@
       "MachineCreationRequest": {
         "properties": {
           "connectionDetails": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
+          },
+          "consumerTsgIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "dekId": {
             "type": "string"
@@ -16349,15 +16531,6 @@
           },
           "pluginId": {
             "format": "uuid",
-            "type": "string"
-          },
-          "status": {
-            "enum": [
-              "DRAFT",
-              "VERIFIED",
-              "UNVERIFIED",
-              "DELETING"
-            ],
             "type": "string"
           },
           "tags": {
@@ -16512,14 +16685,14 @@
       "MachineIdentityCreationRequest": {
         "properties": {
           "binding": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "certificateId": {
             "format": "uuid",
             "type": "string"
           },
           "keystore": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "machineId": {
             "format": "uuid",
@@ -16542,7 +16715,7 @@
             "type": "array"
           },
           "binding": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "certificateFingerprint": {
             "type": "string"
@@ -16571,7 +16744,7 @@
             "type": "string"
           },
           "keystore": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "lastSeenOn": {
             "format": "date-time",
@@ -16585,7 +16758,7 @@
             "type": "string"
           },
           "metadata": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "modificationDate": {
             "format": "date-time",
@@ -16613,6 +16786,10 @@
               "$ref": "#/components/schemas/MachineIdentityDocumentInformation"
             },
             "type": "array"
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
           }
         },
         "type": "object"
@@ -16620,7 +16797,7 @@
       "MachineIdentityInformation": {
         "properties": {
           "binding": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "certificateId": {
             "format": "uuid",
@@ -16639,7 +16816,7 @@
             "type": "string"
           },
           "keystore": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "lastSeenOn": {
             "format": "date-time",
@@ -16650,7 +16827,7 @@
             "type": "string"
           },
           "metadata": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "modificationDate": {
             "format": "date-time",
@@ -16666,6 +16843,9 @@
               "MISSING",
               "FAILED"
             ],
+            "type": "string"
+          },
+          "tsgId": {
             "type": "string"
           }
         },
@@ -16685,7 +16865,7 @@
       "MachineIdentitySearchRequest": {
         "properties": {
           "expression": {
-            "$ref": "#/components/schemas/Expression"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "ordering": {
             "$ref": "#/components/schemas/Ordering"
@@ -16699,14 +16879,14 @@
       "MachineIdentityUpdateRequest": {
         "properties": {
           "binding": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "certificateId": {
             "format": "uuid",
             "type": "string"
           },
           "keystore": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           }
         },
         "type": "object"
@@ -16763,12 +16943,18 @@
             "format": "uuid",
             "type": "string"
           },
+          "consumerTsgIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "creationDate": {
             "format": "date-time",
             "type": "string"
           },
           "discoveryJson": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "discoverySchedulerEnabled": {
             "type": "boolean"
@@ -16819,6 +17005,9 @@
             "format": "uuid",
             "type": "string"
           },
+          "shareWithAll": {
+            "type": "boolean"
+          },
           "status": {
             "enum": [
               "DRAFT",
@@ -16856,10 +17045,16 @@
             "$ref": "#/components/schemas/SchedulerPatternInformation2"
           },
           "connectionDetails": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
+          },
+          "consumerTsgIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "discoveryJson": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "discoverySchedulerEnabled": {
             "type": "boolean"
@@ -16877,15 +17072,6 @@
           "owningTeamId": {
             "format": "uuid",
             "type": "string"
-          },
-          "status": {
-            "enum": [
-              "DRAFT",
-              "VERIFIED",
-              "UNVERIFIED",
-              "DELETING"
-            ],
-            "type": "string"
           }
         },
         "type": "object"
@@ -16893,7 +17079,7 @@
       "MachineWorkflowRequest": {
         "properties": {
           "workflowInput": {
-            "$ref": "#/components/schemas/AnyValue3"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "workflowName": {
             "type": "string"
@@ -16915,7 +17101,7 @@
       "MachinesSearchRequest": {
         "properties": {
           "expression": {
-            "$ref": "#/components/schemas/Expression"
+            "$ref": "#/components/schemas/AnyValue7"
           },
           "ordering": {
             "$ref": "#/components/schemas/Ordering"
@@ -17304,6 +17490,14 @@
           }
         },
         "type": "object"
+      },
+      "MinTLSVersion": {
+        "description": "Minimum required TLS protocol version",
+        "enum": [
+          "TLS12",
+          "TLS13"
+        ],
+        "type": "string"
       },
       "Name": {
         "description": "The Name of CMS configuration",
@@ -17734,111 +17928,23 @@
         "type": "object"
       },
       "PolicyCreateRequest": {
-        "properties": {
-          "extendedKeyUsages": {
-            "description": "Extended key usages",
-            "example": [
-              "CLIENT_AUTH",
-              "SERVER_AUTH"
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PolicyUpdateRequest"
+          },
+          {
+            "required": [
+              "extendedKeyUsages",
+              "keyAlgorithm",
+              "keyUsages",
+              "name",
+              "sans",
+              "subject",
+              "validityPeriod"
             ],
-            "items": {
-              "enum": [
-                "ANY",
-                "SERVER_AUTH",
-                "CLIENT_AUTH",
-                "CODE_SIGNING",
-                "EMAIL_PROTECTION",
-                "IPSEC_ENDSYSTEM",
-                "IPSEC_TUNNEL",
-                "IPSEC_USER",
-                "TIME_STAMPING",
-                "OCSP_SIGNING",
-                "DVCS",
-                "SBGP_CERT_AA_SERVER_AUTH",
-                "SCVP_RESPONDER",
-                "EAP_OVER_PPP",
-                "EAP_OVER_LAN",
-                "SCVP_SERVER",
-                "SCVP_CLIENT",
-                "IPSEC_IKE",
-                "CAPWAP_AC",
-                "CAPWAP_WTP",
-                "IPSEC_IKE_INTERMEDIATE",
-                "SMARTCARD_LOGON"
-              ],
-              "type": "string"
-            },
-            "minItems": 1,
-            "type": "array"
-          },
-          "keyAlgorithm": {
-            "$ref": "#/components/schemas/KeyAlgorithmInformation"
-          },
-          "keyUsages": {
-            "description": "Key usages",
-            "example": [
-              "keyEncipherment",
-              "digitalSignature"
-            ],
-            "items": {
-              "enum": [
-                "digitalSignature",
-                "nonRepudiation",
-                "keyEncipherment",
-                "dataEncipherment",
-                "keyAgreement",
-                "keyCertSign",
-                "cRLSign",
-                "encipherOnly",
-                "decipherOnly"
-              ],
-              "type": "string"
-            },
-            "minItems": 1,
-            "type": "array"
-          },
-          "name": {
-            "description": "Name of the policy",
-            "example": "Some policy",
-            "maxLength": 64,
-            "type": "string"
-          },
-          "sans": {
-            "$ref": "#/components/schemas/SansInformation"
-          },
-          "shareWithAll": {
-            "description": "Share with all sub-TSGs",
-            "example": false,
-            "type": "boolean"
-          },
-          "sharedWithSubTsgIds": {
-            "items": {
-              "description": "Specific sub-TSG IDs to share with",
-              "example": "[\"1378242802\",\"1896239460\"]",
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "subject": {
-            "$ref": "#/components/schemas/SubjectAttributesInformation"
-          },
-          "validityPeriod": {
-            "description": "ISO8601 Period Format",
-            "example": "P30D",
-            "format": "PnYnMnDTnHnMnS",
-            "type": "string"
+            "type": "object"
           }
-        },
-        "required": [
-          "extendedKeyUsages",
-          "keyAlgorithm",
-          "keyUsages",
-          "name",
-          "sans",
-          "subject",
-          "validityPeriod"
-        ],
-        "type": "object"
+        ]
       },
       "PolicyDeleteResponse": {
         "properties": {
@@ -17856,7 +17962,7 @@
         },
         "type": "object"
       },
-      "PolicyInformation": {
+      "PolicyGetResponse": {
         "properties": {
           "companyId": {
             "description": "UUID specific to your company",
@@ -17866,7 +17972,8 @@
           },
           "creationDate": {
             "description": "When the policy was initially created",
-            "example": "2022-10-10T14:50:41.710+00:00",
+            "example": "2022-10-10T14:50:41.71Z",
+            "format": "date-time",
             "type": "string"
           },
           "extendedKeyUsages": {
@@ -17876,31 +17983,7 @@
               "SERVER_AUTH"
             ],
             "items": {
-              "enum": [
-                "ANY",
-                "SERVER_AUTH",
-                "CLIENT_AUTH",
-                "CODE_SIGNING",
-                "EMAIL_PROTECTION",
-                "IPSEC_ENDSYSTEM",
-                "IPSEC_TUNNEL",
-                "IPSEC_USER",
-                "TIME_STAMPING",
-                "OCSP_SIGNING",
-                "DVCS",
-                "SBGP_CERT_AA_SERVER_AUTH",
-                "SCVP_RESPONDER",
-                "EAP_OVER_PPP",
-                "EAP_OVER_LAN",
-                "SCVP_SERVER",
-                "SCVP_CLIENT",
-                "IPSEC_IKE",
-                "CAPWAP_AC",
-                "CAPWAP_WTP",
-                "IPSEC_IKE_INTERMEDIATE",
-                "SMARTCARD_LOGON"
-              ],
-              "type": "string"
+              "$ref": "#/components/schemas/ExtendedKeyUsage"
             },
             "type": "array"
           },
@@ -17920,24 +18003,14 @@
               "digitalSignature"
             ],
             "items": {
-              "enum": [
-                "digitalSignature",
-                "nonRepudiation",
-                "keyEncipherment",
-                "dataEncipherment",
-                "keyAgreement",
-                "keyCertSign",
-                "cRLSign",
-                "encipherOnly",
-                "decipherOnly"
-              ],
-              "type": "string"
+              "$ref": "#/components/schemas/KeyUsage"
             },
             "type": "array"
           },
           "modificationDate": {
             "description": "When the policy was last modified",
-            "example": "2023-12-12T20:00:10.500+00:00",
+            "example": "2023-12-12T20:00:10.5Z",
+            "format": "date-time",
             "type": "string"
           },
           "name": {
@@ -17946,7 +18019,7 @@
             "type": "string"
           },
           "sans": {
-            "$ref": "#/components/schemas/SansInformation"
+            "$ref": "#/components/schemas/SANs"
           },
           "shareWithAll": {
             "description": "Shared with all sub-TSGs",
@@ -17962,7 +18035,7 @@
             "uniqueItems": true
           },
           "subject": {
-            "$ref": "#/components/schemas/SubjectAttributesInformation"
+            "$ref": "#/components/schemas/SubjectAttributes"
           },
           "validityPeriod": {
             "description": "ISO8601 Period Format",
@@ -17973,11 +18046,11 @@
         },
         "type": "object"
       },
-      "PolicyResponse": {
+      "PolicyListResponse": {
         "properties": {
           "policies": {
             "items": {
-              "$ref": "#/components/schemas/ExtendedPolicyInformation"
+              "$ref": "#/components/schemas/ExtendedPolicyGetResponse"
             },
             "type": "array"
           }
@@ -17993,32 +18066,9 @@
               "SERVER_AUTH"
             ],
             "items": {
-              "enum": [
-                "ANY",
-                "SERVER_AUTH",
-                "CLIENT_AUTH",
-                "CODE_SIGNING",
-                "EMAIL_PROTECTION",
-                "IPSEC_ENDSYSTEM",
-                "IPSEC_TUNNEL",
-                "IPSEC_USER",
-                "TIME_STAMPING",
-                "OCSP_SIGNING",
-                "DVCS",
-                "SBGP_CERT_AA_SERVER_AUTH",
-                "SCVP_RESPONDER",
-                "EAP_OVER_PPP",
-                "EAP_OVER_LAN",
-                "SCVP_SERVER",
-                "SCVP_CLIENT",
-                "IPSEC_IKE",
-                "CAPWAP_AC",
-                "CAPWAP_WTP",
-                "IPSEC_IKE_INTERMEDIATE",
-                "SMARTCARD_LOGON"
-              ],
-              "type": "string"
+              "$ref": "#/components/schemas/ExtendedKeyUsage"
             },
+            "minItems": 1,
             "type": "array"
           },
           "keyAlgorithm": {
@@ -18031,19 +18081,9 @@
               "digitalSignature"
             ],
             "items": {
-              "enum": [
-                "digitalSignature",
-                "nonRepudiation",
-                "keyEncipherment",
-                "dataEncipherment",
-                "keyAgreement",
-                "keyCertSign",
-                "cRLSign",
-                "encipherOnly",
-                "decipherOnly"
-              ],
-              "type": "string"
+              "$ref": "#/components/schemas/KeyUsage"
             },
+            "minItems": 1,
             "type": "array"
           },
           "name": {
@@ -18053,22 +18093,25 @@
             "type": "string"
           },
           "sans": {
-            "$ref": "#/components/schemas/SansInformation"
+            "$ref": "#/components/schemas/SANs"
           },
           "shareWithAll": {
             "description": "Share with all sub-TSGs",
             "type": "boolean"
           },
           "sharedWithSubTsgIds": {
+            "example": [
+              "1378242802",
+              "1896239460"
+            ],
             "items": {
               "description": "Specific sub-TSG IDs to share with",
-              "example": "[\"1378242802\",\"1896239460\"]",
               "type": "string"
             },
             "type": "array"
           },
           "subject": {
-            "$ref": "#/components/schemas/SubjectAttributesInformation"
+            "$ref": "#/components/schemas/SubjectAttributes"
           },
           "validityPeriod": {
             "description": "ISO8601 Period Format",
@@ -18089,7 +18132,7 @@
         ],
         "type": "string"
       },
-      "PropertyInformation": {
+      "Property": {
         "properties": {
           "allowedValues": {
             "items": {
@@ -18472,7 +18515,7 @@
             "type": "string"
           },
           "entity": {
-            "$ref": "#/components/schemas/AnyValue4"
+            "$ref": "#/components/schemas/AnyValue6"
           },
           "entityTag": {
             "$ref": "#/components/schemas/EntityTag"
@@ -18480,7 +18523,7 @@
           "headers": {
             "additionalProperties": {
               "items": {
-                "$ref": "#/components/schemas/AnyValue4"
+                "$ref": "#/components/schemas/AnyValue6"
               },
               "type": "array"
             },
@@ -18575,7 +18618,7 @@
           "metadata": {
             "additionalProperties": {
               "items": {
-                "$ref": "#/components/schemas/AnyValue4"
+                "$ref": "#/components/schemas/AnyValue6"
               },
               "type": "array"
             },
@@ -18659,30 +18702,20 @@
           }
         ]
       },
-      "Role": {
-        "enum": [
-          "SYSTEM_ADMIN",
-          "OUTAGE_DETECTION_PLATFORM_ADMIN",
-          "OUTAGE_DETECTION_PKI_ADMIN",
-          "OUTAGE_DETECTION_RESOURCE_OWNER",
-          "OUTAGE_DETECTION_GUEST"
-        ],
-        "type": "string"
-      },
-      "SansInformation": {
+      "SANs": {
         "description": "Subject alternative names",
         "properties": {
           "dnsNames": {
-            "$ref": "#/components/schemas/PropertyInformation"
+            "$ref": "#/components/schemas/Property"
           },
           "ipAddresses": {
-            "$ref": "#/components/schemas/PropertyInformation"
+            "$ref": "#/components/schemas/Property"
           },
           "rfc822Names": {
-            "$ref": "#/components/schemas/PropertyInformation"
+            "$ref": "#/components/schemas/Property"
           },
           "uniformResourceIdentifiers": {
-            "$ref": "#/components/schemas/PropertyInformation"
+            "$ref": "#/components/schemas/Property"
           }
         },
         "type": "object"
@@ -18764,6 +18797,21 @@
           "readableName"
         ],
         "type": "object"
+      },
+      "SearchOperand": {
+        "description": "A search filter operand — a string, integer, or boolean. Date-time operands are ISO-8601 strings; non-string scalars are coerced to their string form for evaluation.",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "format": "int64",
+            "type": "integer"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
       },
       "ServiceAccountBaseObject": {
         "allOf": [
@@ -19140,128 +19188,37 @@
         },
         "type": "object"
       },
-      "SubCaProviderCreateRequest": {
-        "properties": {
-          "caAccountId": {
-            "description": "UUID of the CA account used by this Sub CA provider",
-            "example": "4ece3180-b1e0-11ed-862d-ad36b18e787a",
-            "format": "uuid",
-            "type": "string"
+      "SubCAProviderCreateRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SubCAProviderUpdateRequest"
           },
-          "caProductOptionId": {
-            "description": "UUID of the CA product option used by this Sub CA provider",
-            "example": "6b3d8d20-b1e0-11ed-9c2f-953e35982bbd",
-            "format": "uuid",
-            "type": "string"
-          },
-          "caType": {
-            "description": "Type of CA this Sub CA provider works with",
-            "enum": [
-              "MOCKCA",
-              "DIGICERT",
-              "GLOBALSIGN",
-              "BUILTIN",
-              "ENTRUST",
-              "MICROSOFT",
-              "ACME",
-              "ZTPKI",
-              "GLOBALSIGNMSSL",
-              "TPP"
-            ],
-            "example": "BUILTIN",
-            "type": "string"
-          },
-          "commonName": {
-            "description": "Common name",
-            "example": "example.com",
-            "maxLength": 64,
-            "type": "string"
-          },
-          "country": {
-            "description": "Country",
-            "example": "US",
-            "maxLength": 64,
-            "type": "string"
-          },
-          "keyAlgorithm": {
-            "description": "Key algorithm type",
-            "enum": [
-              "RSA_2048",
-              "RSA_3072",
-              "RSA_4096",
-              "EC_P256",
-              "EC_P384",
-              "EC_P521",
-              "EC_ED25519"
-            ],
-            "example": "EC_P256",
-            "type": "string"
-          },
-          "locality": {
-            "description": "Locality",
-            "example": "San Antonio",
-            "maxLength": 64,
-            "type": "string"
-          },
-          "name": {
-            "description": "Name of the Sub CA provider",
-            "example": "Some Sub CA provider",
-            "maxLength": 64,
-            "type": "string"
-          },
-          "organization": {
-            "description": "Organization",
-            "example": "Some organization",
-            "maxLength": 64,
-            "type": "string"
-          },
-          "organizationalUnit": {
-            "description": "Organizational unit",
-            "example": "Some organizational unit",
-            "maxLength": 64,
-            "type": "string"
-          },
-          "pkcs11": {
-            "$ref": "#/components/schemas/SubCaProviderPkcs11ConfigurationInformation"
-          },
-          "shareWithAll": {
-            "description": "Share with all sub-TSGs",
-            "example": false,
-            "type": "boolean"
-          },
-          "sharedWithSubTsgIds": {
-            "items": {
-              "description": "Specific sub-TSG IDs to share with",
-              "example": "[\"1378242802\",\"1896239460\"]",
-              "type": "string"
+          {
+            "properties": {
+              "caAccountId": {
+                "description": "UUID of the CA account used by this Sub CA provider",
+                "example": "4ece3180-b1e0-11ed-862d-ad36b18e787a",
+                "format": "uuid",
+                "type": "string"
+              },
+              "caType": {
+                "$ref": "#/components/schemas/CAType"
+              }
             },
-            "type": "array"
-          },
-          "stateOrProvince": {
-            "description": "State or province",
-            "example": "Texas",
-            "maxLength": 64,
-            "type": "string"
-          },
-          "validityPeriod": {
-            "description": "ISO8601 Period Format",
-            "example": "P30D",
-            "format": "PnYnMnDTnHnMnS",
-            "type": "string"
+            "required": [
+              "caAccountId",
+              "caProductOptionId",
+              "caType",
+              "commonName",
+              "keyAlgorithm",
+              "name",
+              "validityPeriod"
+            ],
+            "type": "object"
           }
-        },
-        "required": [
-          "caAccountId",
-          "caProductOptionId",
-          "caType",
-          "commonName",
-          "keyAlgorithm",
-          "name",
-          "validityPeriod"
-        ],
-        "type": "object"
+        ]
       },
-      "SubCaProviderDeleteResponse": {
+      "SubCAProviderDeleteResponse": {
         "properties": {
           "id": {
             "description": "UUID of the Sub CA provider",
@@ -19277,7 +19234,7 @@
         },
         "type": "object"
       },
-      "SubCaProviderInformation": {
+      "SubCAProviderGetResponse": {
         "properties": {
           "caAccountId": {
             "description": "UUID of the CA account used by this Sub CA provider",
@@ -19292,21 +19249,7 @@
             "type": "string"
           },
           "caType": {
-            "description": "Type of CA this Sub CA provider works with",
-            "enum": [
-              "MOCKCA",
-              "DIGICERT",
-              "GLOBALSIGN",
-              "BUILTIN",
-              "ENTRUST",
-              "MICROSOFT",
-              "ACME",
-              "ZTPKI",
-              "GLOBALSIGNMSSL",
-              "TPP"
-            ],
-            "example": "BUILTIN",
-            "type": "string"
+            "$ref": "#/components/schemas/CAType"
           },
           "commonName": {
             "description": "Common name",
@@ -19326,7 +19269,8 @@
           },
           "creationDate": {
             "description": "When the Sub CA provider was initially created",
-            "example": "2022-10-10T14:50:41.710+00:00",
+            "example": "2022-10-10T14:50:41.71Z",
+            "format": "date-time",
             "type": "string"
           },
           "id": {
@@ -19336,18 +19280,7 @@
             "type": "string"
           },
           "keyAlgorithm": {
-            "description": "Key algorithm type",
-            "enum": [
-              "RSA_2048",
-              "RSA_3072",
-              "RSA_4096",
-              "EC_P256",
-              "EC_P384",
-              "EC_P521",
-              "EC_ED25519"
-            ],
-            "example": "EC_P256",
-            "type": "string"
+            "$ref": "#/components/schemas/KeyAlgorithm2"
           },
           "locality": {
             "description": "Locality",
@@ -19356,7 +19289,8 @@
           },
           "modificationDate": {
             "description": "When the Sub CA provider was last modified",
-            "example": "2023-12-12T20:00:10.500+00:00",
+            "example": "2023-12-12T20:00:10.5Z",
+            "format": "date-time",
             "type": "string"
           },
           "name": {
@@ -19375,7 +19309,7 @@
             "type": "string"
           },
           "pkcs11": {
-            "$ref": "#/components/schemas/SubCaProviderPkcs11ConfigurationInformation"
+            "$ref": "#/components/schemas/SubCAProviderPKCS11Configuration"
           },
           "shareWithAll": {
             "description": "Shared with all sub-TSGs",
@@ -19404,7 +19338,18 @@
         },
         "type": "object"
       },
-      "SubCaProviderPkcs11ConfigurationInformation": {
+      "SubCAProviderListResponse": {
+        "properties": {
+          "subCaProviders": {
+            "items": {
+              "$ref": "#/components/schemas/SubCAProviderGetResponse"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "SubCAProviderPKCS11Configuration": {
         "properties": {
           "allowedClientLibraries": {
             "description": "A collection of strings each of which represents SHA256 hash of an allowed HSM client library",
@@ -19441,18 +19386,7 @@
         },
         "type": "object"
       },
-      "SubCaProviderResponse": {
-        "properties": {
-          "subCaProviders": {
-            "items": {
-              "$ref": "#/components/schemas/SubCaProviderInformation"
-            },
-            "type": "array"
-          }
-        },
-        "type": "object"
-      },
-      "SubCaProviderUpdateRequest": {
+      "SubCAProviderUpdateRequest": {
         "properties": {
           "caProductOptionId": {
             "description": "UUID of the CA product option used by this Sub CA provider",
@@ -19473,18 +19407,7 @@
             "type": "string"
           },
           "keyAlgorithm": {
-            "description": "Key algorithm type",
-            "enum": [
-              "RSA_2048",
-              "RSA_3072",
-              "RSA_4096",
-              "EC_P256",
-              "EC_P384",
-              "EC_P521",
-              "EC_ED25519"
-            ],
-            "example": "EC_P256",
-            "type": "string"
+            "$ref": "#/components/schemas/KeyAlgorithm2"
           },
           "locality": {
             "description": "Locality",
@@ -19511,16 +19434,19 @@
             "type": "string"
           },
           "pkcs11": {
-            "$ref": "#/components/schemas/SubCaProviderPkcs11ConfigurationInformation"
+            "$ref": "#/components/schemas/SubCAProviderPKCS11Configuration"
           },
           "shareWithAll": {
             "description": "Share with all sub-TSGs",
             "type": "boolean"
           },
           "sharedWithSubTsgIds": {
+            "example": [
+              "1378242802",
+              "1896239460"
+            ],
             "items": {
               "description": "Specific sub-TSG IDs to share with",
-              "example": "[\"1378242802\",\"1896239460\"]",
               "type": "string"
             },
             "type": "array"
@@ -19533,7 +19459,8 @@
           },
           "validityPeriod": {
             "description": "ISO8601 Period Format",
-            "example": "PnYnMnDTnHnMnS",
+            "example": "P30D",
+            "format": "PnYnMnDTnHnMnS",
             "type": "string"
           }
         },
@@ -19568,26 +19495,26 @@
         },
         "type": "object"
       },
-      "SubjectAttributesInformation": {
+      "SubjectAttributes": {
         "description": "Subject attributes",
         "properties": {
           "commonName": {
-            "$ref": "#/components/schemas/PropertyInformation"
+            "$ref": "#/components/schemas/Property"
           },
           "country": {
-            "$ref": "#/components/schemas/PropertyInformation"
+            "$ref": "#/components/schemas/Property"
           },
           "locality": {
-            "$ref": "#/components/schemas/PropertyInformation"
+            "$ref": "#/components/schemas/Property"
           },
           "organization": {
-            "$ref": "#/components/schemas/PropertyInformation"
+            "$ref": "#/components/schemas/Property"
           },
           "organizationalUnit": {
-            "$ref": "#/components/schemas/PropertyInformation"
+            "$ref": "#/components/schemas/Property"
           },
           "stateOrProvince": {
-            "$ref": "#/components/schemas/PropertyInformation"
+            "$ref": "#/components/schemas/Property"
           }
         },
         "type": "object"
@@ -19607,7 +19534,7 @@
         "properties": {
           "args": {
             "items": {
-              "$ref": "#/components/schemas/AnyValue8"
+              "$ref": "#/components/schemas/AnyValue4"
             },
             "type": "array"
           },
@@ -20120,72 +20047,6 @@
         },
         "type": "object"
       },
-      "TenantExpirationReportsConfiguration": {
-        "properties": {
-          "additionalRecipients": {
-            "description": "A list of users and/or teams who should be added as recipients.",
-            "example": [
-              {
-                "id": "22153ae0-4352-11ee-b95c-3531a284802b",
-                "type": "User"
-              },
-              {
-                "id": "22153ae0-4352-11ee-b95c-12345abcd123",
-                "type": "Team"
-              }
-            ],
-            "items": {
-              "$ref": "#/components/schemas/Recipient"
-            },
-            "type": "array",
-            "uniqueItems": true
-          },
-          "channels": {
-            "description": "A list of channels that should be used to deliver the notification.",
-            "example": [
-              "email"
-            ],
-            "items": {
-              "$ref": "#/components/schemas/Channel"
-            },
-            "minItems": 1,
-            "type": "array",
-            "uniqueItems": true
-          },
-          "enabled": {
-            "description": "If true, then the system will send reports providing details of certificates which are nearing expiration.",
-            "example": true,
-            "type": "boolean"
-          },
-          "expiringWithinDays": {
-            "description": "Any certificates which will expire within the number of days specified here will be included in the report.",
-            "example": 30,
-            "type": "integer"
-          },
-          "ignoreAfterDays": {
-            "description": "Any certificates which have expired for more than the specified days will be excluded in the report.",
-            "example": 30,
-            "type": "integer"
-          },
-          "roles": {
-            "description": "All users with the specified VaaS roles will be added as a report recipient.",
-            "example": [
-              "SYSTEM_ADMIN"
-            ],
-            "items": {
-              "$ref": "#/components/schemas/Role"
-            },
-            "type": "array",
-            "uniqueItems": true
-          },
-          "schedule": {
-            "description": "A cron string representing the desired schedule for delivering reports. Note that currently reports may not be sent more than once per day. The `hour` and `minute` fields of the cron schedule will be ignored.",
-            "example": "0 0 * * Mon",
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
       "TenantRenewalConfiguration": {
         "properties": {
           "defaultIssuingTemplateId": {
@@ -20299,6 +20160,32 @@
             "$ref": "#/components/schemas/TestHashiCorpDetails"
           }
         ]
+      },
+      "TestConnectionWorkflowRequest": {
+        "properties": {
+          "connection": {
+            "$ref": "#/components/schemas/AnyValue7"
+          },
+          "dekId": {
+            "type": "string"
+          },
+          "edgeInstanceId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "integrationId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "pluginId": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "wsClientId": {
+            "type": "string"
+          }
+        },
+        "type": "object"
       },
       "TestCredentialDetails": {
         "oneOf": [


### PR DESCRIPTION
## What

Refreshes the NGTS (Venafi TLS Protect Cloud) OpenAPI spec on pan.dev from the latest ua-repo pan.dev pipeline runs:
- [pipeline 2838826459](https://gitlab.com/venafi/developer-hub/ua-repo/-/pipelines/2838826459)
- [pipeline 2848060423](https://gitlab.com/venafi/developer-hub/ua-repo/-/pipelines/2848060423)

## Changes

- **Certificate endpoint paths**: dropped the `/outagedetection` prefix (e.g. `/outagedetection/v1/certificates` -> `/v1/certificates`). This matches the same path change already deployed to `developer.venafi.com` by the same pipeline run's Dev Central job (`Deploy API Production`), so this brings pan.dev in line with what's already live on the primary docs.
- **"Built-in Accounts" tag casing**: corrected from `Built-In Accounts` to `Built-in Accounts`, matching ua-repo's source of truth (`siteconf-pandev.yaml`), which was corrected there shortly after the capitalized version was originally published to this repo and never republished.
- **`existingCertificateFingerprint` field description clarified**: `CertificateRequestRequest.existingCertificateFingerprint` now specifies it's a **SHA-1** fingerprint (was previously just "Fingerprint of an existing inventory certificate...").
- New `containerFormat` query param on `GET /v1/certificates/{id}/contents`, and a new `POST /v1/machines/workflows` endpoint (`machines_initiateTestConnectionWorkflow`), carried over from the regenerated spec.

No Docusaurus config, sidebar, or generated page changes needed — generated files aren't committed (built at deploy time), consistent with #1311.

## Motivation and Context

EPIC: VC-50859

## How Has This Been Tested

- Verified path/naming changes against ua-repo source (`siteconf-pandev.yaml`, `operationsDoc/`) and confirmed the path change is already live on developer.venafi.com via the same pipeline run.
- Diffed schema-level field descriptions between pipeline runs to confirm the `existingCertificateFingerprint` wording change and rule out unrelated component `$ref` renumbering noise.
- Validated the spec is well-formed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)